### PR TITLE
feat: add approval-gated planning memory flow (#8)

### DIFF
--- a/PLANNING_MEMORY.md
+++ b/PLANNING_MEMORY.md
@@ -13,6 +13,8 @@
 - Use a hybrid execution backend with Studio-owned orchestration over pi SDK primitives.
 
 ## Planning Conventions
+- Keep planning memory compact enough to read directly in context.
+- Mutation proposals require browser approval before graph apply.
 - Keep planning docs and issues lean and demoable.
 - Prefer explicit, approval-gated structural updates over append-only planning sprawl.
 - GitHub issues are the execution-facing substrate; the Studio graph is canonical for planning structure.

--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ This runs the server TypeScript check plus the production frontend build.
 9. Ask the planner to propose graph mutations and confirm a reviewable mutation proposal appears in the browser.
 10. Approve a subset of the proposed mutations and confirm the commit succeeds.
 11. Confirm the graph refreshes and the D3 view reflects the approved changes.
-12. Ask the planner to revise or reject the current proposal from the browser and confirm the follow-up stays in the same planner conversation.
-13. Refresh the page and confirm recent transcript state plus the latest active proposal/commit result are restored.
-14. Verify the graph view still loads data from `/api/graph`.
-15. Select a node to edit it in the sidebar.
-16. Create a new work item in the sidebar and confirm it appears in the graph.
-17. Create an edge between two nodes and confirm it appears in the graph and edge list.
-18. Delete an edge from the sidebar.
-19. Change repo/state/track/phase filters and confirm the rendered graph updates.
+12. Ask the planner to propose a planning memory update and confirm a staged memory change appears in the browser.
+13. Approve the staged memory change and confirm `PLANNING_MEMORY.md` updates only after approval.
+14. Ask the planner to revise or reject the current graph or memory proposal from the browser and confirm the follow-up stays in the same planner conversation.
+15. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/commit results are restored.
+16. Verify the graph view still loads data from `/api/graph`.
+17. Select a node to edit it in the sidebar.
+18. Create a new work item in the sidebar and confirm it appears in the graph.
+19. Create an edge between two nodes and confirm it appears in the graph and edge list.
+20. Delete an edge from the sidebar.
+21. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -239,7 +241,40 @@ The assembled planner context includes:
 - a small recent conversation window
 
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
-It also emits Studio mutation workflow events: `mutation_proposal` and `graph_commit_result`.
+It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, and `memory_write_result`.
+
+### Stage and approve a planning memory change
+
+First, ask the planner to read memory and stage a targeted change:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/message \
+  -H 'content-type: application/json' \
+  -d '{
+    "message":"Use memory_read and then memory_write to stage one targeted planning memory edit"
+  }'
+```
+
+Then inspect the staged change and current memory hash:
+
+```bash
+curl http://localhost:3000/api/agent/session
+```
+
+Approve a subset of staged memory edit IDs:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/memory/approve \
+  -H 'content-type: application/json' \
+  -d '{
+    "change_id": "mem_123",
+    "approved_edit_ids": ["e1"]
+  }'
+```
+
+The write result returns `applied`, `validation_failed`, or `stale`, plus the latest `PLANNING_MEMORY.md` content/hash and any remaining active staged memory change.
+
+### Approve a structured mutation proposal
 
 ### Approve a structured mutation proposal
 

--- a/src/modules/planning/context.service.ts
+++ b/src/modules/planning/context.service.ts
@@ -7,6 +7,7 @@ import { EdgesService } from "../graph/edges.service.js";
 import { SQLiteService } from "../graph/sqlite.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { EdgeRecord, WorkItemRecord } from "../graph/types.js";
