### PR TITLE
feat: add mutation proposal approval flow (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,17 @@ This runs the server TypeScript check plus the production frontend build.
 6. Send a planner message from the browser and confirm it posts to `POST /api/agent/message`.
 7. Confirm assistant output streams into the chat panel in real time via `GET /api/agent/stream`.
 8. Ask the planner to use a tool (for example, bash `pwd`) and confirm tool activity appears in the tool activity panel.
-9. Refresh the page and confirm recent transcript state is restored.
-10. Verify the graph view still loads data from `/api/graph`.
-11. Select a node to edit it in the sidebar.
-12. Create a new work item in the sidebar and confirm it appears in the graph.
-13. Create an edge between two nodes and confirm it appears in the graph and edge list.
-14. Delete an edge from the sidebar.
-15. Change repo/state/track/phase filters and confirm the rendered graph updates.
+9. Ask the planner to propose graph mutations and confirm a reviewable mutation proposal appears in the browser.
+10. Approve a subset of the proposed mutations and confirm the commit succeeds.
+11. Confirm the graph refreshes and the D3 view reflects the approved changes.
+12. Ask the planner to revise or reject the current proposal from the browser and confirm the follow-up stays in the same planner conversation.
+13. Refresh the page and confirm recent transcript state plus the latest active proposal/commit result are restored.
+14. Verify the graph view still loads data from `/api/graph`.
+15. Select a node to edit it in the sidebar.
+16. Create a new work item in the sidebar and confirm it appears in the graph.
+17. Create an edge between two nodes and confirm it appears in the graph and edge list.
+18. Delete an edge from the sidebar.
+19. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -235,6 +239,38 @@ The assembled planner context includes:
 - a small recent conversation window
 
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
+It also emits Studio mutation workflow events: `mutation_proposal` and `graph_commit_result`.
+
+### Approve a structured mutation proposal
+
+First, ask the planner to stage a proposal:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/message \
+  -H 'content-type: application/json' \
+  -d '{
+    "message":"Use propose_mutations to stage one demo create_work_item proposal and then reply with exactly: proposal-ready"
+  }'
+```
+
+Then inspect the active proposal:
+
+```bash
+curl http://localhost:3000/api/agent/session
+```
+
+Approve a subset of mutation IDs from that proposal:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/proposals/approve \
+  -H 'content-type: application/json' \
+  -d '{
+    "proposal_id": "prop_123",
+    "approved_mutation_ids": ["m1"]
+  }'
+```
+
+The approval result returns the graph writer status (`applied`, `validation_failed`, or `stale`) plus any remaining active proposal state for the browser.
 
 ### Delete test data
 

--- a/src/modules/planning/planning.controller.ts
+++ b/src/modules/planning/planning.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Get, Inject, MessageEvent, Post, Sse } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { PlanningService } from "./planning.service.js";
-import type { SendAgentMessageDto } from "./types.js";
+import type { ApproveMutationProposalDto, SendAgentMessageDto } from "./types.js";
 
 @Controller("api/agent")
 export class PlanningController {
@@ -15,6 +15,11 @@ export class PlanningController {
   @Post("message")
   sendMessage(@Body() body: SendAgentMessageDto) {
     return this.planningService.sendMessage(body);
+  }
+
+  @Post("proposals/approve")
+  approveProposal(@Body() body: ApproveMutationProposalDto) {
+    return this.planningService.approveProposal(body);
   }
 
   @Sse("stream")

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -1,16 +1,38 @@
 import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
-import { createAgentSession, SessionManager, type AgentSession, type AgentSessionEvent, type SessionEntry } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import { createAgentSession, defineTool, SessionManager, type AgentSession, type AgentSessionEvent, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
-import { resolve } from "node:path";
 import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
+import { GraphService } from "../graph/graph.service.js";
+import { GraphWriterService } from "../graph/graph-writer.service.js";
+import type {
+  ApplyGraphMutationsResult,
+  CreateEdgeDto,
+  CreateWorkItemDto,
+  DeleteEdgeMutation,
+  DeleteWorkItemMutation,
+  EdgeRel,
+  GraphMutation,
+  UpdateWorkItemDto,
+} from "../graph/types.js";
 import { ContextService } from "./context.service.js";
 import type {
+  ApproveMutationProposalDto,
+  CreateEdgePayload,
+  CreateWorkItemPayload,
+  GraphQueryToolInput,
+  PlanningGraphCommitResult,
+  PlanningMutationProposal,
+  PlanningMutationProposalMutation,
   PlanningSessionSnapshot,
   PlanningSessionTranscriptEntry,
+  ProposeMutationsToolInput,
   SendAgentMessageDto,
   SendAgentMessageResult,
   StudioSseEnvelope,
+  UpdateWorkItemPayload,
 } from "./types.js";
 
 @Injectable()
@@ -19,6 +41,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private readonly streamId = "planning-root";
   private readonly eventSubject = new Subject<MessageEvent>();
   private readonly sessionDir = resolve(process.cwd(), getConfig().planningSessionDir);
+  private readonly proposals = new Map<string, PlanningMutationProposal>();
 
   private session?: AgentSession;
   private sessionPromise?: Promise<AgentSession>;
@@ -26,8 +49,14 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private eventCounter = 0;
   private turnCounter = 0;
   private currentTurnId: string | null = null;
+  private activeProposalId: string | null = null;
+  private lastCommitResult: PlanningGraphCommitResult | null = null;
 
-  constructor(@Inject(ContextService) private readonly contextService: ContextService) {}
+  constructor(
+    @Inject(ContextService) private readonly contextService: ContextService,
+    @Inject(GraphService) private readonly graphService: GraphService,
+    @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
+  ) {}
 
   async onModuleInit() {
     await this.ensureSession();
@@ -56,6 +85,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       session_file: session.sessionFile,
       is_streaming: session.isStreaming,
       messages: this.projectSessionEntries(session.sessionManager.getEntries()),
+      active_proposal: this.getActiveProposal(),
+      last_commit_result: this.lastCommitResult,
     };
   }
 
@@ -92,6 +123,53 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     };
   }
 
