### PR TITLE
feat: add browser planner chat integration (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run build
 
 This runs the server TypeScript check plus the production frontend build.
 
-## Graph workspace manual verification
+## Graph workspace + planner chat manual verification
 
 1. Start the API server:
 
@@ -74,12 +74,17 @@ This runs the server TypeScript check plus the production frontend build.
 
 3. Open the Vite URL shown in the terminal.
 4. Confirm the header shows `API healthy`.
-5. Verify the graph view loads data from `/api/graph`.
-6. Select a node to edit it in the sidebar.
-7. Create a new work item in the sidebar and confirm it appears in the graph.
-8. Create an edge between two nodes and confirm it appears in the graph and edge list.
-9. Delete an edge from the sidebar.
-10. Change repo/state/track/phase filters and confirm the rendered graph updates.
+5. In the planner chat panel, confirm the transcript loads from `GET /api/agent/session`.
+6. Send a planner message from the browser and confirm it posts to `POST /api/agent/message`.
+7. Confirm assistant output streams into the chat panel in real time via `GET /api/agent/stream`.
+8. Ask the planner to use a tool (for example, bash `pwd`) and confirm tool activity appears in the tool activity panel.
+9. Refresh the page and confirm recent transcript state is restored.
+10. Verify the graph view still loads data from `/api/graph`.
+11. Select a node to edit it in the sidebar.
+12. Create a new work item in the sidebar and confirm it appears in the graph.
+13. Create an edge between two nodes and confirm it appears in the graph and edge list.
+14. Delete an edge from the sidebar.
+15. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -181,6 +186,14 @@ curl -X POST http://localhost:3000/api/graph/mutations \
 ```
 
 The server validates the full batch, applies it transactionally, and returns either `applied`, `validation_failed`, or `stale`.
+
+### Root planner session snapshot
+
+```bash
+curl http://localhost:3000/api/agent/session
+```
+
+The snapshot returns the recent planner transcript used by the browser to restore chat state after refresh.
 
 ### Root planner message + stream
 

--- a/src/modules/planning/planning.controller.ts
+++ b/src/modules/planning/planning.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Inject, MessageEvent, Post, Sse } from "@nestjs/common";
+import { Body, Controller, Get, Inject, MessageEvent, Post, Sse } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { PlanningService } from "./planning.service.js";
 import type { SendAgentMessageDto } from "./types.js";
@@ -6,6 +6,11 @@ import type { SendAgentMessageDto } from "./types.js";
 @Controller("api/agent")
 export class PlanningController {
   constructor(@Inject(PlanningService) private readonly planningService: PlanningService) {}
+
+  @Get("session")
+  getSessionSnapshot() {
+    return this.planningService.getSessionSnapshot();
+  }
 
   @Post("message")
   sendMessage(@Body() body: SendAgentMessageDto) {

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -1,11 +1,17 @@
 import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
-import { createAgentSession, SessionManager, type AgentSession, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager, type AgentSession, type AgentSessionEvent, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { resolve } from "node:path";
 import { mkdirSync } from "node:fs";
 import { getConfig } from "../../config.js";
 import { ContextService } from "./context.service.js";
-import type { SendAgentMessageDto, SendAgentMessageResult, StudioSseEnvelope } from "./types.js";
+import type {
+  PlanningSessionSnapshot,
+  PlanningSessionTranscriptEntry,
+  SendAgentMessageDto,
+  SendAgentMessageResult,
+  StudioSseEnvelope,
+} from "./types.js";
 
 @Injectable()
 export class PlanningService implements OnModuleInit, OnModuleDestroy {
@@ -40,6 +46,17 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       const subscription = this.eventSubject.subscribe(subscriber);
       return () => subscription.unsubscribe();
     });
+  }
+
+  async getSessionSnapshot(): Promise<PlanningSessionSnapshot> {
+    const session = await this.ensureSession();
+
+    return {
+      session_id: session.sessionId,
+      session_file: session.sessionFile,
+      is_streaming: session.isStreaming,
+      messages: this.projectSessionEntries(session.sessionManager.getEntries()),
+    };
   }
 
   async sendMessage(input: SendAgentMessageDto): Promise<SendAgentMessageResult> {
@@ -139,6 +156,88 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     if (event.type === "turn_end") {
       this.currentTurnId = null;
     }
+  }
+
+  private projectSessionEntries(entries: SessionEntry[]): PlanningSessionTranscriptEntry[] {
+    const transcript: PlanningSessionTranscriptEntry[] = [];
+
+    for (const entry of entries) {
+      if (entry.type !== "message") {
+        continue;
+      }
+
+      const message = entry.message as unknown as Record<string, unknown>;
+      const role = message["role"];
+      const timestamp = typeof message["timestamp"] === "number"
+        ? new Date(message["timestamp"] as number).toISOString()
+        : entry.timestamp;
+
+      if (role === "user") {
+        transcript.push({
+          id: entry.id,
+          role: "user",
+          content: this.stripStudioContext(this.messageContentToText(message)),
+          timestamp,
+        });
+        continue;
+      }
+
+      if (role === "assistant") {
+        transcript.push({
+          id: entry.id,
+          role: "assistant",
+          content: this.messageContentToText(message),
+          timestamp,
+        });
+        continue;
+      }
+
+      if (role === "toolResult") {
+        transcript.push({
+          id: entry.id,
+          role: "tool",
+          content: this.messageContentToText(message) || "(no tool output)",
+          timestamp,
+          tool_name: typeof message["toolName"] === "string" ? message["toolName"] : undefined,
+          is_error: typeof message["isError"] === "boolean" ? message["isError"] : undefined,
+        });
+      }
+    }
+
+    return transcript.slice(-40);
+  }
+
+  private messageContentToText(message: Record<string, unknown>): string {
+    const content = message["content"];
+
+    if (typeof content === "string") {
+      return content.trim();
+    }
+
+    if (!Array.isArray(content)) {
+      return "";
+    }
+
+    return content
+      .map((part) => {
+        if (part && typeof part === "object" && "type" in part && part.type === "text" && "text" in part) {
+          return typeof part.text === "string" ? part.text : "";
+        }
+
+        if (part && typeof part === "object" && "type" in part && part.type === "thinking" && "thinking" in part) {
+          return typeof part.thinking === "string" ? part.thinking : "";
+        }
+
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+  }
+
+  private stripStudioContext(content: string): string {
+    const match = content.match(/<user_message>\s*([\s\S]*?)\s*<\/user_message>/);
+    return match ? match[1].trim() : content.trim();
   }
 
   private isStreamableEvent(type: AgentSessionEvent["type"]): boolean {

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -18,6 +18,22 @@ export interface SendAgentMessageResult {
   session_file?: string;
 }
 
+export interface PlanningSessionTranscriptEntry {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  content: string;
+  timestamp: string;
+  tool_name?: string;
+  is_error?: boolean;
+}
+
+export interface PlanningSessionSnapshot {
+  session_id: string;
+  session_file?: string;
+  is_streaming: boolean;
+  messages: PlanningSessionTranscriptEntry[];
+}
+
 export interface StudioSseEnvelope {
   event_id: string;
   stream_id: string;

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  import PlannerChatAdapter from "./components/PlannerChatAdapter.svelte";
   import GraphView from "./components/GraphView.svelte";
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
@@ -147,6 +148,8 @@
       <button class="secondary" on:click={refresh} disabled={loading}>Refresh</button>
     </div>
   </header>
+
+  <PlannerChatAdapter />
 
   <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -160,6 +160,118 @@ h2 {
   gap: 1rem;
 }
 
+.planner-chat {
+  width: min(1500px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.planner-header,
+.planner-controls,
+.planner-body,
+.planner-composer,
+.planner-actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.planner-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+}
+
+.planner-status {
+  display: grid;
+  justify-items: end;
+  gap: 0.5rem;
+}
+
+.planner-controls {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.planner-body {
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 0.9fr);
+}
+
+.planner-transcript,
+.planner-tools {
+  display: grid;
+  gap: 0.75rem;
+  align-content: start;
+}
+
+.planner-transcript {
+  max-height: 520px;
+  overflow: auto;
+  padding-right: 0.35rem;
+}
+
+.chat-entry,
+.tool-activity-list li {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.55);
+}
+
+.chat-entry.user {
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.chat-entry.assistant {
+  border-color: rgba(52, 211, 153, 0.35);
+}
+
+.chat-entry-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.chat-entry pre,
+.tool-activity-list pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: inherit;
+  color: #e2e8f0;
+}
+
+.tool-activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tool-activity-list p {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.inline-banner {
+  width: 100%;
+  margin: 0;
+}
+
+.compact {
+  min-height: 140px;
+}
+
+.planner-actions {
+  grid-template-columns: auto auto;
+  justify-content: end;
+}
+
 .card,
 .sidebar {
   background: rgba(15, 23, 42, 0.88);
@@ -234,21 +346,31 @@ h2 {
 }
 
 @media (max-width: 1200px) {
-  .layout {
+  .layout,
+  .planner-body {
     grid-template-columns: 1fr;
   }
 
+  .planner-controls,
   .toolbar {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 720px) {
-  .app-header {
+  .app-header,
+  .planner-header {
     flex-direction: column;
+    display: flex;
   }
 
-  .toolbar {
+  .planner-status {
+    justify-items: start;
+  }
+
+  .planner-controls,
+  .toolbar,
+  .planner-actions {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -1,0 +1,248 @@
+<script>
+  import { onMount } from "svelte";
+  import { getPlannerSessionSnapshot, sendAgentMessage } from "../lib/api.js";
+  import { connectPlannerStream, extractMessageText, toToolStatus } from "../lib/planner-chat.js";
+
+  const graphModes = ["default", "focused", "full"];
+
+  let draft = "";
+  let graphMode = "default";
+  let repo = "";
+  let track = "";
+  let messages = [];
+  let toolEvents = [];
+  let loading = true;
+  let sending = false;
+  let connected = false;
+  let error = "";
+  let sessionId = "";
+  let isStreaming = false;
+  let stream;
+
+  function mergeSnapshot(snapshot) {
+    sessionId = snapshot.session_id;
+    isStreaming = snapshot.is_streaming;
+    messages = snapshot.messages ?? [];
+  }
+
+  async function loadSnapshot() {
+    loading = true;
+    error = "";
+
+    try {
+      mergeSnapshot(await getPlannerSessionSnapshot());
+    } catch (loadError) {
+      error = loadError.message;
+    } finally {
+      loading = false;
+    }
+  }
+
+  function appendMessage(nextMessage) {
+    const existingIndex = messages.findIndex((message) => message.id === nextMessage.id);
+    if (existingIndex >= 0) {
+      messages = messages.map((message, index) => (index === existingIndex ? { ...message, ...nextMessage } : message));
+      return;
+    }
+
+    messages = [...messages, nextMessage];
+  }
+
+  function handlePlannerEvent(event) {
+    sessionId = event.session_id || sessionId;
+
+    if (event.event_type === "agent_start" || event.event_type === "turn_start") {
+      isStreaming = true;
+      return;
+    }
+
+    if (event.event_type === "agent_end" || event.event_type === "turn_end") {
+      isStreaming = false;
+      return;
+    }
+
+    if (event.event_type === "message_start" || event.event_type === "message_update" || event.event_type === "message_end") {
+      const payloadMessage = event.payload?.message;
+      const role = payloadMessage?.role;
+
+      if (role !== "assistant") {
+        return;
+      }
+
+      appendMessage({
+        id: `${event.turn_id || event.event_id}:assistant`,
+        role: "assistant",
+        content: extractMessageText(payloadMessage),
+        timestamp: payloadMessage?.timestamp
+          ? new Date(payloadMessage.timestamp).toISOString()
+          : event.timestamp,
+      });
+
+      return;
+    }
+
+    if (event.event_type.startsWith("tool_execution_")) {
+      const payload = event.payload ?? {};
+      const toolName = payload.toolName || "tool";
+      const text = payload.partialResult?.content?.map((part) => part?.text || "").filter(Boolean).join("\n") || "";
+
+      toolEvents = [
+        ...toolEvents.filter((item) => item.id !== payload.toolCallId),
+        {
+          id: payload.toolCallId || event.event_id,
+          tool_name: toolName,
+          status: toToolStatus(event.event_type, payload),
+          content: text,
+          timestamp: event.timestamp,
+        },
+      ].slice(-8);
+    }
+  }
+
+  async function submitMessage() {
+    const message = draft.trim();
+    if (!message || sending) {
+      return;
+    }
+
+    sending = true;
+    error = "";
+
+    const optimisticId = `local-user-${Date.now()}`;
+    appendMessage({
+      id: optimisticId,
+      role: "user",
+      content: message,
+      timestamp: new Date().toISOString(),
+    });
+
+    try {
+      const response = await sendAgentMessage({
+        message,
+        context: {
+          graph_mode: graphMode,
+          repo: repo.trim() || undefined,
+          track: track.trim() || undefined,
+        },
+      });
+      sessionId = response.session_id;
+      draft = "";
+    } catch (sendError) {
+      messages = messages.filter((entry) => entry.id !== optimisticId);
+      error = sendError.message;
+    } finally {
+      sending = false;
+    }
+  }
+
+  onMount(() => {
+    loadSnapshot();
+
+    stream = connectPlannerStream({
+      onOpen: () => {
+        connected = true;
+      },
+      onError: () => {
+        connected = false;
+      },
+      onEvent: handlePlannerEvent,
+    });
+
+    return () => stream?.close();
+  });
+</script>
+
+<section class="card planner-chat">
+  <div class="planner-header">
+    <div>
+      <h2>Planner chat</h2>
+      <p class="muted">Persistent root planner over REST + SSE.</p>
+    </div>
+    <div class="planner-status">
+      <span class:healthy={connected} class="status-pill">{connected ? "stream connected" : "stream reconnecting"}</span>
+      {#if sessionId}
+        <code>{sessionId}</code>
+      {/if}
+    </div>
+  </div>
+
+  <div class="planner-controls">
+    <label>
+      Graph mode
+      <select bind:value={graphMode}>
+        {#each graphModes as mode}
+          <option value={mode}>{mode}</option>
+        {/each}
+      </select>
+    </label>
+    <label>
+      Repo filter
+      <input bind:value={repo} placeholder="fusupo/escapement-studio" />
+    </label>
+    <label>
+      Track filter
+      <input bind:value={track} placeholder="track:foundation" />
+    </label>
+  </div>
+
+  {#if error}
+    <div class="banner error inline-banner">{error}</div>
+  {/if}
+
+  <div class="planner-body">
+    <div class="planner-transcript">
+      {#if loading}
+        <div class="empty-state compact">Loading planner transcript…</div>
+      {:else if messages.length === 0}
+        <div class="empty-state compact">No planner messages yet. Send the first prompt from the browser.</div>
+      {:else}
+        {#each messages as message}
+          <article class="chat-entry {message.role}">
+            <div class="chat-entry-meta">
+              <strong>{message.role === "user" ? "You" : message.role === "assistant" ? "Planner" : message.tool_name || "Tool"}</strong>
+              <span>{new Date(message.timestamp).toLocaleTimeString()}</span>
+            </div>
+            <pre>{message.content || (message.role === "assistant" && isStreaming ? "…" : "")}</pre>
+          </article>
+        {/each}
+      {/if}
+    </div>
+
+    <aside class="planner-tools">
+      <div>
+        <h3>Tool activity</h3>
+        <p class="muted">Live SDK-native tool execution events.</p>
+      </div>
+
+      {#if toolEvents.length === 0}
+        <p class="muted">Tool activity will appear here during planner turns.</p>
+      {:else}
+        <ul class="tool-activity-list">
+          {#each toolEvents as toolEvent}
+            <li>
+              <div class="chat-entry-meta">
+                <strong>{toolEvent.tool_name}</strong>
+                <span>{new Date(toolEvent.timestamp).toLocaleTimeString()}</span>
+              </div>
+              <p>{toolEvent.status}</p>
+              {#if toolEvent.content}
+                <pre>{toolEvent.content}</pre>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </aside>
+  </div>
+
+  <div class="planner-composer">
+    <label>
+      Message
+      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, explain blockers, or propose next work."></textarea>
+    </label>
+    <div class="planner-actions">
+      <button class="secondary" on:click={loadSnapshot} disabled={loading}>Refresh transcript</button>
+      <button on:click={submitMessage} disabled={sending || !draft.trim()}>{sending ? "Sending..." : isStreaming ? "Queue follow-up" : "Send to planner"}</button>
+    </div>
+  </div>
+</section>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -21,6 +21,18 @@ export function getHealth() {
   return request("/health");
 }
 
+export function getPlannerSessionSnapshot() {
+  return request("/api/agent/session");
+}
+
+export function sendAgentMessage(payload) {
+  return request("/api/agent/message", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {

--- a/web/src/lib/planner-chat.js
+++ b/web/src/lib/planner-chat.js
@@ -1,0 +1,78 @@
+export function connectPlannerStream({ onEvent, onOpen, onError } = {}) {
+  const stream = new EventSource("/api/agent/stream");
+
+  const forward = (eventType) => {
+    stream.addEventListener(eventType, (event) => {
+      try {
+        const payload = JSON.parse(event.data);
+        onEvent?.(payload);
+      } catch (error) {
+        console.error(`Failed to parse planner event ${eventType}`, error);
+      }
+    });
+  };
+
+  [
+    "agent_start",
+    "agent_end",
+    "turn_start",
+    "turn_end",
+    "message_start",
+    "message_update",
+    "message_end",
+    "tool_execution_start",
+    "tool_execution_update",
+    "tool_execution_end",
+  ].forEach(forward);
+
+  stream.onopen = () => onOpen?.();
+  stream.onerror = (error) => onError?.(error);
+
+  return stream;
+}
+
+export function extractMessageText(message) {
+  const content = message?.content;
+
+  if (typeof content === "string") {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  return content
+    .map((part) => {
+      if (part?.type === "text") {
+        return part.text ?? "";
+      }
+
+      if (part?.type === "thinking") {
+        return part.thinking ?? "";
+      }
+
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+export function toToolStatus(eventType, payload = {}) {
+  const toolName = payload.toolName || "tool";
+
+  if (eventType === "tool_execution_start") {
+    return `${toolName} running…`;
+  }
+
+  if (eventType === "tool_execution_update") {
+    return `${toolName} updating…`;
+  }
+
+  if (eventType === "tool_execution_end") {
+    return `${toolName} finished`;
+  }
+
+  return toolName;
+}


### PR DESCRIPTION
## Summary
Add the first browser-integrated planner chat surface so Escapement Studio can talk to the persistent root planner directly from the workspace UI.

Closes #6

## Changes
- add `GET /api/agent/session` for recent planner transcript snapshot recovery
- project recent planner transcript entries from the persistent pi session
- add browser planner transport helpers for session snapshot, message send, and SSE streaming
- add `PlannerChatAdapter.svelte` as the Studio-owned chat adapter boundary
- render assistant transcript and live tool activity in the browser
- integrate planner chat alongside the existing graph workspace
- update `README.md` with browser chat verification steps

## Testing
- `npm run build`
- manual `GET /api/agent/session` verification against API and Vite proxy
- manual planner send + SSE streaming verification
- manual tool event verification with `tool_execution_start/update/end`
- manual refresh recovery verification using the session snapshot endpoint
- manual graph workspace regression check alongside the chat panel

## Notes
- keeps the chat UI behind a Studio-owned adapter boundary
- uses a custom transcript renderer for now instead of forcing `@mariozechner/pi-web-ui` into this pass
- preserves room to slot `pi-web-ui` in later without reshaping the app architecture