+import { MemoryService } from "./memory.service.js";
 import type {
   AssemblePlanningContextInput,
   PlanningContext,
@@ -29,6 +30,7 @@ export class ContextService {
     @Inject(SQLiteService) private readonly sqlite: SQLiteService,
     @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
     @Inject(EdgesService) private readonly edges: EdgesService,
+    @Inject(MemoryService) private readonly memoryService: MemoryService,
   ) {}
 
   assemble(input: AssemblePlanningContextInput = {}): PlanningContext {
@@ -39,7 +41,7 @@ export class ContextService {
       documents: [
         this.readDocument("studio_overview", this.overviewPath),
         this.readDocument("studio_architecture", this.architecturePath),
-        this.readDocument("planning_memory", this.planningMemoryPath),
+        this.readPlanningMemoryDocument(),
       ],
       graph,
       conversation_window: this.buildConversationWindow(input.session),
@@ -275,6 +277,16 @@ export class ContextService {
       label: this.getDocumentLabel(kind),
       path,
       content: this.compact(content, this.documentCharLimit),
+    };
+  }
+
+  private readPlanningMemoryDocument(): PlanningContextDocument {
+    const memory = this.memoryService.read();
+    return {
+      kind: "planning_memory",
+      label: this.getDocumentLabel("planning_memory"),
+      path: memory.path,
+      content: this.compact(memory.content, this.documentCharLimit),
     };
   }
 

--- a/src/modules/planning/memory.service.ts
+++ b/src/modules/planning/memory.service.ts
@@ -1,0 +1,210 @@
+import { Injectable } from "@nestjs/common";
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type {
+  PlanningMemoryApplyResult,
+  PlanningMemoryChange,
+  PlanningMemoryDocument,
+  PlanningMemoryEdit,
+} from "./types.js";
+
+@Injectable()
+export class MemoryService {
+  private readonly memoryPath = resolve(process.cwd(), "PLANNING_MEMORY.md");
+
+  read(): PlanningMemoryDocument {
+    const content = readFileSync(this.memoryPath, "utf8").replace(/\r/g, "");
+    return {
+      path: this.memoryPath,
+      content,
+      content_hash: this.hash(content),
+    };
+  }
+
+  applyChange(change: PlanningMemoryChange, approvedEditIds: string[]): { result: PlanningMemoryApplyResult; memory: PlanningMemoryDocument } {
+    const memory = this.read();
+
+    if (memory.content_hash !== change.based_on_content_hash) {
+      return {
+        result: {
+          status: "stale",
+          previous_content_hash: change.based_on_content_hash,
+          current_content_hash: memory.content_hash,
+          message: "Planning memory changed since this edit set was staged and must be regenerated.",
+        },
+        memory,
+      };
+    }
+
+    const selectedEdits = approvedEditIds.map((id) => {
+      const edit = change.edits.find((candidate) => candidate.id === id);
+      if (!edit) {
+        return null;
+      }
+      return edit;
+    });
+
+    const missingEditIds = approvedEditIds.filter((id, index) => !selectedEdits[index]);
+    if (missingEditIds.length > 0) {
+      return {
+        result: {
+          status: "validation_failed",
+          errors: missingEditIds.map((editId) => ({ edit_id: editId, message: "Unknown memory edit id" })),
+        },
+        memory,
+      };
+    }
+
+    const validationErrors = this.validateEdits(memory.content, selectedEdits as PlanningMemoryEdit[]);
+    if (validationErrors.length > 0) {
+      return {
+        result: {
+          status: "validation_failed",
+          errors: validationErrors,
+        },
+        memory,
+      };
+    }
+
+    const nextContent = this.applyEdits(memory.content, selectedEdits as PlanningMemoryEdit[]);
+    writeFileSync(this.memoryPath, nextContent, "utf8");
+
+    const nextMemory = this.read();
+    return {
+      result: {
+        status: "applied",
+        applied_edit_ids: approvedEditIds,
+        previous_content_hash: memory.content_hash,
+        new_content_hash: nextMemory.content_hash,
+      },
+      memory: nextMemory,
+    };
+  }
+
+  private validateEdits(content: string, edits: PlanningMemoryEdit[]): Array<{ edit_id: string; message: string }> {
+    const errors: Array<{ edit_id: string; message: string }> = [];
+
+    for (const edit of edits) {
+      switch (edit.kind) {
+        case "replace_text": {
+          if (!edit.old_text) {
+            errors.push({ edit_id: edit.id, message: "replace_text edit requires old_text" });
+            break;
+          }
+
+          if (typeof edit.new_text !== "string") {
+            errors.push({ edit_id: edit.id, message: "replace_text edit requires new_text" });
+            break;
+          }
+
+          const count = this.countOccurrences(content, edit.old_text);
+          if (count === 0) {
+            errors.push({ edit_id: edit.id, message: "replace_text old_text was not found" });
+          } else if (count > 1) {
+            errors.push({ edit_id: edit.id, message: "replace_text old_text matched multiple locations" });
+          }
+          break;
+        }
+
+        case "delete_text": {
+          if (!edit.old_text) {
+            errors.push({ edit_id: edit.id, message: "delete_text edit requires old_text" });
+            break;
+          }
+
+          const count = this.countOccurrences(content, edit.old_text);
+          if (count === 0) {
+            errors.push({ edit_id: edit.id, message: "delete_text old_text was not found" });
+          } else if (count > 1) {
+            errors.push({ edit_id: edit.id, message: "delete_text old_text matched multiple locations" });
+          }
+          break;
+        }
+
+        case "insert_after_heading": {
+          if (!edit.target_heading?.trim()) {
+            errors.push({ edit_id: edit.id, message: "insert_after_heading edit requires target_heading" });
+            break;
+          }
+
+          if (!edit.new_text?.trim()) {
+            errors.push({ edit_id: edit.id, message: "insert_after_heading edit requires new_text" });
+            break;
+          }
+
+          const heading = this.normalizeHeading(edit.target_heading);
+          if (!content.includes(`\n${heading}\n`) && !content.startsWith(`${heading}\n`)) {
+            errors.push({ edit_id: edit.id, message: `Heading not found: ${heading}` });
+          }
+          break;
+        }
+      }
+    }
+
+    return errors;
+  }
+
+  private applyEdits(content: string, edits: PlanningMemoryEdit[]): string {
+    let next = content;
+
+    for (const edit of edits) {
+      switch (edit.kind) {
+        case "replace_text":
+          next = next.replace(edit.old_text ?? "", edit.new_text ?? "");
+          break;
+        case "delete_text":
+          next = next.replace(edit.old_text ?? "", "");
+          break;
+        case "insert_after_heading":
+          next = this.insertAfterHeading(next, this.normalizeHeading(edit.target_heading ?? ""), edit.new_text ?? "");
+          break;
+      }
+    }
+
+    return this.normalizeSpacing(next);
+  }
+
+  private insertAfterHeading(content: string, heading: string, insertion: string): string {
+    const normalizedInsertion = insertion.replace(/\r/g, "").trimEnd();
+    const headingIndex = content.indexOf(heading);
+    if (headingIndex < 0) {
+      return content;
+    }
+
+    const lineEndIndex = content.indexOf("\n", headingIndex);
+    const insertAt = lineEndIndex >= 0 ? lineEndIndex + 1 : content.length;
+    return `${content.slice(0, insertAt)}${normalizedInsertion}\n${content.slice(insertAt)}`;
+  }
+
+  private normalizeHeading(value: string): string {
+    const trimmed = value.trim();
+    return trimmed.startsWith("## ") ? trimmed : `## ${trimmed.replace(/^#+\s*/, "")}`;
+  }
+
+  private normalizeSpacing(value: string): string {
+    return `${value.replace(/\r/g, "").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
+  }
+
+  private countOccurrences(content: string, target: string): number {
+    if (!target) {
+      return 0;
+    }
+
+    let count = 0;
+    let fromIndex = 0;
+
+    while (true) {
+      const index = content.indexOf(target, fromIndex);
+      if (index === -1) {
+        return count;
+      }
+      count += 1;
+      fromIndex = index + target.length;
+    }
+  }
+
+  private hash(content: string): string {
+    return createHash("sha1").update(content).digest("hex");
+  }
+}

--- a/src/modules/planning/planning.controller.ts
+++ b/src/modules/planning/planning.controller.ts
@@ -1,7 +1,11 @@
 import { Body, Controller, Get, Inject, MessageEvent, Post, Sse } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { PlanningService } from "./planning.service.js";
-import type { ApproveMutationProposalDto, SendAgentMessageDto } from "./types.js";
+import type {
+  ApproveMutationProposalDto,
+  ApprovePlanningMemoryChangeDto,
+  SendAgentMessageDto,
+} from "./types.js";
 
 @Controller("api/agent")
 export class PlanningController {
@@ -20,6 +24,11 @@ export class PlanningController {
   @Post("proposals/approve")
   approveProposal(@Body() body: ApproveMutationProposalDto) {
     return this.planningService.approveProposal(body);
+  }
+
+  @Post("memory/approve")
+  approveMemoryChange(@Body() body: ApprovePlanningMemoryChangeDto) {
+    return this.planningService.approveMemoryChange(body);
   }
 
   @Sse("stream")

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { GraphModule } from "../graph/graph.module.js";
 import { ContextService } from "./context.service.js";
+import { MemoryService } from "./memory.service.js";
 import { PlanningController } from "./planning.controller.js";
 import { PlanningService } from "./planning.service.js";
 
 @Module({
   imports: [GraphModule],
   controllers: [PlanningController],
-  providers: [PlanningService, ContextService],
-  exports: [PlanningService, ContextService],
+  providers: [PlanningService, ContextService, MemoryService],
+  exports: [PlanningService, ContextService, MemoryService],
 })
 export class PlanningModule {}

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -8,7 +8,6 @@ import { getConfig } from "../../config.js";
 import { GraphService } from "../graph/graph.service.js";
 import { GraphWriterService } from "../graph/graph-writer.service.js";
 import type {
-  ApplyGraphMutationsResult,
   CreateEdgeDto,
   CreateWorkItemDto,
   DeleteEdgeMutation,
@@ -18,16 +17,22 @@ import type {
   UpdateWorkItemDto,
 } from "../graph/types.js";
 import { ContextService } from "./context.service.js";
+import { MemoryService } from "./memory.service.js";
 import type {
   ApproveMutationProposalDto,
+  ApprovePlanningMemoryChangeDto,
   CreateEdgePayload,
   CreateWorkItemPayload,
   GraphQueryToolInput,
   PlanningGraphCommitResult,
+  PlanningMemoryChange,
+  PlanningMemoryEdit,
+  PlanningMemoryWriteResult,
   PlanningMutationProposal,
   PlanningMutationProposalMutation,
   PlanningSessionSnapshot,
   PlanningSessionTranscriptEntry,
+  ProposeMemoryWriteToolInput,
   ProposeMutationsToolInput,
   SendAgentMessageDto,
   SendAgentMessageResult,
@@ -42,6 +47,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private readonly eventSubject = new Subject<MessageEvent>();
   private readonly sessionDir = resolve(process.cwd(), getConfig().planningSessionDir);
   private readonly proposals = new Map<string, PlanningMutationProposal>();
+  private readonly memoryChanges = new Map<string, PlanningMemoryChange>();
 
   private session?: AgentSession;
   private sessionPromise?: Promise<AgentSession>;
@@ -51,11 +57,14 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private currentTurnId: string | null = null;
   private activeProposalId: string | null = null;
   private lastCommitResult: PlanningGraphCommitResult | null = null;
+  private activeMemoryChangeId: string | null = null;
+  private lastMemoryWriteResult: PlanningMemoryWriteResult | null = null;
 
   constructor(
     @Inject(ContextService) private readonly contextService: ContextService,
     @Inject(GraphService) private readonly graphService: GraphService,
     @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
+    @Inject(MemoryService) private readonly memoryService: MemoryService,
   ) {}
 
   async onModuleInit() {
@@ -87,6 +96,9 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       messages: this.projectSessionEntries(session.sessionManager.getEntries()),
       active_proposal: this.getActiveProposal(),
       last_commit_result: this.lastCommitResult,
+      active_memory_change: this.getActiveMemoryChange(),
+      last_memory_write_result: this.lastMemoryWriteResult,
+      memory: this.memoryService.read(),
     };
   }
 
@@ -170,6 +182,40 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     return commitResult;
   }
 
+  async approveMemoryChange(input: ApprovePlanningMemoryChangeDto): Promise<PlanningMemoryWriteResult> {
+    const changeId = input.change_id?.trim();
+    if (!changeId) {
+      throw new BadRequestException("change_id is required");
+    }
+
+    const approvedEditIds = Array.from(new Set((input.approved_edit_ids ?? []).filter((id) => typeof id === "string" && id.trim())));
+    if (approvedEditIds.length === 0) {
+      throw new BadRequestException("approved_edit_ids must contain at least one edit id");
+    }
+
+    const change = this.memoryChanges.get(changeId);
+    if (!change) {
+      throw new BadRequestException(`Unknown memory change: ${changeId}`);
+    }
+
+    const { result, memory } = this.memoryService.applyChange(change, approvedEditIds);
+    const activeMemoryChange = result.status === "applied"
+      ? this.updateActiveMemoryChangeAfterApply(change, approvedEditIds)
+      : this.getActiveMemoryChange();
+
+    const writeResult: PlanningMemoryWriteResult = {
+      change_id: change.change_id,
+      approved_edit_ids: approvedEditIds,
+      result,
+      active_memory_change: activeMemoryChange,
+      memory,
+    };
+
+    this.lastMemoryWriteResult = writeResult;
+    this.emitStudioEvent("memory_write_result", writeResult);
+    return writeResult;
+  }
+
   private async ensureSession(): Promise<AgentSession> {
     if (this.session) {
       return this.session;
@@ -192,7 +238,13 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd: process.cwd(),
       sessionManager: SessionManager.continueRecent(process.cwd(), this.sessionDir),
-      customTools: [this.createGraphQueryTool(), this.createProposeMutationsTool(), this.createGraphMutateTool()],
+      customTools: [
+        this.createGraphQueryTool(),
+        this.createProposeMutationsTool(),
+        this.createGraphMutateTool(),
+        this.createMemoryReadTool(),
+        this.createMemoryWriteTool(),
+      ],
     });
 
     if (modelFallbackMessage) {
@@ -358,6 +410,75 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     });
   }
 
+  private createMemoryReadTool() {
+    return defineTool({
+      name: "memory_read",
+      label: "Planning Memory Read",
+      description: "Read the curated durable planning memory file.",
+      promptSnippet: "memory_read: inspect the curated planning memory before proposing durable memory changes.",
+      promptGuidelines: [
+        "Use memory_read before suggesting durable planning-memory edits so you can update the existing curated structure intentionally.",
+      ],
+      parameters: Type.Object({}),
+      execute: async () => {
+        const memory = this.memoryService.read();
+        return {
+          content: [{ type: "text", text: memory.content }],
+          details: memory,
+        };
+      },
+    });
+  }
+
+  private createMemoryWriteTool() {
+    return defineTool({
+      name: "memory_write",
+      label: "Planning Memory Write",
+      description: "Stage targeted planning memory edits for browser approval.",
+      promptSnippet: "memory_write: stage targeted edits to PLANNING_MEMORY.md for browser approval instead of writing directly.",
+      promptGuidelines: [
+        "Use memory_write only for durable, curated planning-memory updates.",
+        "Prefer targeted replacements or section-specific inserts over append-only growth.",
+        "Do not include transcript residue, raw tool output, or broad dumps.",
+      ],
+      parameters: Type.Object({
+        change_id: Type.Optional(Type.String()),
+        created_at: Type.Optional(Type.String()),
+        source: Type.Optional(Type.Object({
+          agent: Type.Optional(Type.String()),
+          turn_id: Type.Optional(Type.String()),
+          session_id: Type.Optional(Type.String()),
+        })),
+        summary: Type.String(),
+        edits: Type.Array(Type.Object({
+          id: Type.Optional(Type.String()),
+          kind: Type.Union([
+            Type.Literal("replace_text"),
+            Type.Literal("insert_after_heading"),
+            Type.Literal("delete_text"),
+          ]),
+          summary: Type.String(),
+          rationale: Type.String(),
+          old_text: Type.Optional(Type.String()),
+          new_text: Type.Optional(Type.String()),
+          target_heading: Type.Optional(Type.String()),
+        })),
+      }),
+      execute: async (_toolCallId, params: ProposeMemoryWriteToolInput) => {
+        const change = this.normalizeMemoryChange(params);
+        this.memoryChanges.set(change.change_id, change);
+        this.activeMemoryChangeId = change.change_id;
+        this.lastMemoryWriteResult = null;
+        this.emitStudioEvent("memory_change_proposal", { change });
+
+        return {
+          content: [{ type: "text", text: `Staged planning memory change ${change.change_id} with ${change.edits.length} edit(s).` }],
+          details: { change },
+        };
+      },
+    });
+  }
+
   private normalizeProposal(input: ProposeMutationsToolInput): PlanningMutationProposal {
     const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
     const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}`;
@@ -403,6 +524,37 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       validation: mutation.validation,
       group_id: mutation.group_id,
       depends_on_mutation_ids: mutation.depends_on_mutation_ids,
+    };
+  }
+
+  private normalizeMemoryChange(input: ProposeMemoryWriteToolInput): PlanningMemoryChange {
+    const memory = this.memoryService.read();
+    const changeId = input.change_id?.trim() || `mem_${Date.now()}`;
+    const createdAt = input.created_at?.trim() || this.now();
+
+    return {
+      change_id: changeId,
+      created_at: createdAt,
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
+        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
+      },
+      summary: input.summary.trim(),
+      based_on_content_hash: memory.content_hash,
+      edits: input.edits.map((edit, index) => this.normalizeMemoryEdit(edit, index)),
+    };
+  }
+
+  private normalizeMemoryEdit(edit: ProposeMemoryWriteToolInput["edits"][number], index: number): PlanningMemoryEdit {
+    return {
+      id: edit.id?.trim() || `e${index + 1}`,
+      kind: edit.kind,
+      summary: edit.summary.trim(),
+      rationale: edit.rationale.trim(),
+      old_text: edit.old_text,
+      new_text: edit.new_text,
+      target_heading: edit.target_heading,
     };
   }
 
@@ -517,8 +669,37 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     return nextProposal;
   }
 