+  async approveProposal(input: ApproveMutationProposalDto): Promise<PlanningGraphCommitResult> {
+    const proposalId = input.proposal_id?.trim();
+    if (!proposalId) {
+      throw new BadRequestException("proposal_id is required");
+    }
+
+    const approvedIds = Array.from(new Set((input.approved_mutation_ids ?? []).filter((id) => typeof id === "string" && id.trim())));
+    if (approvedIds.length === 0) {
+      throw new BadRequestException("approved_mutation_ids must contain at least one mutation id");
+    }
+
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal) {
+      throw new BadRequestException(`Unknown proposal: ${proposalId}`);
+    }
+
+    const selectedMutations = approvedIds.map((id) => {
+      const mutation = proposal.mutations.find((candidate) => candidate.id === id);
+      if (!mutation) {
+        throw new BadRequestException(`Unknown mutation id for proposal ${proposalId}: ${id}`);
+      }
+      return mutation;
+    });
+
+    const result = this.graphWriter.apply({
+      proposal_id: proposal.proposal_id,
+      based_on_graph_version: proposal.context?.based_on_graph_version,
+      mutations: selectedMutations.map((mutation) => this.toGraphMutation(mutation)),
+    });
+
+    const activeProposal = result.status === "applied"
+      ? this.updateActiveProposalAfterApply(proposal, approvedIds)
+      : this.getActiveProposal();
+
+    const commitResult: PlanningGraphCommitResult = {
+      proposal_id: proposal.proposal_id,
+      approved_mutation_ids: approvedIds,
+      result,
+      active_proposal: activeProposal,
+    };
+
+    this.lastCommitResult = commitResult;
+    this.emitStudioEvent("graph_commit_result", commitResult);
+
+    return commitResult;
+  }
+
   private async ensureSession(): Promise<AgentSession> {
     if (this.session) {
       return this.session;
@@ -114,6 +192,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd: process.cwd(),
       sessionManager: SessionManager.continueRecent(process.cwd(), this.sessionDir),
+      customTools: [this.createGraphQueryTool(), this.createProposeMutationsTool(), this.createGraphMutateTool()],
     });
 
     if (modelFallbackMessage) {
@@ -156,6 +235,308 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     if (event.type === "turn_end") {
       this.currentTurnId = null;
     }
+  }
+
+  private createGraphQueryTool() {
+    return defineTool({
+      name: "graph_query",
+      label: "Graph Query",
+      description: "Query the Studio planning graph, frontier, or dispatch plan.",
+      promptSnippet: "graph_query: inspect graph, frontier, or dispatch plan data before proposing structural changes.",
+      promptGuidelines: [
+        "Use graph_query to inspect the current graph/frontier/plan before proposing structural graph changes.",
+      ],
+      parameters: Type.Object({
+        query: Type.Union([Type.Literal("graph"), Type.Literal("frontier"), Type.Literal("plan")]),
+        repo: Type.Optional(Type.String()),
+        state: Type.Optional(Type.String()),
+        track: Type.Optional(Type.String()),
+        phase: Type.Optional(Type.String()),
+      }),
+      execute: async (_toolCallId, params: GraphQueryToolInput) => {
+        const result = params.query === "graph"
+          ? this.graphService.getGraph({
+              repo: params.repo,
+              state: params.state,
+              track: params.track,
+              phase: params.phase,
+            })
+          : params.query === "frontier"
+            ? this.graphService.getFrontier(params.repo)
+            : this.graphService.getPlan(params.repo);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+    });
+  }
+
+  private createProposeMutationsTool() {
+    return defineTool({
+      name: "propose_mutations",
+      label: "Propose Mutations",
+      description: "Stage a structured graph mutation proposal for browser review and approval.",
+      promptSnippet: "propose_mutations: emit a structured mutation proposal envelope for browser approval instead of only describing changes in prose.",
+      promptGuidelines: [
+        "When recommending graph changes, call propose_mutations with a structured proposal envelope that matches the browser approval contract.",
+        "Include a concise summary plus rationale for each mutation so the browser can render reviewable cards.",
+        "Set based_on_graph_version from graph_query results when available.",
+      ],
+      parameters: Type.Object({
+        proposal_id: Type.Optional(Type.String()),
+        created_at: Type.Optional(Type.String()),
+        source: Type.Optional(Type.Object({
+          agent: Type.Optional(Type.String()),
+          turn_id: Type.Optional(Type.String()),
+          session_id: Type.Optional(Type.String()),
+        })),
+        context: Type.Optional(Type.Object({
+          scope: Type.Optional(Type.String()),
+          mode: Type.Optional(Type.Union([Type.Literal("default"), Type.Literal("focused"), Type.Literal("full")])) ,
+          based_on_graph_version: Type.Optional(Type.String()),
+        })),
+        summary: Type.String(),
+        mutations: Type.Array(Type.Object({
+          id: Type.Optional(Type.String()),
+          type: Type.Union([
+            Type.Literal("create_work_item"),
+            Type.Literal("update_work_item"),
+            Type.Literal("create_edge"),
+            Type.Literal("delete_edge"),
+            Type.Literal("delete_work_item"),
+          ]),
+          entity_id: Type.Optional(Type.String()),
+          payload: Type.Optional(Type.Any()),
+          rationale: Type.String(),
+          validation: Type.Optional(Type.Any()),
+          group_id: Type.Optional(Type.String()),
+          depends_on_mutation_ids: Type.Optional(Type.Array(Type.String())),
+        })),
+      }),
+      execute: async (_toolCallId, params: ProposeMutationsToolInput) => {
+        const proposal = this.normalizeProposal(params);
+        this.proposals.set(proposal.proposal_id, proposal);
+        this.activeProposalId = proposal.proposal_id;
+        this.lastCommitResult = null;
+        this.emitStudioEvent("mutation_proposal", { proposal });
+
+        return {
+          content: [{ type: "text", text: `Staged proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s).` }],
+          details: { proposal },
+        };
+      },
+    });
+  }
+
+  private createGraphMutateTool() {
+    return defineTool({
+      name: "graph_mutate",
+      label: "Graph Mutate",
+      description: "Reserved graph commit tool. In V1, actual commits must go through browser approval.",
+      promptSnippet: "graph_mutate: reserved for approval-backed graph commits; do not call directly in V1.",
+      promptGuidelines: [
+        "Do not call graph_mutate directly in V1. Human approval in the browser is required; use propose_mutations instead.",
+      ],
+      parameters: Type.Object({
+        proposal_id: Type.String(),
+        approved_mutation_ids: Type.Array(Type.String()),
+      }),
+      execute: async (_toolCallId, params: ApproveMutationProposalDto) => ({
+        content: [{
+          type: "text",
+          text: `Direct graph_mutate execution is disabled in V1. Proposal ${params.proposal_id} must be committed from the browser approval UI.`,
+        }],
+        details: {
+          blocked: true,
+          reason: "browser_approval_required",
+          proposal_id: params.proposal_id,
+          approved_mutation_ids: params.approved_mutation_ids,
+        },
+      }),
+    });
+  }
+
+  private normalizeProposal(input: ProposeMutationsToolInput): PlanningMutationProposal {
+    const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
+    const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}`;
+    const createdAt = input.created_at?.trim() || this.now();
+
+    return {
+      proposal_id: proposalId,
+      created_at: createdAt,
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
+        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
+      },
+      context: {
+        ...input.context,
+        based_on_graph_version: graphVersion,
+      },
+      summary: input.summary.trim(),
+      mutations: input.mutations.map((mutation, index) => this.normalizeProposalMutation(mutation, index)),
+    };
+  }
+
+  private normalizeProposalMutation(
+    mutation: ProposeMutationsToolInput["mutations"][number],
+    index: number,
+  ): PlanningMutationProposalMutation {
+    const payload = mutation.payload && typeof mutation.payload === "object"
+      ? { ...(mutation.payload as Record<string, unknown>) }
+      : undefined;
+
+    const entityId = mutation.entity_id
+      ?? (typeof payload?.id === "string" ? payload.id : undefined)
+      ?? (mutation.type === "create_edge" && payload
+        ? `${String(payload.from_id ?? "")}:${String(payload.rel ?? "")}:${String(payload.to_id ?? "")}`
+        : undefined);
+
+    return {
+      id: mutation.id?.trim() || `m${index + 1}`,
+      type: mutation.type,
+      entity_id: entityId,
+      payload,
+      rationale: mutation.rationale.trim(),
+      validation: mutation.validation,
+      group_id: mutation.group_id,
+      depends_on_mutation_ids: mutation.depends_on_mutation_ids,
+    };
+  }
+
+  private toGraphMutation(mutation: PlanningMutationProposalMutation): GraphMutation {
+    switch (mutation.type) {
+      case "create_work_item": {
+        const payload = mutation.payload as CreateWorkItemPayload | undefined;
+        const id = mutation.entity_id ?? payload?.id;
+        if (!id || !payload?.name || !payload.kind) {
+          throw new BadRequestException(`Mutation ${mutation.id} is missing create_work_item payload fields`);
+        }
+        const workItem: CreateWorkItemDto = {
+          ...payload,
+          id,
+          name: payload.name,
+          kind: payload.kind,
+        };
+        return {
+          mutation_id: mutation.id,
+          kind: "create_work_item",
+          work_item: workItem,
+        };
+      }
+
+      case "update_work_item": {
+        const id = mutation.entity_id;
+        if (!id || !mutation.payload) {
+          throw new BadRequestException(`Mutation ${mutation.id} is missing update_work_item payload fields`);
+        }
+        return {
+          mutation_id: mutation.id,
+          kind: "update_work_item",
+          id,
+          patch: mutation.payload as UpdateWorkItemDto,
+        };
+      }
+
+      case "delete_work_item": {
+        const id = mutation.entity_id;
+        if (!id) {
+          throw new BadRequestException(`Mutation ${mutation.id} is missing delete_work_item entity_id`);
+        }
+        const deleteMutation: DeleteWorkItemMutation = {
+          mutation_id: mutation.id,
+          kind: "delete_work_item",
+          id,
+        };
+        return deleteMutation;
+      }
+
+      case "create_edge": {
+        const payload = mutation.payload as CreateEdgePayload | undefined;
+        if (!payload?.from_id || !payload.rel || !payload.to_id) {
+          throw new BadRequestException(`Mutation ${mutation.id} is missing create_edge payload fields`);
+        }
+        const edge: CreateEdgeDto = {
+          from_id: payload.from_id,
+          rel: payload.rel as EdgeRel,
+          to_id: payload.to_id,
+          confidence: payload.confidence,
+          meta: payload.meta,
+        };
+        return {
+          mutation_id: mutation.id,
+          kind: "create_edge",
+          edge,
+        };
+      }
+
+      case "delete_edge": {
+        const payloadId = typeof mutation.payload?.id === "number"
+          ? mutation.payload.id
+          : typeof mutation.entity_id === "string"
+            ? Number(mutation.entity_id)
+            : Number.NaN;
+
+        if (!Number.isInteger(payloadId)) {
+          throw new BadRequestException(`Mutation ${mutation.id} is missing delete_edge id`);
+        }
+
+        const deleteMutation: DeleteEdgeMutation = {
+          mutation_id: mutation.id,
+          kind: "delete_edge",
+          id: payloadId,
+        };
+        return deleteMutation;
+      }
+    }
+  }
+
+  private updateActiveProposalAfterApply(
+    proposal: PlanningMutationProposal,
+    approvedIds: string[],
+  ): PlanningMutationProposal | null {
+    const remainingMutations = proposal.mutations.filter((mutation) => !approvedIds.includes(mutation.id));
+
+    if (remainingMutations.length === 0) {
+      this.proposals.delete(proposal.proposal_id);
+      if (this.activeProposalId === proposal.proposal_id) {
+        this.activeProposalId = null;
+      }
+      return null;
+    }
+
+    const nextProposal: PlanningMutationProposal = {
+      ...proposal,
+      summary: `${proposal.summary} (${remainingMutations.length} mutation(s) remaining)`,
+      mutations: remainingMutations,
+    };
+    this.proposals.set(nextProposal.proposal_id, nextProposal);
+    this.activeProposalId = nextProposal.proposal_id;
+    return nextProposal;
+  }
+
+  private getActiveProposal(): PlanningMutationProposal | null {
+    return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
+  }
+
+  private emitStudioEvent(eventType: string, payload: unknown) {
+    const envelope: StudioSseEnvelope = {
+      event_id: `evt_${String(++this.eventCounter).padStart(6, "0")}`,
+      stream_id: this.streamId,
+      timestamp: this.now(),
+      event_type: eventType,
+      session_id: this.session?.sessionId ?? "planning-root",
+      turn_id: this.currentTurnId,
+      payload,
+    };
+
+    this.eventSubject.next({
+      id: envelope.event_id,
+      type: envelope.event_type,
+      data: envelope,
+    });
   }
 
   private projectSessionEntries(entries: SessionEntry[]): PlanningSessionTranscriptEntry[] {

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -1,6 +1,8 @@
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
+import type { ApplyGraphMutationsResult, EdgeRel, WorkItemKind, WorkItemState } from "../graph/types.js";
 
 export type PlanningContextGraphMode = "default" | "focused" | "full";
+export type PlanningMutationType = "create_work_item" | "update_work_item" | "create_edge" | "delete_edge" | "delete_work_item";
 
 export interface SendAgentMessageDto {
   message: string;
@@ -27,11 +29,57 @@ export interface PlanningSessionTranscriptEntry {
   is_error?: boolean;
 }
 
+export interface PlanningMutationProposalSource {
+  agent: string;
+  turn_id?: string | null;
+  session_id: string;
+}
+
+export interface PlanningMutationProposalContext {
+  scope?: string;
+  mode?: PlanningContextGraphMode;
+  based_on_graph_version?: string;
+}
+
+export interface PlanningMutationProposalMutation {
+  id: string;
+  type: PlanningMutationType;
+  entity_id?: string;
+  payload?: Record<string, unknown>;
+  rationale: string;
+  validation?: Record<string, unknown>;
+  group_id?: string;
+  depends_on_mutation_ids?: string[];
+}
+
+export interface PlanningMutationProposal {
+  proposal_id: string;
+  created_at: string;
+  source: PlanningMutationProposalSource;
+  context?: PlanningMutationProposalContext;
+  summary: string;
+  mutations: PlanningMutationProposalMutation[];
+}
+
+export interface ApproveMutationProposalDto {
+  proposal_id: string;
+  approved_mutation_ids: string[];
+}
+
+export interface PlanningGraphCommitResult {
+  proposal_id: string;
+  approved_mutation_ids: string[];
+  result: ApplyGraphMutationsResult;
+  active_proposal: PlanningMutationProposal | null;
+}
+
 export interface PlanningSessionSnapshot {
   session_id: string;
   session_file?: string;
   is_streaming: boolean;
   messages: PlanningSessionTranscriptEntry[];
+  active_proposal: PlanningMutationProposal | null;
+  last_commit_result: PlanningGraphCommitResult | null;
 }
 
 export interface StudioSseEnvelope {
@@ -87,4 +135,56 @@ export interface PlanningContext {
   documents: PlanningContextDocument[];
   graph: PlanningContextGraph;
   conversation_window: PlanningContextMessage[];
+}
+
+export interface ProposeMutationsToolInput {
+  proposal_id?: string;
+  created_at?: string;
+  source?: Partial<PlanningMutationProposalSource>;
+  context?: PlanningMutationProposalContext;
+  summary: string;
+  mutations: Array<{
+    id?: string;
+    type: PlanningMutationType;
+    entity_id?: string;
+    payload?: Record<string, unknown>;
+    rationale: string;
+    validation?: Record<string, unknown>;
+    group_id?: string;
+    depends_on_mutation_ids?: string[];
+  }>;
+}
+
+export interface GraphQueryToolInput {
+  query: "graph" | "frontier" | "plan";
+  repo?: string;
+  state?: WorkItemState;
+  track?: string;
+  phase?: string;
+}
+
+export interface CreateWorkItemPayload {
+  id?: string;
+  name?: string;
+  kind?: WorkItemKind;
+  state?: WorkItemState;
+  repo?: string | null;
+  issue_number?: number | null;
+  issue_url?: string | null;
+  scope_hint?: string | null;
+  branch?: string | null;
+  archive_path?: string | null;
+  predicted_files?: string[];
+  actual_files?: string[];
+  meta?: Record<string, unknown>;
+}
+
+export interface UpdateWorkItemPayload extends Omit<CreateWorkItemPayload, "id"> {}
+
+export interface CreateEdgePayload {
+  from_id?: string;
+  rel?: EdgeRel;
+  to_id?: string;
+  confidence?: "certain" | "inferred" | "ambiguous";
+  meta?: Record<string, unknown>;
 }

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -149,7 +149,7 @@
     </div>
   </header>
 
-  <PlannerChatAdapter />
+  <PlannerChatAdapter on:graphChanged={refresh} />
 
   <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -154,6 +154,12 @@ h2 {
   color: #fecaca;
 }
 
+.banner.success {
+  background: rgba(20, 83, 45, 0.22);
+  border: 1px solid rgba(74, 222, 128, 0.45);
+  color: #dcfce7;
+}
+
 .layout {
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(320px, 420px);
@@ -172,7 +178,9 @@ h2 {
 .planner-controls,
 .planner-body,
 .planner-composer,
-.planner-actions {
+.planner-actions,
+.proposal-panel,
+.proposal-list {
   display: grid;
   gap: 0.75rem;
 }
@@ -256,6 +264,68 @@ h2 {
 .tool-activity-list p {
   margin: 0;
   color: #cbd5e1;
+}
+
+.proposal-panel {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  padding-top: 1rem;
+}
+
+.proposal-header,
+.proposal-card-header,
+.proposal-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.proposal-summary {
+  flex-direction: column;
+}
+
+.proposal-summary p {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.proposal-card {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  background: rgba(2, 6, 23, 0.4);
+}
+
+.proposal-card input {
+  width: auto;
+  margin-top: 0.2rem;
+}
+
+.proposal-card p {
+  margin: 0;
+  color: #cbd5e1;
+}
+
+.proposal-card pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.85rem;
+  color: #bfdbfe;
+}
+
+.proposal-type {
+  display: inline-flex;
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+  color: #93c5fd;
+}
+
+.proposal-actions {
+  grid-template-columns: repeat(3, auto);
+  justify-content: start;
 }
 
 .inline-banner {

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -1,8 +1,9 @@
 <script>
-  import { onMount } from "svelte";
-  import { getPlannerSessionSnapshot, sendAgentMessage } from "../lib/api.js";
+  import { createEventDispatcher, onMount } from "svelte";
+  import { approveMutationProposal, getPlannerSessionSnapshot, sendAgentMessage } from "../lib/api.js";
   import { connectPlannerStream, extractMessageText, toToolStatus } from "../lib/planner-chat.js";
 
+  const dispatch = createEventDispatcher();
   const graphModes = ["default", "focused", "full"];
 
   let draft = "";
@@ -13,16 +14,38 @@
   let toolEvents = [];
   let loading = true;
   let sending = false;
+  let approving = false;
   let connected = false;
   let error = "";
   let sessionId = "";
   let isStreaming = false;
+  let activeProposal = null;
+  let selectedMutationIds = [];
+  let lastCommitResult = null;
   let stream;
+
+  function syncSelection(proposal, preserve = false) {
+    if (!proposal) {
+      selectedMutationIds = [];
+      return;
+    }
+
+    const ids = proposal.mutations?.map((mutation) => mutation.id) ?? [];
+    selectedMutationIds = preserve
+      ? selectedMutationIds.filter((id) => ids.includes(id))
+      : ids;
+  }
 
   function mergeSnapshot(snapshot) {
     sessionId = snapshot.session_id;
     isStreaming = snapshot.is_streaming;
     messages = snapshot.messages ?? [];
+    lastCommitResult = snapshot.last_commit_result ?? null;
+
+    const nextProposal = snapshot.active_proposal ?? null;
+    const changedProposal = nextProposal?.proposal_id !== activeProposal?.proposal_id;
+    activeProposal = nextProposal;
+    syncSelection(activeProposal, !changedProposal);
   }
 
   async function loadSnapshot() {
@@ -50,6 +73,24 @@
 
   function handlePlannerEvent(event) {
     sessionId = event.session_id || sessionId;
+
+    if (event.event_type === "mutation_proposal") {
+      activeProposal = event.payload?.proposal ?? null;
+      lastCommitResult = null;
+      syncSelection(activeProposal);
+      return;
+    }
+
+    if (event.event_type === "graph_commit_result") {
+      lastCommitResult = event.payload ?? null;
+      activeProposal = event.payload?.active_proposal ?? null;
+      syncSelection(activeProposal);
+
+      if (event.payload?.result?.status === "applied") {
+        dispatch("graphChanged");
+      }
+      return;
+    }
 
     if (event.event_type === "agent_start" || event.event_type === "turn_start") {
       isStreaming = true;
@@ -99,10 +140,10 @@
     }
   }
 
-  async function submitMessage() {
-    const message = draft.trim();
-    if (!message || sending) {
-      return;
+  async function sendPlannerMessage(message, { graphModeOverride = graphMode, clearDraft = false } = {}) {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || sending) {
+      return false;
     }
 
     sending = true;
@@ -112,27 +153,98 @@
     appendMessage({
       id: optimisticId,
       role: "user",
-      content: message,
+      content: trimmedMessage,
       timestamp: new Date().toISOString(),
     });
 
     try {
       const response = await sendAgentMessage({
-        message,
+        message: trimmedMessage,
         context: {
-          graph_mode: graphMode,
+          graph_mode: graphModeOverride,
           repo: repo.trim() || undefined,
           track: track.trim() || undefined,
         },
       });
       sessionId = response.session_id;
-      draft = "";
+      if (clearDraft) {
+        draft = "";
+      }
+      return true;
     } catch (sendError) {
       messages = messages.filter((entry) => entry.id !== optimisticId);
       error = sendError.message;
+      return false;
     } finally {
       sending = false;
     }
+  }
+
+  async function submitMessage() {
+    await sendPlannerMessage(draft, { clearDraft: true });
+  }
+
+  async function approveSelectedMutations() {
+    if (!activeProposal || selectedMutationIds.length === 0 || approving) {
+      return;
+    }
+
+    approving = true;
+    error = "";
+
+    try {
+      const commitResult = await approveMutationProposal({
+        proposal_id: activeProposal.proposal_id,
+        approved_mutation_ids: selectedMutationIds,
+      });
+      lastCommitResult = commitResult;
+      activeProposal = commitResult.active_proposal;
+      syncSelection(activeProposal);
+
+      if (commitResult.result?.status === "applied") {
+        dispatch("graphChanged");
+      }
+    } catch (approveError) {
+      error = approveError.message;
+    } finally {
+      approving = false;
+    }
+  }
+
+  async function rejectProposal() {
+    if (!activeProposal) {
+      return;
+    }
+
+    await sendPlannerMessage(
+      `Reject proposal ${activeProposal.proposal_id}. Do not restage the same mutations unchanged. Briefly explain why it was rejected and propose a better alternative if appropriate.`,
+    );
+  }
+
+  async function reviseProposal() {
+    if (!activeProposal) {
+      return;
+    }
+
+    const revisionNote = draft.trim() || window.prompt("How should the planner revise this proposal?", "");
+    if (!revisionNote?.trim()) {
+      return;
+    }
+
+    const sent = await sendPlannerMessage(
+      `Revise proposal ${activeProposal.proposal_id}. Keep the same planning goal, but adjust it as follows: ${revisionNote.trim()}`,
+      { clearDraft: draft.trim() === revisionNote.trim() },
+    );
+
+    if (sent && draft.trim() === revisionNote.trim()) {
+      draft = "";
+    }
+  }
+
+  function toggleMutationSelection(mutationId, checked) {
+    selectedMutationIds = checked
+      ? [...selectedMutationIds, mutationId]
+      : selectedMutationIds.filter((id) => id !== mutationId);
   }
 
   onMount(() => {
@@ -189,6 +301,18 @@
     <div class="banner error inline-banner">{error}</div>
   {/if}
 
+  {#if lastCommitResult}
+    <div class="banner {lastCommitResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+      {#if lastCommitResult.result.status === 'applied'}
+        Applied {lastCommitResult.approved_mutation_ids.length} mutation(s) from {lastCommitResult.proposal_id}. Graph version {lastCommitResult.result.previous_graph_version} → {lastCommitResult.result.new_graph_version}.
+      {:else if lastCommitResult.result.status === 'stale'}
+        Proposal {lastCommitResult.proposal_id} is stale. Current graph version: {lastCommitResult.result.current_graph_version}.
+      {:else}
+        Commit failed for proposal {lastCommitResult.proposal_id}: {lastCommitResult.result.errors.map((error) => error.message).join('; ')}
+      {/if}
+    </div>
+  {/if}
+
   <div class="planner-body">
     <div class="planner-transcript">
       {#if loading}
@@ -234,6 +358,60 @@
       {/if}
     </aside>
   </div>
+
+  <section class="proposal-panel">
+    <div class="proposal-header">
+      <div>
+        <h3>Active mutation proposal</h3>
+        <p class="muted">Latest structured proposal emitted by the planner.</p>
+      </div>
+      {#if activeProposal?.context?.based_on_graph_version}
+        <span class="status-pill healthy">graph v{activeProposal.context.based_on_graph_version}</span>
+      {/if}
+    </div>
+
+    {#if !activeProposal}
+      <p class="muted">No active proposal yet. Ask the planner to propose graph mutations.</p>
+    {:else}
+      <div class="proposal-summary">
+        <strong>{activeProposal.proposal_id}</strong>
+        <p>{activeProposal.summary}</p>
+      </div>
+
+      <div class="proposal-list">
+        {#each activeProposal.mutations as mutation}
+          <label class="proposal-card">
+            <div class="proposal-card-header">
+              <input
+                type="checkbox"
+                checked={selectedMutationIds.includes(mutation.id)}
+                on:change={(event) => toggleMutationSelection(mutation.id, event.currentTarget.checked)}
+              />
+              <div>
+                <strong>{mutation.id}</strong>
+                <span class="proposal-type">{mutation.type}</span>
+                {#if mutation.entity_id}
+                  <code>{mutation.entity_id}</code>
+                {/if}
+              </div>
+            </div>
+            <p>{mutation.rationale}</p>
+            {#if mutation.payload}
+              <pre>{JSON.stringify(mutation.payload, null, 2)}</pre>
+            {/if}
+          </label>
+        {/each}
+      </div>
+
+      <div class="planner-actions proposal-actions">
+        <button on:click={approveSelectedMutations} disabled={approving || selectedMutationIds.length === 0}>
+          {approving ? "Applying..." : `Approve ${selectedMutationIds.length} selected`}
+        </button>
+        <button class="secondary" on:click={rejectProposal} disabled={sending}>Reject via follow-up</button>
+        <button class="secondary" on:click={reviseProposal} disabled={sending}>Revise via follow-up</button>
+      </div>
+    {/if}
+  </section>
 
   <div class="planner-composer">
     <label>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -33,6 +33,14 @@ export function sendAgentMessage(payload) {
   });
 }
 
+export function approveMutationProposal(payload) {
+  return request("/api/agent/proposals/approve", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {

--- a/web/src/lib/planner-chat.js
+++ b/web/src/lib/planner-chat.js
@@ -23,6 +23,8 @@ export function connectPlannerStream({ onEvent, onOpen, onError } = {}) {
     "tool_execution_start",
     "tool_execution_update",
     "tool_execution_end",
+    "mutation_proposal",
+    "graph_commit_result",
   ].forEach(forward);
 
   stream.onopen = () => onOpen?.();


### PR DESCRIPTION
## Summary
Add the first structured mutation proposal and approval flow so the root planner can stage graph changes, the browser can review them, and selected mutations can be applied atomically.

Closes #7

## Changes
- add planning DTOs for mutation proposals, approval requests, and graph commit results
- add `graph_query`, `propose_mutations`, and V1-blocked `graph_mutate` custom planner tools
- retain the latest active proposal in the planning service and expose it in `GET /api/agent/session`
- add `POST /api/agent/proposals/approve` to map approved mutation IDs onto the atomic graph writer
- emit `mutation_proposal` and `graph_commit_result` SSE events
- render active proposal cards, selection controls, and approve/reject/revise actions in the browser chat workspace
- refresh the graph view after successful proposal commits
- update `README.md` with mutation proposal and approval verification steps

## Testing
- `npm run build`
- manual planner proposal staging via `propose_mutations`
- manual `GET /api/agent/session` verification for active proposal + last commit result
- manual approval flow verification against `POST /api/agent/proposals/approve`
- manual stale rejection verification after bumping graph version
- manual revise follow-up verification with a restaged proposal
- manual Vite proxy verification for planner session reads

## Notes
- keeps reject/revise lightweight in V1 by sending follow-up planner messages instead of adding dedicated backend lifecycle endpoints
- keeps actual graph commits browser-approval-backed; direct `graph_mutate` tool execution is intentionally blocked in this pass
