### PR TITLE
feat: add transactional graph writer and versioning (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .manifest/
 node_modules/
 web-dist/
+.env

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ npm run start
 
 Default server URL: `http://localhost:3000`
 
+This repo also supports a local `.env` override. For example, setting `PORT=5000` avoids conflicts with other services already using `3000`.
+
 ### Run the graph frontend
 
 ```bash
@@ -29,6 +31,8 @@ If the API is running on a non-default port, point Vite at it with:
 ```bash
 STUDIO_API_URL=http://localhost:3100 npm run dev:web
 ```
+
+Vite will also read `STUDIO_API_URL` from a local `.env` file.
 
 ### Configure manifest path
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,50 @@ curl http://localhost:3000/api/frontier
 curl http://localhost:3000/api/plan
 ```
 
+`GET /api/graph` also returns `graph_version` for stale-write detection.
+
+### Apply an atomic graph mutation batch
+
+```bash
+curl -X POST http://localhost:3000/api/graph/mutations \
+  -H 'content-type: application/json' \
+  -d '{
+    "proposal_id": "prop-1",
+    "based_on_graph_version": "0",
+    "mutations": [
+      {
+        "mutation_id": "m1",
+        "kind": "create_work_item",
+        "work_item": {
+          "id": "studio-track",
+          "name": "Studio Track",
+          "kind": "track"
+        }
+      },
+      {
+        "mutation_id": "m2",
+        "kind": "create_work_item",
+        "work_item": {
+          "id": "studio-1",
+          "name": "Server scaffold",
+          "kind": "issue"
+        }
+      },
+      {
+        "mutation_id": "m3",
+        "kind": "create_edge",
+        "edge": {
+          "from_id": "studio-1",
+          "rel": "is_part_of",
+          "to_id": "studio-track"
+        }
+      }
+    ]
+  }'
+```
+
+The server validates the full batch, applies it transactionally, and returns either `applied`, `validation_failed`, or `stale`.
+
 ### Delete test data
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "node --import tsx --watch src/main.ts",
-    "dev:server": "node --import tsx --watch src/main.ts",
+    "dev": "node --env-file-if-exists=.env --import tsx --watch src/main.ts",
+    "dev:server": "node --env-file-if-exists=.env --import tsx --watch src/main.ts",
     "dev:web": "vite --config web/vite.config.ts",
-    "start": "node --import tsx src/main.ts",
+    "start": "node --env-file-if-exists=.env --import tsx src/main.ts",
     "build": "npm run check && npm run build:web",
     "build:web": "vite build --config web/vite.config.ts",
     "check": "tsc --noEmit"

--- a/src/modules/graph/edges.service.ts
+++ b/src/modules/graph/edges.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
+import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
 import type { CreateEdgeDto, EdgeRecord, UpdateEdgeDto } from "./types.js";
 
@@ -15,7 +16,10 @@ interface RawEdgeRecord {
 
 @Injectable()
 export class EdgesService {
-  constructor(@Inject(SQLiteService) private readonly sqlite: SQLiteService) {}
+  constructor(
+    @Inject(SQLiteService) private readonly sqlite: SQLiteService,
+    @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
+  ) {}
 
   private get db(): DatabaseType {
     return this.sqlite.getDb();
@@ -52,51 +56,39 @@ export class EdgesService {
   }
 
   create(input: CreateEdgeDto): EdgeRecord {
-    let id: number;
-    try {
-      const result = this.db
-        .prepare(`INSERT INTO edges (from_id, rel, to_id, confidence, meta) VALUES (?, ?, ?, ?, ?)`)
-        .run(
-          input.from_id,
-          input.rel,
-          input.to_id,
-          input.confidence ?? "certain",
-          JSON.stringify(input.meta ?? {}),
-        );
-      id = Number(result.lastInsertRowid);
-    } catch (error) {
-      throw new BadRequestException(this.getErrorMessage(error));
+    const previousMaxId = this.getMaxEdgeId();
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "create_edge", edge: input }],
+    });
+
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
     }
-    return this.get(id);
+
+    return this.get(previousMaxId + 1);
   }
 
   update(id: number, input: UpdateEdgeDto): EdgeRecord {
-    this.get(id);
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "update_edge", id, patch: input }],
+    });
 