+  private updateActiveMemoryChangeAfterApply(
+    change: PlanningMemoryChange,
+    approvedEditIds: string[],
+  ): PlanningMemoryChange | null {
+    const remainingEdits = change.edits.filter((edit) => !approvedEditIds.includes(edit.id));
+
+    if (remainingEdits.length === 0) {
+      this.memoryChanges.delete(change.change_id);
+      if (this.activeMemoryChangeId === change.change_id) {
+        this.activeMemoryChangeId = null;
+      }
+      return null;
+    }
+
+    const nextChange: PlanningMemoryChange = {
+      ...change,
+      summary: `${change.summary} (${remainingEdits.length} edit(s) remaining)`,
+      edits: remainingEdits,
+      based_on_content_hash: this.memoryService.read().content_hash,
+    };
+    this.memoryChanges.set(nextChange.change_id, nextChange);
+    this.activeMemoryChangeId = nextChange.change_id;
+    return nextChange;
+  }
+
   private getActiveProposal(): PlanningMutationProposal | null {
     return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
+  }
+
+  private getActiveMemoryChange(): PlanningMemoryChange | null {
+    return this.activeMemoryChangeId ? this.memoryChanges.get(this.activeMemoryChangeId) ?? null : null;
   }
 
   private emitStudioEvent(eventType: string, payload: unknown) {

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -3,6 +3,7 @@ import type { ApplyGraphMutationsResult, EdgeRel, WorkItemKind, WorkItemState } 
 
 export type PlanningContextGraphMode = "default" | "focused" | "full";
 export type PlanningMutationType = "create_work_item" | "update_work_item" | "create_edge" | "delete_edge" | "delete_work_item";
+export type PlanningMemoryEditKind = "replace_text" | "insert_after_heading" | "delete_text";
 
 export interface SendAgentMessageDto {
   message: string;
@@ -73,6 +74,68 @@ export interface PlanningGraphCommitResult {
   active_proposal: PlanningMutationProposal | null;
 }
 
+export interface PlanningMemoryDocument {
+  path: string;
+  content: string;
+  content_hash: string;
+}
+
+export interface PlanningMemoryEdit {
+  id: string;
+  kind: PlanningMemoryEditKind;
+  summary: string;
+  rationale: string;
+  old_text?: string;
+  new_text?: string;
+  target_heading?: string;
+}
+
+export interface PlanningMemoryChange {
+  change_id: string;
+  created_at: string;
+  source: PlanningMutationProposalSource;
+  summary: string;
+  based_on_content_hash: string;
+  edits: PlanningMemoryEdit[];
+}
+
+export interface ApprovePlanningMemoryChangeDto {
+  change_id: string;
+  approved_edit_ids: string[];
+}
+
+export interface PlanningMemoryApplySuccess {
+  status: "applied";
+  applied_edit_ids: string[];
+  previous_content_hash: string;
+  new_content_hash: string;
+}
+
+export interface PlanningMemoryApplyValidationFailure {
+  status: "validation_failed";
+  errors: Array<{ edit_id: string; message: string }>;
+}
+
+export interface PlanningMemoryApplyStale {
+  status: "stale";
+  previous_content_hash: string;
+  current_content_hash: string;
+  message: string;
+}
+
+export type PlanningMemoryApplyResult =
+  | PlanningMemoryApplySuccess
+  | PlanningMemoryApplyValidationFailure
+  | PlanningMemoryApplyStale;
+
+export interface PlanningMemoryWriteResult {
+  change_id: string;
+  approved_edit_ids: string[];
+  result: PlanningMemoryApplyResult;
+  active_memory_change: PlanningMemoryChange | null;
+  memory: PlanningMemoryDocument;
+}
+
 export interface PlanningSessionSnapshot {
   session_id: string;
   session_file?: string;
@@ -80,6 +143,9 @@ export interface PlanningSessionSnapshot {
   messages: PlanningSessionTranscriptEntry[];
   active_proposal: PlanningMutationProposal | null;
   last_commit_result: PlanningGraphCommitResult | null;
+  active_memory_change: PlanningMemoryChange | null;
+  last_memory_write_result: PlanningMemoryWriteResult | null;
+  memory: PlanningMemoryDocument;
 }
 
 export interface StudioSseEnvelope {
@@ -152,6 +218,22 @@ export interface ProposeMutationsToolInput {
     validation?: Record<string, unknown>;
     group_id?: string;
     depends_on_mutation_ids?: string[];
+  }>;
+}
+
+export interface ProposeMemoryWriteToolInput {
+  change_id?: string;
+  created_at?: string;
+  source?: Partial<PlanningMutationProposalSource>;
+  summary: string;
+  edits: Array<{
+    id?: string;
+    kind: PlanningMemoryEditKind;
+    summary: string;
+    rationale: string;
+    old_text?: string;
+    new_text?: string;
+    target_heading?: string;
   }>;
 }
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -328,6 +328,33 @@ h2 {
   justify-content: start;
 }
 
+.memory-panel {
+  border-top-style: dashed;
+}
+
+.memory-preview {
+  padding: 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.4);
+}
+
+.memory-preview summary {
+  cursor: pointer;
+  color: #cbd5e1;
+}
+
+.memory-preview pre {
+  margin: 0.75rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.85rem;
+}
+
+.memory-edit-card strong {
+  color: #f8fafc;
+}
+
 .inline-banner {
   width: 100%;
   margin: 0;

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -1,6 +1,11 @@
 <script>
   import { createEventDispatcher, onMount } from "svelte";
-  import { approveMutationProposal, getPlannerSessionSnapshot, sendAgentMessage } from "../lib/api.js";
+  import {
+    approveMemoryChange,
+    approveMutationProposal,
+    getPlannerSessionSnapshot,
+    sendAgentMessage,
+  } from "../lib/api.js";
   import { connectPlannerStream, extractMessageText, toToolStatus } from "../lib/planner-chat.js";
 
   const dispatch = createEventDispatcher();
@@ -22,18 +27,30 @@
   let activeProposal = null;
   let selectedMutationIds = [];
   let lastCommitResult = null;
+  let activeMemoryChange = null;
+  let selectedMemoryEditIds = [];
+  let lastMemoryWriteResult = null;
+  let memoryDocument = null;
   let stream;
 
-  function syncSelection(proposal, preserve = false) {
+  function syncMutationSelection(proposal, preserve = false) {
     if (!proposal) {
       selectedMutationIds = [];
       return;
     }
 
     const ids = proposal.mutations?.map((mutation) => mutation.id) ?? [];
-    selectedMutationIds = preserve
-      ? selectedMutationIds.filter((id) => ids.includes(id))
-      : ids;
+    selectedMutationIds = preserve ? selectedMutationIds.filter((id) => ids.includes(id)) : ids;
+  }
+
+  function syncMemorySelection(change, preserve = false) {
+    if (!change) {
+      selectedMemoryEditIds = [];
+      return;
+    }
+
+    const ids = change.edits?.map((edit) => edit.id) ?? [];
+    selectedMemoryEditIds = preserve ? selectedMemoryEditIds.filter((id) => ids.includes(id)) : ids;
   }
 
   function mergeSnapshot(snapshot) {
@@ -41,11 +58,18 @@
     isStreaming = snapshot.is_streaming;
     messages = snapshot.messages ?? [];
     lastCommitResult = snapshot.last_commit_result ?? null;
+    lastMemoryWriteResult = snapshot.last_memory_write_result ?? null;
+    memoryDocument = snapshot.memory ?? null;
 
     const nextProposal = snapshot.active_proposal ?? null;
-    const changedProposal = nextProposal?.proposal_id !== activeProposal?.proposal_id;
+    const proposalChanged = nextProposal?.proposal_id !== activeProposal?.proposal_id;
     activeProposal = nextProposal;
-    syncSelection(activeProposal, !changedProposal);
+    syncMutationSelection(activeProposal, !proposalChanged);
+
+    const nextMemoryChange = snapshot.active_memory_change ?? null;
+    const memoryChanged = nextMemoryChange?.change_id !== activeMemoryChange?.change_id;
+    activeMemoryChange = nextMemoryChange;
+    syncMemorySelection(activeMemoryChange, !memoryChanged);
   }
 
   async function loadSnapshot() {
@@ -77,18 +101,32 @@
     if (event.event_type === "mutation_proposal") {
       activeProposal = event.payload?.proposal ?? null;
       lastCommitResult = null;
-      syncSelection(activeProposal);
+      syncMutationSelection(activeProposal);
       return;
     }
 
     if (event.event_type === "graph_commit_result") {
       lastCommitResult = event.payload ?? null;
       activeProposal = event.payload?.active_proposal ?? null;
-      syncSelection(activeProposal);
-
+      syncMutationSelection(activeProposal);
       if (event.payload?.result?.status === "applied") {
         dispatch("graphChanged");
       }
+      return;
+    }
+
+    if (event.event_type === "memory_change_proposal") {
+      activeMemoryChange = event.payload?.change ?? null;
+      lastMemoryWriteResult = null;
+      syncMemorySelection(activeMemoryChange);
+      return;
+    }
+
+    if (event.event_type === "memory_write_result") {
+      lastMemoryWriteResult = event.payload ?? null;
+      activeMemoryChange = event.payload?.active_memory_change ?? null;
+      memoryDocument = event.payload?.memory ?? memoryDocument;
+      syncMemorySelection(activeMemoryChange);
       return;
     }
 
@@ -104,9 +142,7 @@
 
     if (event.event_type === "message_start" || event.event_type === "message_update" || event.event_type === "message_end") {
       const payloadMessage = event.payload?.message;
-      const role = payloadMessage?.role;
-
-      if (role !== "assistant") {
+      if (payloadMessage?.role !== "assistant") {
         return;
       }
 
@@ -114,11 +150,8 @@
         id: `${event.turn_id || event.event_id}:assistant`,
         role: "assistant",
         content: extractMessageText(payloadMessage),
-        timestamp: payloadMessage?.timestamp
-          ? new Date(payloadMessage.timestamp).toISOString()
-          : event.timestamp,
+        timestamp: payloadMessage?.timestamp ? new Date(payloadMessage.timestamp).toISOString() : event.timestamp,
       });
-
       return;
     }
 
@@ -191,7 +224,6 @@
 
     approving = true;
     error = "";
-
     try {
       const commitResult = await approveMutationProposal({
         proposal_id: activeProposal.proposal_id,
@@ -199,11 +231,33 @@
       });
       lastCommitResult = commitResult;
       activeProposal = commitResult.active_proposal;
-      syncSelection(activeProposal);
-
+      syncMutationSelection(activeProposal);
       if (commitResult.result?.status === "applied") {
         dispatch("graphChanged");
       }
+    } catch (approveError) {
+      error = approveError.message;
+    } finally {
+      approving = false;
+    }
+  }
+
+  async function approveSelectedMemoryEdits() {
+    if (!activeMemoryChange || selectedMemoryEditIds.length === 0 || approving) {
+      return;
+    }
+
+    approving = true;
+    error = "";
+    try {
+      const writeResult = await approveMemoryChange({
+        change_id: activeMemoryChange.change_id,
+        approved_edit_ids: selectedMemoryEditIds,
+      });
+      lastMemoryWriteResult = writeResult;
+      activeMemoryChange = writeResult.active_memory_change;
+      memoryDocument = writeResult.memory ?? memoryDocument;
+      syncMemorySelection(activeMemoryChange);
     } catch (approveError) {
       error = approveError.message;
     } finally {
@@ -216,9 +270,7 @@
       return;
     }
 
-    await sendPlannerMessage(
-      `Reject proposal ${activeProposal.proposal_id}. Do not restage the same mutations unchanged. Briefly explain why it was rejected and propose a better alternative if appropriate.`,
-    );
+    await sendPlannerMessage(`Reject proposal ${activeProposal.proposal_id}. Do not restage the same mutations unchanged. Briefly explain why it was rejected and propose a better alternative if appropriate.`);
   }
 
   async function reviseProposal() {
@@ -241,15 +293,44 @@
     }
   }
 
+  async function rejectMemoryChange() {
+    if (!activeMemoryChange) {
+      return;
+    }
+
+    await sendPlannerMessage(`Reject planning memory change ${activeMemoryChange.change_id}. Keep planning memory compact and curated, explain what was wrong, and propose a better targeted edit if appropriate.`);
+  }
+
+  async function reviseMemoryChange() {
+    if (!activeMemoryChange) {
+      return;
+    }
+
+    const revisionNote = draft.trim() || window.prompt("How should the planner revise this memory change?", "");
+    if (!revisionNote?.trim()) {
+      return;
+    }
+
+    const sent = await sendPlannerMessage(
+      `Revise planning memory change ${activeMemoryChange.change_id}. Keep the same durable memory goal, but adjust it as follows: ${revisionNote.trim()}`,
+      { clearDraft: draft.trim() === revisionNote.trim() },
+    );
+
+    if (sent && draft.trim() === revisionNote.trim()) {
+      draft = "";
+    }
+  }
+
   function toggleMutationSelection(mutationId, checked) {
-    selectedMutationIds = checked
-      ? [...selectedMutationIds, mutationId]
-      : selectedMutationIds.filter((id) => id !== mutationId);
+    selectedMutationIds = checked ? [...selectedMutationIds, mutationId] : selectedMutationIds.filter((id) => id !== mutationId);
+  }
+
+  function toggleMemorySelection(editId, checked) {
+    selectedMemoryEditIds = checked ? [...selectedMemoryEditIds, editId] : selectedMemoryEditIds.filter((id) => id !== editId);
   }
 
   onMount(() => {
     loadSnapshot();
-
     stream = connectPlannerStream({
       onOpen: () => {
         connected = true;
@@ -272,9 +353,7 @@
     </div>
     <div class="planner-status">
       <span class:healthy={connected} class="status-pill">{connected ? "stream connected" : "stream reconnecting"}</span>
-      {#if sessionId}
-        <code>{sessionId}</code>
-      {/if}
+      {#if sessionId}<code>{sessionId}</code>{/if}
     </div>
   </div>
 
@@ -282,9 +361,7 @@
     <label>
       Graph mode
       <select bind:value={graphMode}>
-        {#each graphModes as mode}
-          <option value={mode}>{mode}</option>
-        {/each}
+        {#each graphModes as mode}<option value={mode}>{mode}</option>{/each}
       </select>
     </label>
     <label>
@@ -297,9 +374,7 @@
     </label>
   </div>
 
-  {#if error}
-    <div class="banner error inline-banner">{error}</div>
-  {/if}
+  {#if error}<div class="banner error inline-banner">{error}</div>{/if}
 
   {#if lastCommitResult}
     <div class="banner {lastCommitResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
@@ -308,7 +383,19 @@
       {:else if lastCommitResult.result.status === 'stale'}
         Proposal {lastCommitResult.proposal_id} is stale. Current graph version: {lastCommitResult.result.current_graph_version}.
       {:else}
-        Commit failed for proposal {lastCommitResult.proposal_id}: {lastCommitResult.result.errors.map((error) => error.message).join('; ')}
+        Commit failed for proposal {lastCommitResult.proposal_id}: {lastCommitResult.result.errors.map((item) => item.message).join('; ')}
+      {/if}
+    </div>
+  {/if}
+
+  {#if lastMemoryWriteResult}
+    <div class="banner {lastMemoryWriteResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+      {#if lastMemoryWriteResult.result.status === 'applied'}
+        Applied {lastMemoryWriteResult.approved_edit_ids.length} planning memory edit(s). Memory hash {lastMemoryWriteResult.result.previous_content_hash.slice(0, 8)} → {lastMemoryWriteResult.result.new_content_hash.slice(0, 8)}.
+      {:else if lastMemoryWriteResult.result.status === 'stale'}
+        Memory change {lastMemoryWriteResult.change_id} is stale. Current memory hash: {lastMemoryWriteResult.result.current_content_hash.slice(0, 8)}.
+      {:else}
+        Memory write failed: {lastMemoryWriteResult.result.errors.map((item) => item.message).join('; ')}
       {/if}
     </div>
   {/if}
@@ -323,10 +410,10 @@
         {#each messages as message}
           <article class="chat-entry {message.role}">
             <div class="chat-entry-meta">
-              <strong>{message.role === "user" ? "You" : message.role === "assistant" ? "Planner" : message.tool_name || "Tool"}</strong>
+              <strong>{message.role === 'user' ? 'You' : message.role === 'assistant' ? 'Planner' : message.tool_name || 'Tool'}</strong>
               <span>{new Date(message.timestamp).toLocaleTimeString()}</span>
             </div>
-            <pre>{message.content || (message.role === "assistant" && isStreaming ? "…" : "")}</pre>
+            <pre>{message.content || (message.role === 'assistant' && isStreaming ? '…' : '')}</pre>
           </article>
         {/each}
       {/if}
@@ -337,7 +424,6 @@
         <h3>Tool activity</h3>
         <p class="muted">Live SDK-native tool execution events.</p>
       </div>
-
       {#if toolEvents.length === 0}
         <p class="muted">Tool activity will appear here during planner turns.</p>
       {:else}
@@ -349,9 +435,7 @@
                 <span>{new Date(toolEvent.timestamp).toLocaleTimeString()}</span>
               </div>
               <p>{toolEvent.status}</p>
-              {#if toolEvent.content}
-                <pre>{toolEvent.content}</pre>
-              {/if}
+              {#if toolEvent.content}<pre>{toolEvent.content}</pre>{/if}
             </li>
           {/each}
         </ul>
@@ -363,52 +447,97 @@
     <div class="proposal-header">
       <div>
         <h3>Active mutation proposal</h3>
-        <p class="muted">Latest structured proposal emitted by the planner.</p>
+        <p class="muted">Latest structured graph proposal emitted by the planner.</p>
       </div>
-      {#if activeProposal?.context?.based_on_graph_version}
-        <span class="status-pill healthy">graph v{activeProposal.context.based_on_graph_version}</span>
-      {/if}
+      {#if activeProposal?.context?.based_on_graph_version}<span class="status-pill healthy">graph v{activeProposal.context.based_on_graph_version}</span>{/if}
     </div>
 
     {#if !activeProposal}
-      <p class="muted">No active proposal yet. Ask the planner to propose graph mutations.</p>
+      <p class="muted">No active graph proposal yet.</p>
     {:else}
       <div class="proposal-summary">
         <strong>{activeProposal.proposal_id}</strong>
         <p>{activeProposal.summary}</p>
       </div>
-
       <div class="proposal-list">
         {#each activeProposal.mutations as mutation}
           <label class="proposal-card">
             <div class="proposal-card-header">
-              <input
-                type="checkbox"
-                checked={selectedMutationIds.includes(mutation.id)}
-                on:change={(event) => toggleMutationSelection(mutation.id, event.currentTarget.checked)}
-              />
+              <input type="checkbox" checked={selectedMutationIds.includes(mutation.id)} on:change={(event) => toggleMutationSelection(mutation.id, event.currentTarget.checked)} />
               <div>
                 <strong>{mutation.id}</strong>
                 <span class="proposal-type">{mutation.type}</span>
-                {#if mutation.entity_id}
-                  <code>{mutation.entity_id}</code>
-                {/if}
+                {#if mutation.entity_id}<code>{mutation.entity_id}</code>{/if}
               </div>
             </div>
             <p>{mutation.rationale}</p>
-            {#if mutation.payload}
-              <pre>{JSON.stringify(mutation.payload, null, 2)}</pre>
+            {#if mutation.payload}<pre>{JSON.stringify(mutation.payload, null, 2)}</pre>{/if}
+          </label>
+        {/each}
+      </div>
+      <div class="planner-actions proposal-actions">
+        <button on:click={approveSelectedMutations} disabled={approving || selectedMutationIds.length === 0}>{approving ? 'Applying...' : `Approve ${selectedMutationIds.length} selected`}</button>
+        <button class="secondary" on:click={rejectProposal} disabled={sending}>Reject via follow-up</button>
+        <button class="secondary" on:click={reviseProposal} disabled={sending}>Revise via follow-up</button>
+      </div>
+    {/if}
+  </section>
+
+  <section class="proposal-panel memory-panel">
+    <div class="proposal-header">
+      <div>
+        <h3>Planning memory</h3>
+        <p class="muted">Curated durable memory from <code>PLANNING_MEMORY.md</code>.</p>
+      </div>
+      {#if memoryDocument}<span class="status-pill">{memoryDocument.content_hash.slice(0, 8)}</span>{/if}
+    </div>
+
+    {#if memoryDocument}
+      <details class="memory-preview">
+        <summary>Current planning memory</summary>
+        <pre>{memoryDocument.content}</pre>
+      </details>
+    {/if}
+
+    {#if !activeMemoryChange}
+      <p class="muted">No staged planning memory change yet.</p>
+    {:else}
+      <div class="proposal-summary">
+        <strong>{activeMemoryChange.change_id}</strong>
+        <p>{activeMemoryChange.summary}</p>
+      </div>
+      <div class="proposal-list">
+        {#each activeMemoryChange.edits as edit}
+          <label class="proposal-card memory-edit-card">
+            <div class="proposal-card-header">
+              <input type="checkbox" checked={selectedMemoryEditIds.includes(edit.id)} on:change={(event) => toggleMemorySelection(edit.id, event.currentTarget.checked)} />
+              <div>
+                <strong>{edit.id}</strong>
+                <span class="proposal-type">{edit.kind}</span>
+                {#if edit.target_heading}<code>{edit.target_heading}</code>{/if}
+              </div>
+            </div>
+            <strong>{edit.summary}</strong>
+            <p>{edit.rationale}</p>
+            {#if edit.old_text}
+              <div>
+                <div class="muted">Old text</div>
+                <pre>{edit.old_text}</pre>
+              </div>
+            {/if}
+            {#if edit.new_text}
+              <div>
+                <div class="muted">New text</div>
+                <pre>{edit.new_text}</pre>
+              </div>
             {/if}
           </label>
         {/each}
       </div>
-
       <div class="planner-actions proposal-actions">
-        <button on:click={approveSelectedMutations} disabled={approving || selectedMutationIds.length === 0}>
-          {approving ? "Applying..." : `Approve ${selectedMutationIds.length} selected`}
-        </button>
-        <button class="secondary" on:click={rejectProposal} disabled={sending}>Reject via follow-up</button>
-        <button class="secondary" on:click={reviseProposal} disabled={sending}>Revise via follow-up</button>
+        <button on:click={approveSelectedMemoryEdits} disabled={approving || selectedMemoryEditIds.length === 0}>{approving ? 'Applying...' : `Approve ${selectedMemoryEditIds.length} memory edit(s)`}</button>
+        <button class="secondary" on:click={rejectMemoryChange} disabled={sending}>Reject via follow-up</button>
+        <button class="secondary" on:click={reviseMemoryChange} disabled={sending}>Revise via follow-up</button>
       </div>
     {/if}
   </section>
@@ -416,11 +545,11 @@
   <div class="planner-composer">
     <label>
       Message
-      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, explain blockers, or propose next work."></textarea>
+      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, propose memory updates, or explain blockers."></textarea>
     </label>
     <div class="planner-actions">
       <button class="secondary" on:click={loadSnapshot} disabled={loading}>Refresh transcript</button>
-      <button on:click={submitMessage} disabled={sending || !draft.trim()}>{sending ? "Sending..." : isStreaming ? "Queue follow-up" : "Send to planner"}</button>
+      <button on:click={submitMessage} disabled={sending || !draft.trim()}>{sending ? 'Sending...' : isStreaming ? 'Queue follow-up' : 'Send to planner'}</button>
     </div>
   </div>
 </section>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -41,6 +41,14 @@ export function approveMutationProposal(payload) {
   });
 }
 
+export function approveMemoryChange(payload) {
+  return request("/api/agent/memory/approve", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {

--- a/web/src/lib/planner-chat.js
+++ b/web/src/lib/planner-chat.js
@@ -25,6 +25,8 @@ export function connectPlannerStream({ onEvent, onOpen, onError } = {}) {
     "tool_execution_end",
     "mutation_proposal",
     "graph_commit_result",
+    "memory_change_proposal",
+    "memory_write_result",
   ].forEach(forward);
 
   stream.onopen = () => onOpen?.();


### PR DESCRIPTION
## Summary
Add the first approval-gated planning memory workflow so the root planner can read durable memory, stage targeted edits for review, and apply approved changes from the browser.

Closes #8

## Changes
- add `MemoryService` to read, hash, validate, and apply targeted edits to `PLANNING_MEMORY.md`
- add `memory_read` and `memory_write` custom planner tools
- stage memory edits for browser approval instead of mutating the file directly
- add `POST /api/agent/memory/approve`
- include current memory content/hash, active memory change, and last write result in `GET /api/agent/session`
- emit `memory_change_proposal` and `memory_write_result` SSE events
- render staged memory edits, approval controls, and current memory preview in the browser planner workspace
- route planning context memory reads through the shared memory service
- update `PLANNING_MEMORY.md` with approved durable conventions
- update `README.md` with planning memory verification steps

## Testing
- `npm run build`
- manual `memory_read` verification through the root planner
- manual `memory_write` staging verification and browser/session snapshot checks
- manual `POST /api/agent/memory/approve` approval flow verification
- manual stale memory write rejection verification after touching `PLANNING_MEMORY.md`
- manual restaging verification after stale rejection
- manual Vite proxy verification for planner session reads

## Notes
- keeps planning memory approval-gated and targeted per ADR 010 instead of treating memory as append-only transcript residue
- keeps reject/revise lightweight in V1 through follow-up planner messages, matching the existing mutation proposal UX
