### PR TITLE
feat: add planning context assembly and triples (#5)

### DIFF
--- a/PLANNING_MEMORY.md
+++ b/PLANNING_MEMORY.md
@@ -1,0 +1,24 @@
+# Planning Memory
+
+## Product Principles
+- Escapement Studio treats the dependency graph as the primary planning artifact.
+- Chat is where ideas emerge; the graph is where planning becomes operational.
+
+## Architecture Decisions
+- Use Node for the V1 runtime.
+- Use Svelte for the V1 frontend.
+- Use a Studio-owned adapter around `@mariozechner/pi-web-ui`.
+- Use pi session JSONL as the canonical conversation store.
+- Serialize graph context as triples.
+- Use a hybrid execution backend with Studio-owned orchestration over pi SDK primitives.
+
+## Planning Conventions
+- Keep planning docs and issues lean and demoable.
+- Prefer explicit, approval-gated structural updates over append-only planning sprawl.
+- GitHub issues are the execution-facing substrate; the Studio graph is canonical for planning structure.
+
+## Active Open Questions
+- None yet.
+
+## Reconciliation Learnings
+- None yet.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,29 @@ curl -X POST http://localhost:3000/api/agent/message \
   -d '{"message":"Reply with exactly: ok"}'
 ```
 
+You can also request a specific graph context mode for the turn:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/message \
+  -H 'content-type: application/json' \
+  -d '{
+    "message":"Inspect the current planning graph",
+    "context": {
+      "graph_mode": "focused",
+      "repo": "fusupo/escapement-studio",
+      "track": "track:foundation"
+    }
+  }'
+```
+
+`graph_mode` supports `default`, `focused`, and `full`.
+The assembled planner context includes:
+- truncated `STUDIO_OVERVIEW.md`
+- truncated `STUDIO_ARCHITECTURE.md`
+- `PLANNING_MEMORY.md`
+- graph triples for the selected slice
+- a small recent conversation window
+
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
 
 ### Delete test data

--- a/src/modules/planning/context.service.ts
+++ b/src/modules/planning/context.service.ts
@@ -1,0 +1,303 @@
+import { Inject, Injectable } from "@nestjs/common";
+import type { AgentSession, SessionMessageEntry } from "@mariozechner/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { queryBlocked, queryFrontier } from "../../lib/manifest-core.js";
+import { EdgesService } from "../graph/edges.service.js";
+import { SQLiteService } from "../graph/sqlite.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { EdgeRecord, WorkItemRecord } from "../graph/types.js";
+import type {
+  AssemblePlanningContextInput,
+  PlanningContext,
+  PlanningContextDocument,
+  PlanningContextGraph,
+  PlanningContextGraphMode,
+  PlanningContextMessage,
+  PlanningContextTriple,
+} from "./types.js";
+
+@Injectable()
+export class ContextService {
+  private readonly overviewPath = resolve(process.cwd(), "STUDIO_OVERVIEW.md");
+  private readonly architecturePath = resolve(process.cwd(), "STUDIO_ARCHITECTURE.md");
+  private readonly planningMemoryPath = resolve(process.cwd(), "PLANNING_MEMORY.md");
+  private readonly documentCharLimit = 3200;
+  private readonly conversationWindowSize = 8;
+
+  constructor(
+    @Inject(SQLiteService) private readonly sqlite: SQLiteService,
+    @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
+    @Inject(EdgesService) private readonly edges: EdgesService,
+  ) {}
+
+  assemble(input: AssemblePlanningContextInput = {}): PlanningContext {
+    const graph = this.buildGraphContext(input);
+
+    return {
+      generated_at: this.now(),
+      documents: [
+        this.readDocument("studio_overview", this.overviewPath),
+        this.readDocument("studio_architecture", this.architecturePath),
+        this.readDocument("planning_memory", this.planningMemoryPath),
+      ],
+      graph,
+      conversation_window: this.buildConversationWindow(input.session),
+    };
+  }
+
+  formatForPrompt(context: PlanningContext, userMessage: string): string {
+    const documents = context.documents
+      .map((document) => `### ${document.label}\n${document.content}`)
+      .join("\n\n");
+
+    const triples = context.graph.triples
+      .map((triple) => `- (${triple.subject}, ${triple.predicate}, ${triple.object})`)
+      .join("\n");
+
+    const conversation = context.conversation_window.length === 0
+      ? "- (no recent conversation window)"
+      : context.conversation_window
+          .map((message) => `- ${message.role}: ${message.content}`)
+          .join("\n");
+
+    const filters = [
+      context.graph.filters.repo ? `repo=${context.graph.filters.repo}` : null,
+      context.graph.filters.track ? `track=${context.graph.filters.track}` : null,
+    ]
+      .filter(Boolean)
+      .join(", ");
+
+    return [
+      "<studio_context>",
+      `generated_at: ${context.generated_at}`,
+      `graph_mode: ${context.graph.mode}`,
+      `graph_summary: ${context.graph.item_count} items, ${context.graph.edge_count} edges, ${context.graph.triple_count} triples`,
+      `graph_filters: ${filters || "none"}`,
+      "",
+      "## Vision docs + planning memory",
+      documents,
+      "",
+      "## Graph triples",
+      triples || "- (no graph triples)",
+      "",
+      "## Recent conversation window",
+      conversation,
+      "</studio_context>",
+      "",
+      "<user_message>",
+      userMessage.trim(),
+      "</user_message>",
+    ].join("\n");
+  }
+
+  private buildGraphContext(input: AssemblePlanningContextInput): PlanningContextGraph {
+    const mode = input.graph_mode ?? "default";
+    const allItems = this.workItems.list();
+    const allEdges = this.edges.list();
+
+    const includedIds = mode === "full"
+      ? new Set(allItems.map((item) => item.id))
+      : mode === "focused"
+        ? this.buildFocusedSlice(allItems, allEdges, input)
+        : this.buildDefaultSlice(allItems, allEdges);
+
+    const items = allItems.filter((item) => includedIds.has(item.id));
+    const edges = allEdges.filter((edge) => includedIds.has(edge.from_id) && includedIds.has(edge.to_id));
+    const triples = this.serializeTriples(items, edges);
+
+    return {
+      mode,
+      filters: {
+        repo: input.repo,
+        track: input.track,
+      },
+      item_count: items.length,
+      edge_count: edges.length,
+      triple_count: triples.length,
+      triples,
+    };
+  }
+
+  private buildDefaultSlice(allItems: WorkItemRecord[], allEdges: EdgeRecord[]): Set<string> {
+    const byId = new Map(allItems.map((item) => [item.id, item]));
+    const includedIds = new Set<string>();
+    const seedIds = new Set<string>();
+
+    for (const item of queryFrontier(this.sqlite.getDb())) {
+      if (byId.has(item.id)) {
+        seedIds.add(item.id);
+      }
+    }
+
+    for (const item of queryBlocked(this.sqlite.getDb())) {
+      if (byId.has(item.id)) {
+        seedIds.add(item.id);
+      }
+    }
+
+    for (const id of seedIds) {
+      includedIds.add(id);
+    }
+
+    for (const edge of allEdges) {
+      if (edge.rel === "depends_on" || edge.rel === "implemented_by") {
+        if (seedIds.has(edge.from_id) || seedIds.has(edge.to_id)) {
+          includedIds.add(edge.from_id);
+          includedIds.add(edge.to_id);
+        }
+      }
+
+      if (edge.rel === "is_part_of") {
+        if (seedIds.has(edge.from_id) || seedIds.has(edge.to_id)) {
+          includedIds.add(edge.from_id);
+          includedIds.add(edge.to_id);
+        }
+      }
+    }
+
+    return includedIds;
+  }
+
+  private buildFocusedSlice(
+    allItems: WorkItemRecord[],
+    allEdges: EdgeRecord[],
+    input: AssemblePlanningContextInput,
+  ): Set<string> {
+    const includedIds = new Set<string>();
+
+    for (const item of allItems) {
+      const repoMatches = input.repo ? item.repo === input.repo : true;
+      const trackMatches = input.track ? false : true;
+
+      if (repoMatches && trackMatches) {
+        includedIds.add(item.id);
+      }
+    }
+
+    if (input.track) {
+      includedIds.add(input.track);
+
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const edge of allEdges) {
+          if (edge.rel !== "is_part_of") {
+            continue;
+          }
+
+          if (includedIds.has(edge.to_id) && !includedIds.has(edge.from_id)) {
+            const candidate = allItems.find((item) => item.id === edge.from_id);
+            if (!candidate) {
+              continue;
+            }
+
+            if (!input.repo || candidate.repo === input.repo || candidate.id === input.track) {
+              includedIds.add(edge.from_id);
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    return includedIds;
+  }
+
+  private serializeTriples(items: WorkItemRecord[], edges: EdgeRecord[]): PlanningContextTriple[] {
+    const triples: PlanningContextTriple[] = [];
+
+    for (const item of items) {
+      triples.push(
+        { subject: item.id, predicate: "kind", object: item.kind },
+        { subject: item.id, predicate: "name", object: item.name },
+        { subject: item.id, predicate: "state", object: item.state },
+      );
+
+      if (item.repo) {
+        triples.push({ subject: item.id, predicate: "repo", object: item.repo });
+      }
+    }
+
+    for (const edge of edges) {
+      triples.push({ subject: edge.from_id, predicate: edge.rel, object: edge.to_id });
+    }
+
+    return triples;
+  }
+
+  private buildConversationWindow(session?: AgentSession): PlanningContextMessage[] {
+    if (!session) {
+      return [];
+    }
+
+    const entries = session.sessionManager.getEntries();
+    const recentMessages = entries
+      .filter((entry): entry is SessionMessageEntry => entry.type === "message")
+      .slice(-this.conversationWindowSize);
+
+    return recentMessages.map((entry) => ({
+      role: entry.message.role,
+      content: this.messageToText(entry),
+      timestamp: entry.timestamp,
+    }));
+  }
+
+  private messageToText(entry: SessionMessageEntry): string {
+    const message = entry.message as unknown as Record<string, unknown>;
+    const content = message["content"];
+
+    if (typeof content === "string") {
+      return this.compact(content, 500);
+    }
+
+    if (Array.isArray(content)) {
+      const text = content
+        .map((part) => {
+          if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+            return typeof part.text === "string" ? part.text : "";
+          }
+          return "";
+        })
+        .filter(Boolean)
+        .join(" ");
+
+      return this.compact(text || "(non-text content)", 500);
+    }
+
+    return this.compact(JSON.stringify(message), 500);
+  }
+
+  private readDocument(kind: PlanningContextDocument["kind"], path: string): PlanningContextDocument {
+    const content = readFileSync(path, "utf8");
+    return {
+      kind,
+      label: this.getDocumentLabel(kind),
+      path,
+      content: this.compact(content, this.documentCharLimit),
+    };
+  }
+
+  private getDocumentLabel(kind: PlanningContextDocument["kind"]): string {
+    switch (kind) {
+      case "studio_overview":
+        return "Studio overview";
+      case "studio_architecture":
+        return "Studio architecture";
+      case "planning_memory":
+        return "Planning memory";
+    }
+  }
+
+  private compact(value: string, maxChars: number): string {
+    const normalized = value.replace(/\r/g, "").trim();
+    if (normalized.length <= maxChars) {
+      return normalized;
+    }
+    return `${normalized.slice(0, maxChars).trimEnd()}\n...[truncated]`;
+  }
+
+  private now(): string {
+    return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+}

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -1,10 +1,13 @@
 import { Module } from "@nestjs/common";
+import { GraphModule } from "../graph/graph.module.js";
+import { ContextService } from "./context.service.js";
 import { PlanningController } from "./planning.controller.js";
 import { PlanningService } from "./planning.service.js";
 
 @Module({
+  imports: [GraphModule],
   controllers: [PlanningController],
-  providers: [PlanningService],
-  exports: [PlanningService],
+  providers: [PlanningService, ContextService],
+  exports: [PlanningService, ContextService],
 })
 export class PlanningModule {}

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -1,9 +1,10 @@
-import { BadRequestException, Injectable, Logger, MessageEvent, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
 import { createAgentSession, SessionManager, type AgentSession, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { resolve } from "node:path";
 import { mkdirSync } from "node:fs";
 import { getConfig } from "../../config.js";
+import { ContextService } from "./context.service.js";
 import type { SendAgentMessageDto, SendAgentMessageResult, StudioSseEnvelope } from "./types.js";
 
 @Injectable()
@@ -19,6 +20,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private eventCounter = 0;
   private turnCounter = 0;
   private currentTurnId: string | null = null;
+
+  constructor(@Inject(ContextService) private readonly contextService: ContextService) {}
 
   async onModuleInit() {
     await this.ensureSession();
@@ -45,10 +48,20 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     }
 
     const session = await this.ensureSession();
+    const prompt = this.contextService.formatForPrompt(
+      this.contextService.assemble({
+        graph_mode: input.context?.graph_mode,
+        repo: input.context?.repo,
+        track: input.context?.track,
+        session,
+      }),
+      input.message,
+    );
+
     const queued = session.isStreaming;
     const promptPromise = queued
-      ? session.prompt(input.message, { streamingBehavior: "followUp" })
-      : session.prompt(input.message);
+      ? session.prompt(prompt, { streamingBehavior: "followUp" })
+      : session.prompt(prompt);
 
     void promptPromise.catch((error) => {
       this.logger.error(`Planner prompt failed: ${this.getErrorMessage(error)}`);

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -1,5 +1,14 @@
+import type { AgentSession } from "@mariozechner/pi-coding-agent";
+
+export type PlanningContextGraphMode = "default" | "focused" | "full";
+
 export interface SendAgentMessageDto {
   message: string;
+  context?: {
+    graph_mode?: PlanningContextGraphMode;
+    repo?: string;
+    track?: string;
+  };
 }
 
 export interface SendAgentMessageResult {
@@ -17,4 +26,49 @@ export interface StudioSseEnvelope {
   session_id: string;
   turn_id: string | null;
   payload: unknown;
+}
+
+export interface AssemblePlanningContextInput {
+  graph_mode?: PlanningContextGraphMode;
+  repo?: string;
+  track?: string;
+  session?: AgentSession;
+}
+
+export interface PlanningContextDocument {
+  kind: "studio_overview" | "studio_architecture" | "planning_memory";
+  label: string;
+  path: string;
+  content: string;
+}
+
+export interface PlanningContextTriple {
+  subject: string;
+  predicate: string;
+  object: string;
+}
+
+export interface PlanningContextGraph {
+  mode: PlanningContextGraphMode;
+  filters: {
+    repo?: string;
+    track?: string;
+  };
+  item_count: number;
+  edge_count: number;
+  triple_count: number;
+  triples: PlanningContextTriple[];
+}
+
+export interface PlanningContextMessage {
+  role: string;
+  content: string;
+  timestamp: string;
+}
+
+export interface PlanningContext {
+  generated_at: string;
+  documents: PlanningContextDocument[];
+  graph: PlanningContextGraph;
+  conversation_window: PlanningContextMessage[];
 }


### PR DESCRIPTION
## Summary
Add the first planning context assembly pipeline for Escapement Studio so the root planner receives compact docs, memory, graph triples, and recent conversation context on every turn.

Closes #5

## Changes
- add `ContextService` for assembled planning context
- add planning context types for graph modes, triples, docs, and recent conversation window payloads
- support `default`, `focused`, and `full` graph serialization modes
- add initial `PLANNING_MEMORY.md` template and include it in planner context
- update `PlanningService` to wrap each prompt in assembled Studio context before the live user message
- update `README.md` with planner context and graph-mode request examples

## Testing
- `npm run build`
- manual app-context checks for `default`, `focused`, and `full` graph modes
- manual SSE verification showing the wrapped planner context in the user message payload
- manual conversation window verification from the persistent planner session

## Notes
- keeps conversation windowing intentionally MVP-sized for now
- includes truncated overview/architecture docs to bound prompt size while still giving the planner durable project context