-    const assignments: string[] = [];
-    const params: unknown[] = [];
-
-    for (const [key, value] of Object.entries(input)) {
-      assignments.push(`${key} = ?`);
-      params.push(key === "meta" ? JSON.stringify(value ?? {}) : value ?? null);
-    }
-
-    if (assignments.length === 0) {
-      return this.get(id);
-    }
-
-    try {
-      this.db.prepare(`UPDATE edges SET ${assignments.join(", ")} WHERE id = ?`).run(...params, id);
-    } catch (error) {
-      throw new BadRequestException(this.getErrorMessage(error));
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
     }
 
     return this.get(id);
   }
 
   delete(id: number): { deleted: true; id: number } {
-    this.get(id);
-    this.db.prepare("DELETE FROM edges WHERE id = ?").run(id);
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "delete_edge", id }],
+    });
+
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
+    }
+
     return { deleted: true, id };
   }
 
@@ -118,5 +110,20 @@ export class EdgesService {
 
   private getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : "Unknown SQLite error";
+  }
+
+  private getMutationFailureMessage(result: { status: string; errors?: Array<{ message: string }>; message?: string }) {
+    if (result.status === "validation_failed") {
+      return result.errors?.[0]?.message ?? "Graph mutation validation failed";
+    }
+    if (result.status === "stale") {
+      return result.message ?? "Graph mutation is stale";
+    }
+    return "Graph mutation failed";
+  }
+
+  private getMaxEdgeId(): number {
+    const row = this.db.prepare("SELECT COALESCE(MAX(id), 0) AS max_id FROM edges").get() as { max_id: number };
+    return row.max_id;
   }
 }

--- a/src/modules/graph/graph-writer.service.ts
+++ b/src/modules/graph/graph-writer.service.ts
@@ -1,0 +1,449 @@
+import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { SQLiteService } from "./sqlite.service.js";
+import type {
+  ApplyGraphMutationsDto,
+  ApplyGraphMutationsResult,
+  CreateEdgeDto,
+  CreateWorkItemDto,
+  EdgeConfidence,
+  EdgeRel,
+  GraphMutation,
+  GraphMutationError,
+  UpdateEdgeDto,
+  UpdateWorkItemDto,
+  WorkItemKind,
+  WorkItemState,
+} from "./types.js";
+
+interface RawWorkItemRecord {
+  id: string;
+  name: string;
+  kind: WorkItemKind;
+  state: WorkItemState;
+  repo: string | null;
+  issue_number: number | null;
+  issue_url: string | null;
+  scope_hint: string | null;
+  branch: string | null;
+  archive_path: string | null;
+  predicted_files: string;
+  actual_files: string;
+  meta: string;
+  updated_at: string;
+}
+
+interface RawEdgeRecord {
+  id: number;
+  from_id: string;
+  rel: EdgeRel;
+  to_id: string;
+  confidence: EdgeConfidence;
+  meta: string;
+  created_at: string;
+}
+
+interface GraphStateSnapshot {
+  workItems: Map<string, RawWorkItemRecord>;
+  edges: Map<number, RawEdgeRecord>;
+  nextEdgeId: number;
+}
+
+@Injectable()
+export class GraphWriterService {
+  constructor(@Inject(SQLiteService) private readonly sqlite: SQLiteService) {}
+
+  private get db(): DatabaseType {
+    return this.sqlite.getDb();
+  }
+
+  apply(input: ApplyGraphMutationsDto): ApplyGraphMutationsResult {
+    const currentGraphVersion = this.sqlite.getGraphVersion();
+    const proposalId = input.proposal_id ?? null;
+
+    if (!Array.isArray(input.mutations) || input.mutations.length === 0) {
+      return {
+        status: "validation_failed",
+        proposal_id: proposalId,
+        current_graph_version: currentGraphVersion,
+        errors: [
+          {
+            mutation_id: null,
+            code: "malformed_payload",
+            message: "mutations must contain at least one mutation",
+          },
+        ],
+      };
+    }
+
+    if (input.based_on_graph_version && input.based_on_graph_version !== currentGraphVersion) {
+      return {
+        status: "stale",
+        proposal_id: proposalId,
+        previous_graph_version: input.based_on_graph_version,
+        current_graph_version: currentGraphVersion,
+        message: "Proposal is out of date and must be regenerated.",
+      };
+    }
+
+    const normalizedMutations = [...input.mutations].sort((left, right) => {
+      const order = this.getMutationOrder(left.kind) - this.getMutationOrder(right.kind);
+      return order !== 0 ? order : this.getMutationId(left).localeCompare(this.getMutationId(right));
+    });
+
+    const snapshot = this.loadSnapshot();
+    const errors = this.validateMutations(normalizedMutations, snapshot);
+    if (errors.length > 0) {
+      return {
+        status: "validation_failed",
+        proposal_id: proposalId,
+        current_graph_version: currentGraphVersion,
+        errors,
+      };
+    }
+
+    const transaction = this.db.transaction((mutations: GraphMutation[]) => {
+      for (const mutation of mutations) {
+        this.applyMutation(mutation);
+      }
+      return this.sqlite.incrementGraphVersion();
+    });
+
+    try {
+      const newGraphVersion = transaction(normalizedMutations);
+      return {
+        status: "applied",
+        proposal_id: proposalId,
+        applied_mutation_ids: normalizedMutations.map((mutation) => this.getMutationId(mutation)),
+        previous_graph_version: currentGraphVersion,
+        new_graph_version: newGraphVersion,
+      };
+    } catch (error) {
+      throw new BadRequestException(error instanceof Error ? error.message : "Graph write failed");
+    }
+  }
+
+  private validateMutations(mutations: GraphMutation[], snapshot: GraphStateSnapshot): GraphMutationError[] {
+    const errors: GraphMutationError[] = [];
+
+    for (const mutation of mutations) {
+      switch (mutation.kind) {
+        case "create_work_item": {
+          const { work_item } = mutation;
+          if (!work_item?.id || !work_item?.name || !work_item?.kind) {
+            errors.push(this.error(mutation, "malformed_payload", "create_work_item requires id, name, and kind"));
+            continue;
+          }
+          if (snapshot.workItems.has(work_item.id)) {
+            errors.push(this.error(mutation, "duplicate_entity", `work item already exists: ${work_item.id}`));
+            continue;
+          }
+          snapshot.workItems.set(work_item.id, this.toRawWorkItem(work_item));
+          continue;
+        }
+
+        case "update_work_item": {
+          const { id, patch } = mutation;
+          if (!id || !patch || typeof patch !== "object") {
+            errors.push(this.error(mutation, "malformed_payload", "update_work_item requires id and patch"));
+            continue;
+          }
+          const existing = snapshot.workItems.get(id);
+          if (!existing) {
+            errors.push(this.error(mutation, "missing_entity", `work item does not exist: ${id}`));
+            continue;
+          }
+          snapshot.workItems.set(id, {
+            ...existing,
+            ...this.toRawWorkItemPatch(patch),
+            updated_at: this.now(),
+          });
+          continue;
+        }
+
+        case "delete_work_item": {
+          const { id } = mutation;
+          if (!id) {
+            errors.push(this.error(mutation, "malformed_payload", "delete_work_item requires id"));
+            continue;
+          }
+          if (!snapshot.workItems.has(id)) {
+            errors.push(this.error(mutation, "missing_entity", `work item does not exist: ${id}`));
+            continue;
+          }
+          const connected = Array.from(snapshot.edges.values()).some((edge) => edge.from_id === id || edge.to_id === id);
+          if (connected) {
+            errors.push(this.error(mutation, "unsafe_delete", `work item has connected edges: ${id}`));
+            continue;
+          }
+          snapshot.workItems.delete(id);
+          continue;
+        }
+
+        case "create_edge": {
+          const { edge } = mutation;
+          if (!edge?.from_id || !edge?.to_id || !edge?.rel) {
+            errors.push(this.error(mutation, "malformed_payload", "create_edge requires from_id, to_id, and rel"));
+            continue;
+          }
+          if (!snapshot.workItems.has(edge.from_id)) {
+            errors.push(this.error(mutation, "missing_entity", `from_id does not exist: ${edge.from_id}`));
+            continue;
+          }
+          if (!snapshot.workItems.has(edge.to_id)) {
+            errors.push(this.error(mutation, "missing_entity", `to_id does not exist: ${edge.to_id}`));
+            continue;
+          }
+          if (this.hasEdge(snapshot.edges, edge.from_id, edge.rel, edge.to_id)) {
+            errors.push(this.error(mutation, "duplicate_edge", `edge already exists: ${edge.from_id} ${edge.rel} ${edge.to_id}`));
+            continue;
+          }
+          const id = snapshot.nextEdgeId++;
+          snapshot.edges.set(id, this.toRawEdge(id, edge));
+          continue;
+        }
+
+        case "update_edge": {
+          const { id, patch } = mutation;
+          if (typeof id !== "number" || !patch || typeof patch !== "object") {
+            errors.push(this.error(mutation, "malformed_payload", "update_edge requires id and patch"));
+            continue;
+          }
+          const existing = snapshot.edges.get(id);
+          if (!existing) {
+            errors.push(this.error(mutation, "missing_entity", `edge does not exist: ${id}`));
+            continue;
+          }
+          const next = {
+            ...existing,
+            ...this.toRawEdgePatch(patch),
+          } satisfies RawEdgeRecord;
+          if (!snapshot.workItems.has(next.from_id)) {
+            errors.push(this.error(mutation, "missing_entity", `from_id does not exist: ${next.from_id}`));
+            continue;
+          }
+          if (!snapshot.workItems.has(next.to_id)) {
+            errors.push(this.error(mutation, "missing_entity", `to_id does not exist: ${next.to_id}`));
+            continue;
+          }
+          if (
+            Array.from(snapshot.edges.values()).some(
+              (edge) => edge.id !== id && edge.from_id === next.from_id && edge.rel === next.rel && edge.to_id === next.to_id,
+            )
+          ) {
+            errors.push(this.error(mutation, "duplicate_edge", `edge already exists: ${next.from_id} ${next.rel} ${next.to_id}`));
+            continue;
+          }
+          snapshot.edges.set(id, next);
+          continue;
+        }
+
+        case "delete_edge": {
+          const { id } = mutation;
+          if (typeof id !== "number") {
+            errors.push(this.error(mutation, "malformed_payload", "delete_edge requires id"));
+            continue;
+          }
+          if (!snapshot.edges.has(id)) {
+            errors.push(this.error(mutation, "missing_entity", `edge does not exist: ${id}`));
+            continue;
+          }
+          snapshot.edges.delete(id);
+          continue;
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  private applyMutation(mutation: GraphMutation) {
+    switch (mutation.kind) {
+      case "create_work_item":
+        this.db
+          .prepare(
+            `INSERT INTO work_items (
+              id, name, kind, state, repo, issue_number, issue_url, scope_hint,
+              branch, archive_path, predicted_files, actual_files, meta
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          )
+          .run(
+            mutation.work_item.id,
+            mutation.work_item.name,
+            mutation.work_item.kind,
+            mutation.work_item.state ?? "planned",
+            mutation.work_item.repo ?? null,
+            mutation.work_item.issue_number ?? null,
+            mutation.work_item.issue_url ?? null,
+            mutation.work_item.scope_hint ?? null,
+            mutation.work_item.branch ?? null,
+            mutation.work_item.archive_path ?? null,
+            JSON.stringify(mutation.work_item.predicted_files ?? []),
+            JSON.stringify(mutation.work_item.actual_files ?? []),
+            JSON.stringify(mutation.work_item.meta ?? {}),
+          );
+        return;
+
+      case "update_work_item": {
+        const assignments: string[] = [];
+        const params: unknown[] = [];
+        for (const [key, value] of Object.entries(mutation.patch)) {
+          assignments.push(`${key} = ?`);
+          if (key === "predicted_files" || key === "actual_files" || key === "meta") {
+            params.push(JSON.stringify(value ?? (key === "meta" ? {} : [])));
+          } else {
+            params.push(value ?? null);
+          }
+        }
+        if (assignments.length > 0) {
+          assignments.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')");
+          this.db.prepare(`UPDATE work_items SET ${assignments.join(", ")} WHERE id = ?`).run(...params, mutation.id);
+        }
+        return;
+      }
+
+      case "delete_work_item":
+        this.db.prepare("DELETE FROM work_items WHERE id = ?").run(mutation.id);
+        return;
+
+      case "create_edge":
+        this.db
+          .prepare(`INSERT INTO edges (from_id, rel, to_id, confidence, meta) VALUES (?, ?, ?, ?, ?)`)
+          .run(
+            mutation.edge.from_id,
+            mutation.edge.rel,
+            mutation.edge.to_id,
+            mutation.edge.confidence ?? "certain",
+            JSON.stringify(mutation.edge.meta ?? {}),
+          );
+        return;
+
+      case "update_edge": {
+        const assignments: string[] = [];
+        const params: unknown[] = [];
+        for (const [key, value] of Object.entries(mutation.patch)) {
+          assignments.push(`${key} = ?`);
+          params.push(key === "meta" ? JSON.stringify(value ?? {}) : value ?? null);
+        }
+        if (assignments.length > 0) {
+          this.db.prepare(`UPDATE edges SET ${assignments.join(", ")} WHERE id = ?`).run(...params, mutation.id);
+        }
+        return;
+      }
+
+      case "delete_edge":
+        this.db.prepare("DELETE FROM edges WHERE id = ?").run(mutation.id);
+        return;
+    }
+  }
+
+  private loadSnapshot(): GraphStateSnapshot {
+    const workItems = new Map<string, RawWorkItemRecord>();
+    const edges = new Map<number, RawEdgeRecord>();
+
+    const workItemRows = this.db.prepare("SELECT * FROM work_items ORDER BY id").all() as RawWorkItemRecord[];
+    const edgeRows = this.db.prepare("SELECT * FROM edges ORDER BY id").all() as RawEdgeRecord[];
+
+    for (const row of workItemRows) {
+      workItems.set(row.id, { ...row });
+    }
+    for (const row of edgeRows) {
+      edges.set(row.id, { ...row });
+    }
+
+    const nextEdgeId = (this.db.prepare("SELECT COALESCE(MAX(id), 0) AS max_id FROM edges").get() as { max_id: number }).max_id + 1;
+    return { workItems, edges, nextEdgeId };
+  }
+
+  private getMutationOrder(kind: GraphMutation["kind"]): number {
+    switch (kind) {
+      case "create_work_item":
+        return 1;
+      case "update_work_item":
+        return 2;
+      case "create_edge":
+        return 3;
+      case "update_edge":
+        return 4;
+      case "delete_edge":
+        return 5;
+      case "delete_work_item":
+        return 6;
+    }
+  }
+
+  private getMutationId(mutation: GraphMutation): string {
+    return mutation.mutation_id ?? `${mutation.kind}:${JSON.stringify(mutation)}`;
+  }
+
+  private error(mutation: GraphMutation, code: GraphMutationError["code"], message: string): GraphMutationError {
+    return {
+      mutation_id: mutation.mutation_id ?? null,
+      code,
+      message,
+    };
+  }
+
+  private hasEdge(edges: Map<number, RawEdgeRecord>, fromId: string, rel: EdgeRel, toId: string): boolean {
+    return Array.from(edges.values()).some((edge) => edge.from_id === fromId && edge.rel === rel && edge.to_id === toId);
+  }
+
+  private toRawWorkItem(input: CreateWorkItemDto): RawWorkItemRecord {
+    return {
+      id: input.id,
+      name: input.name,
+      kind: input.kind,
+      state: input.state ?? "planned",
+      repo: input.repo ?? null,
+      issue_number: input.issue_number ?? null,
+      issue_url: input.issue_url ?? null,
+      scope_hint: input.scope_hint ?? null,
+      branch: input.branch ?? null,
+      archive_path: input.archive_path ?? null,
+      predicted_files: JSON.stringify(input.predicted_files ?? []),
+      actual_files: JSON.stringify(input.actual_files ?? []),
+      meta: JSON.stringify(input.meta ?? {}),
+      updated_at: this.now(),
+    };
+  }
+
+  private toRawWorkItemPatch(input: UpdateWorkItemDto) {
+    const patch: Partial<RawWorkItemRecord> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key === "predicted_files" || key === "actual_files" || key === "meta") {
+        patch[key] = JSON.stringify(value ?? (key === "meta" ? {} : [])) as never;
+      } else if (key !== "id" && key !== "updated_at") {
+        patch[key as keyof RawWorkItemRecord] = (value ?? null) as never;
+      }
+    }
+    return patch;
+  }
+
+  private toRawEdge(id: number, input: CreateEdgeDto): RawEdgeRecord {
+    return {
+      id,
+      from_id: input.from_id,
+      rel: input.rel,
+      to_id: input.to_id,
+      confidence: input.confidence ?? "certain",
+      meta: JSON.stringify(input.meta ?? {}),
+      created_at: this.now(),
+    };
+  }
+
+  private toRawEdgePatch(input: UpdateEdgeDto) {
+    const patch: Partial<RawEdgeRecord> = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (key === "meta") {
+        patch.meta = JSON.stringify(value ?? {});
+      } else if (key !== "id" && key !== "created_at") {
+        patch[key as keyof RawEdgeRecord] = (value ?? null) as never;
+      }
+    }
+    return patch;
+  }
+
+  private now(): string {
+    return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+}

--- a/src/modules/graph/graph.controller.ts
+++ b/src/modules/graph/graph.controller.ts
@@ -1,10 +1,14 @@
-import { Controller, Get, Inject, Query } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Query } from "@nestjs/common";
 import { GraphService } from "./graph.service.js";
-import type { WorkItemState } from "./types.js";
+import { GraphWriterService } from "./graph-writer.service.js";
+import type { ApplyGraphMutationsDto, WorkItemState } from "./types.js";
 
 @Controller("api")
 export class GraphController {
-  constructor(@Inject(GraphService) private readonly graphService: GraphService) {}
+  constructor(
+    @Inject(GraphService) private readonly graphService: GraphService,
+    @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
+  ) {}
 
   @Get("graph")
   getGraph(
@@ -24,5 +28,10 @@ export class GraphController {
   @Get("plan")
   getPlan(@Query("repo") repo?: string) {
     return this.graphService.getPlan(repo);
+  }
+
+  @Post("graph/mutations")
+  applyMutations(@Body() body: ApplyGraphMutationsDto) {
+    return this.graphWriter.apply(body);
   }
 }

--- a/src/modules/graph/graph.module.ts
+++ b/src/modules/graph/graph.module.ts
@@ -3,13 +3,14 @@ import { EdgesController } from "./edges.controller.js";
 import { EdgesService } from "./edges.service.js";
 import { GraphController } from "./graph.controller.js";
 import { GraphService } from "./graph.service.js";
+import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
 import { WorkItemsController } from "./work-items.controller.js";
 import { WorkItemsService } from "./work-items.service.js";
 
 @Module({
   controllers: [WorkItemsController, EdgesController, GraphController],
-  providers: [SQLiteService, WorkItemsService, EdgesService, GraphService],
-  exports: [SQLiteService, WorkItemsService, EdgesService, GraphService],
+  providers: [SQLiteService, WorkItemsService, EdgesService, GraphService, GraphWriterService],
+  exports: [SQLiteService, WorkItemsService, EdgesService, GraphService, GraphWriterService],
 })
 export class GraphModule {}

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -44,6 +44,7 @@ export class GraphService {
 
     return {
       filters,
+      graph_version: this.sqlite.getGraphVersion(),
       items,
       edges,
     };

--- a/src/modules/graph/sqlite.service.ts
+++ b/src/modules/graph/sqlite.service.ts
@@ -8,6 +8,10 @@ export class SQLiteService {
   private readonly manifestPath = getConfig().manifestPath;
   private readonly db: DatabaseType = initManifest(this.manifestPath);
 
+  constructor() {
+    this.initializeStudioMetadata();
+  }
+
   getDb(): DatabaseType {
     return this.db;
   }
@@ -22,5 +26,36 @@ export class SQLiteService {
 
   hasSchema(): boolean {
     return hasSchema(this.db);
+  }
+
+  getGraphVersion(): string {
+    const row = this.db
+      .prepare("SELECT value FROM studio_metadata WHERE key = 'graph_version'")
+      .get() as { value: string } | undefined;
+    return row?.value ?? "0";
+  }
+
+  incrementGraphVersion(): string {
+    const next = String(Number(this.getGraphVersion()) + 1);
+    this.db
+      .prepare(
+        `INSERT INTO studio_metadata (key, value) VALUES ('graph_version', ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+      )
+      .run(next);
+    return next;
+  }
+
+  private initializeStudioMetadata() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS studio_metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+
+    this.db
+      .prepare("INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0')")
+      .run();
   }
 }

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -64,3 +64,95 @@ export interface GraphFilters {
   track?: string;
   phase?: string;
 }
+
+export interface CreateWorkItemMutation {
+  mutation_id?: string;
+  kind: "create_work_item";
+  work_item: CreateWorkItemDto;
+}
+
+export interface UpdateWorkItemMutation {
+  mutation_id?: string;
+  kind: "update_work_item";
+  id: string;
+  patch: UpdateWorkItemDto;
+}
+
+export interface DeleteWorkItemMutation {
+  mutation_id?: string;
+  kind: "delete_work_item";
+  id: string;
+}
+
+export interface CreateEdgeMutation {
+  mutation_id?: string;
+  kind: "create_edge";
+  edge: CreateEdgeDto;
+}
+
+export interface UpdateEdgeMutation {
+  mutation_id?: string;
+  kind: "update_edge";
+  id: number;
+  patch: UpdateEdgeDto;
+}
+
+export interface DeleteEdgeMutation {
+  mutation_id?: string;
+  kind: "delete_edge";
+  id: number;
+}
+
+export type GraphMutation =
+  | CreateWorkItemMutation
+  | UpdateWorkItemMutation
+  | DeleteWorkItemMutation
+  | CreateEdgeMutation
+  | UpdateEdgeMutation
+  | DeleteEdgeMutation;
+
+export interface ApplyGraphMutationsDto {
+  proposal_id?: string;
+  based_on_graph_version?: string;
+  mutations: GraphMutation[];
+}
+
+export interface GraphMutationError {
+  mutation_id: string | null;
+  code:
+    | "missing_entity"
+    | "duplicate_entity"
+    | "duplicate_edge"
+    | "invalid_relation"
+    | "unsafe_delete"
+    | "malformed_payload";
+  message: string;
+}
+
+export interface GraphMutationsAppliedResult {
+  status: "applied";
+  proposal_id: string | null;
+  applied_mutation_ids: string[];
+  previous_graph_version: string;
+  new_graph_version: string;
+}
+
+export interface GraphMutationsValidationFailedResult {
+  status: "validation_failed";
+  proposal_id: string | null;
+  current_graph_version: string;
+  errors: GraphMutationError[];
+}
+
+export interface GraphMutationsStaleResult {
+  status: "stale";
+  proposal_id: string | null;
+  previous_graph_version: string;
+  current_graph_version: string;
+  message: string;
+}
+
+export type ApplyGraphMutationsResult =
+  | GraphMutationsAppliedResult
+  | GraphMutationsValidationFailedResult
+  | GraphMutationsStaleResult;

--- a/src/modules/graph/work-items.service.ts
+++ b/src/modules/graph/work-items.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { parseJsonArray } from "../../lib/manifest-core.js";
+import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
 import type { CreateWorkItemDto, UpdateWorkItemDto, WorkItemRecord } from "./types.js";
 
@@ -23,7 +24,10 @@ interface RawWorkItemRecord {
 
 @Injectable()
 export class WorkItemsService {
-  constructor(@Inject(SQLiteService) private readonly sqlite: SQLiteService) {}
+  constructor(
+    @Inject(SQLiteService) private readonly sqlite: SQLiteService,
+    @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
+  ) {}
 
   private get db(): DatabaseType {
     return this.sqlite.getDb();
@@ -67,76 +71,36 @@ export class WorkItemsService {
   }
 
   create(input: CreateWorkItemDto): WorkItemRecord {
-    try {
-      this.db
-        .prepare(
-          `INSERT INTO work_items (
-            id, name, kind, state, repo, issue_number, issue_url, scope_hint,
-            branch, archive_path, predicted_files, actual_files, meta
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-        )
-        .run(
-          input.id,
-          input.name,
-          input.kind,
-          input.state ?? "planned",
-          input.repo ?? null,
-          input.issue_number ?? null,
-          input.issue_url ?? null,
-          input.scope_hint ?? null,
-          input.branch ?? null,
-          input.archive_path ?? null,
-          JSON.stringify(input.predicted_files ?? []),
-          JSON.stringify(input.actual_files ?? []),
-          JSON.stringify(input.meta ?? {}),
-        );
-    } catch (error) {
-      throw new BadRequestException(this.getErrorMessage(error));
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "create_work_item", work_item: input }],
+    });
+
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
     }
 
     return this.get(input.id);
   }
 
   update(id: string, input: UpdateWorkItemDto): WorkItemRecord {
-    this.get(id);
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "update_work_item", id, patch: input }],
+    });
 
-    const assignments: string[] = [];
-    const params: unknown[] = [];
-    const entries = Object.entries(input) as [keyof UpdateWorkItemDto, unknown][];
-
-    for (const [key, value] of entries) {
-      assignments.push(`${key} = ?`);
-      if (key === "predicted_files" || key === "actual_files" || key === "meta") {
-        params.push(JSON.stringify(value ?? (key === "meta" ? {} : [])));
-      } else {
-        params.push(value ?? null);
-      }
-    }
-
-    if (assignments.length === 0) {
-      return this.get(id);
-    }
-
-    assignments.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')");
-
-    try {
-      this.db
-        .prepare(`UPDATE work_items SET ${assignments.join(", ")} WHERE id = ?`)
-        .run(...params, id);
-    } catch (error) {
-      throw new BadRequestException(this.getErrorMessage(error));
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
     }
 
     return this.get(id);
   }
 
   delete(id: string): { deleted: true; id: string } {
-    this.get(id);
+    const result = this.graphWriter.apply({
+      mutations: [{ kind: "delete_work_item", id }],
+    });
 
-    try {
-      this.db.prepare("DELETE FROM work_items WHERE id = ?").run(id);
-    } catch (error) {
-      throw new BadRequestException(this.getErrorMessage(error));
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
     }
 
     return { deleted: true, id };
@@ -162,5 +126,15 @@ export class WorkItemsService {
 
   private getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : "Unknown SQLite error";
+  }
+
+  private getMutationFailureMessage(result: { status: string; errors?: Array<{ message: string }>; message?: string }) {
+    if (result.status === "validation_failed") {
+      return result.errors?.[0]?.message ?? "Graph mutation validation failed";
+    }
+    if (result.status === "stale") {
+      return result.message ?? "Graph mutation is stale";
+    }
+    return "Graph mutation failed";
   }
 }

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,7 +1,8 @@
+import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById("app"),
 });
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,11 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 
-const apiBaseUrl = process.env.STUDIO_API_URL ?? "http://localhost:3000";
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiBaseUrl = env.STUDIO_API_URL || "http://localhost:3000";
 
-export default defineConfig({
+  return {
   root: "web",
   plugins: [svelte()],
   server: {
@@ -17,4 +19,5 @@ export default defineConfig({
     outDir: "../web-dist",
     emptyOutDir: true,
   },
+  };
 });


### PR DESCRIPTION
## Summary
Add the first deterministic graph write path for Escapement Studio with transactional apply, graph version tracking, and stale-detection support.

Closes #3

## Changes
- add `GraphWriterService` to normalize, validate, and apply graph mutations atomically
- add `POST /api/graph/mutations` as the canonical graph write endpoint
- persist monotonic `graph_version` state in SQLite via `studio_metadata`
- return structured `applied`, `validation_failed`, and `stale` results
- expose `graph_version` in `GET /api/graph`
- route existing `work-items` and `edges` write endpoints through the shared writer as compatibility wrappers
- document atomic graph mutation usage in `README.md`

## Testing
- `npm run build`
- manual mutation batch apply against local SQLite
- manual validation-failure check for unsafe delete
- manual stale-request check with outdated `based_on_graph_version`
- manual compatibility checks through existing `POST/PUT/DELETE /api/work-items` and `/api/edges`
- manual verification that `/api/graph`, `/api/frontier`, and `/api/plan` still work after writes

## Notes
- keeps the existing single-entity write routes for compatibility while establishing `POST /api/graph/mutations` as the canonical write boundary
- surfaces graph version only on `GET /api/graph` for now; a dedicated version endpoint can wait until it is justified by later workflow needs
