### PR TITLE
feat: add specialist sub-agent framework (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ By default, the server stores the dedicated root planner session under `.studio/
 PLANNING_SESSION_DIR=/path/to/planning-sessions npm run start
 ```
 
+### Configure run artifact storage
+
+By default, specialist/execution run artifacts are written under the external context root `/home/marc/escapement-studio-ctx/runs/`. Override with:
+
+```bash
+ARTIFACT_ROOT=/path/to/context-root npm run start
+```
+
 ### Build checks
 
 ```bash
@@ -83,14 +91,16 @@ This runs the server TypeScript check plus the production frontend build.
 11. Confirm the graph refreshes and the D3 view reflects the approved changes.
 12. Ask the planner to propose a planning memory update and confirm a staged memory change appears in the browser.
 13. Approve the staged memory change and confirm `PLANNING_MEMORY.md` updates only after approval.
-14. Ask the planner to revise or reject the current graph or memory proposal from the browser and confirm the follow-up stays in the same planner conversation.
-15. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/commit results are restored.
-16. Verify the graph view still loads data from `/api/graph`.
-17. Select a node to edit it in the sidebar.
-18. Create a new work item in the sidebar and confirm it appears in the graph.
-19. Create an edge between two nodes and confirm it appears in the graph and edge list.
-20. Delete an edge from the sidebar.
-21. Change repo/state/track/phase filters and confirm the rendered graph updates.
+14. Ask the planner to delegate a `code-crawler` or `scope-predictor` specialist and confirm a visible specialist run appears in the browser.
+15. Confirm the specialist run finishes with a structured summary/findings payload and an artifact directory under `/home/marc/escapement-studio-ctx/runs/`.
+16. Ask the planner to revise or reject the current graph or memory proposal from the browser and confirm the follow-up stays in the same planner conversation.
+17. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/commit results and recent specialist runs are restored.
+18. Verify the graph view still loads data from `/api/graph`.
+19. Select a node to edit it in the sidebar.
+20. Create a new work item in the sidebar and confirm it appears in the graph.
+21. Create an edge between two nodes and confirm it appears in the graph and edge list.
+22. Delete an edge from the sidebar.
+23. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -199,7 +209,7 @@ The server validates the full batch, applies it transactionally, and returns eit
 curl http://localhost:3000/api/agent/session
 ```
 
-The snapshot returns the recent planner transcript used by the browser to restore chat state after refresh.
+The snapshot returns the recent planner transcript plus active proposal/memory state and recent specialist runs used by the browser to restore workspace state after refresh.
 
 ### Root planner message + stream
 
@@ -241,7 +251,36 @@ The assembled planner context includes:
 - a small recent conversation window
 
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
-It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, and `memory_write_result`.
+It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, `memory_write_result`, `subagent_status`, and `subagent_result`.
+
+### Delegate a specialist sub-agent
+
+Ask the planner to run a specialist, or directly ask it to call `delegate_subagent`:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/message \
+  -H 'content-type: application/json' \
+  -d '{
+    "message":"Use delegate_subagent with agent_type `code-crawler` to inspect likely files for the planning service browser workflow"
+  }'
+```
+
+Then inspect recent specialist runs in the session snapshot:
+
+```bash
+curl http://localhost:3000/api/agent/session
+```
+
+Each completed run should also persist artifacts under:
+
+```text
+/home/marc/escapement-studio-ctx/runs/<run_id>/
+  metadata.json
+  status.json
+  events.jsonl
+  summary.md
+  outputs/
+```
 
 ### Stage and approve a planning memory change
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ export interface AppConfig {
   port: number;
   manifestPath: string;
   planningSessionDir: string;
+  artifactRoot: string;
 }
 
 export function getConfig(): AppConfig {
@@ -9,5 +10,6 @@ export function getConfig(): AppConfig {
     port: Number(process.env.PORT ?? 3000),
     manifestPath: process.env.MANIFEST_PATH ?? ".manifest",
     planningSessionDir: process.env.PLANNING_SESSION_DIR ?? ".studio/planning/sessions",
+    artifactRoot: process.env.ARTIFACT_ROOT ?? "/home/marc/escapement-studio-ctx",
   };
 }

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -4,11 +4,12 @@ import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { PlanningController } from "./planning.controller.js";
 import { PlanningService } from "./planning.service.js";
+import { SubAgentService } from "./sub-agent.service.js";
 
 @Module({
   imports: [GraphModule],
   controllers: [PlanningController],
-  providers: [PlanningService, ContextService, MemoryService],
-  exports: [PlanningService, ContextService, MemoryService],
+  providers: [PlanningService, ContextService, MemoryService, SubAgentService],
+  exports: [PlanningService, ContextService, MemoryService, SubAgentService],
 })
 export class PlanningModule {}

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -18,11 +18,13 @@ import type {
 } from "../graph/types.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
+import { SubAgentService } from "./sub-agent.service.js";
 import type {
   ApproveMutationProposalDto,
   ApprovePlanningMemoryChangeDto,
   CreateEdgePayload,
   CreateWorkItemPayload,
+  DelegateSubAgentToolInput,
   GraphQueryToolInput,
   PlanningGraphCommitResult,
   PlanningMemoryChange,
@@ -65,6 +67,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     @Inject(GraphService) private readonly graphService: GraphService,
     @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
     @Inject(MemoryService) private readonly memoryService: MemoryService,
+    @Inject(SubAgentService) private readonly subAgentService: SubAgentService,
   ) {}
 
   async onModuleInit() {
@@ -99,6 +102,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       active_memory_change: this.getActiveMemoryChange(),
       last_memory_write_result: this.lastMemoryWriteResult,
       memory: this.memoryService.read(),
+      recent_subagent_runs: this.subAgentService.listRecentRuns(),
     };
   }
 
@@ -244,6 +248,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         this.createGraphMutateTool(),
         this.createMemoryReadTool(),
         this.createMemoryWriteTool(),
+        this.createDelegateSubAgentTool(),
       ],
     });
 
@@ -474,6 +479,39 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         return {
           content: [{ type: "text", text: `Staged planning memory change ${change.change_id} with ${change.edits.length} edit(s).` }],
           details: { change },
+        };
+      },
+    });
+  }
+
+  private createDelegateSubAgentTool() {
+    return defineTool({
+      name: "delegate_subagent",
+      label: "Delegate Sub-agent",
+      description: "Launch a bounded specialist run for repo research and return a structured result.",
+      promptSnippet: "delegate_subagent: delegate bounded code research to a structured specialist when the planner needs grounded repo evidence.",
+      promptGuidelines: [
+        "Use delegate_subagent when you need grounded repository evidence beyond quick direct reasoning.",
+        "Pick code-crawler for concrete implementation tracing and scope-predictor for bounded impact prediction.",
+        "Keep the delegated task narrow and include focus paths or work item ids when useful.",
+      ],
+      parameters: Type.Object({
+        agent_type: Type.Union([Type.Literal("code-crawler"), Type.Literal("scope-predictor")]),
+        task: Type.String(),
+        repo: Type.Optional(Type.String()),
+        focus_paths: Type.Optional(Type.Array(Type.String())),
+        work_item_ids: Type.Optional(Type.Array(Type.String())),
+        notes: Type.Optional(Type.String()),
+      }),
+      execute: async (_toolCallId, params: DelegateSubAgentToolInput) => {
+        const run = await this.subAgentService.runDelegation(params, {
+          onStatus: (nextRun) => this.emitStudioEvent("subagent_status", { run: nextRun }),
+          onResult: (nextRun) => this.emitStudioEvent("subagent_result", { run: nextRun }),
+        });
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(run.result ?? run, null, 2) }],
+          details: { run },
         };
       },
     });

--- a/src/modules/planning/sub-agent.service.ts
+++ b/src/modules/planning/sub-agent.service.ts
@@ -1,0 +1,385 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import {
+  createAgentSession,
+  createBashTool,
+  createGrepTool,
+  createReadTool,
+  SessionManager,
+  type AgentSessionEvent,
+} from "@mariozechner/pi-coding-agent";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import type {
+  DelegateSubAgentToolInput,
+  SubAgentResultEnvelope,
+  SubAgentRunRecord,
+  SubAgentRunStatus,
+  SubAgentType,
+} from "./types.js";
+
+interface RunHooks {
+  onStatus?: (run: SubAgentRunRecord) => void;
+  onResult?: (run: SubAgentRunRecord) => void;
+}
+
+@Injectable()
+export class SubAgentService {
+  private readonly logger = new Logger(SubAgentService.name);
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+  private readonly recentRuns: SubAgentRunRecord[] = [];
+  private readonly recentRunLimit = 12;
+
+  listRecentRuns(): SubAgentRunRecord[] {
+    return [...this.recentRuns].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  }
+
+  async runDelegation(input: DelegateSubAgentToolInput, hooks: RunHooks = {}): Promise<SubAgentRunRecord> {
+    const runId = `sub_${Date.now()}`;
+    const createdAt = this.now();
+    const artifactDir = join(this.artifactRoot, "runs", runId);
+    mkdirSync(artifactDir, { recursive: true });
+
+    let run: SubAgentRunRecord = {
+      run_id: runId,
+      agent_type: input.agent_type,
+      task: input.task.trim(),
+      status: "queued",
+      created_at: createdAt,
+      updated_at: createdAt,
+      repo: input.repo?.trim() || undefined,
+      focus_paths: input.focus_paths?.filter(Boolean),
+      work_item_ids: input.work_item_ids?.filter(Boolean),
+      notes: input.notes?.trim() || undefined,
+      artifact_dir: artifactDir,
+      progress_message: "Queued specialist run.",
+    };
+
+    this.upsertRecentRun(run);
+    this.writeMetadata(run);
+    this.writeStatus(run);
+    this.appendEvent(run, { type: "run_created", task: run.task });
+    hooks.onStatus?.(run);
+
+    try {
+      const { session, modelFallbackMessage } = await createAgentSession({
+        cwd: process.cwd(),
+        sessionManager: SessionManager.inMemory(process.cwd()),
+        tools: [
+          createReadTool(process.cwd()),
+          createBashTool(process.cwd()),
+          createGrepTool(process.cwd()),
+        ],
+      });
+
+      if (modelFallbackMessage) {
+        this.logger.warn(modelFallbackMessage);
+      }
+
+      run = this.updateRun(run, {
+        status: "running",
+        started_at: this.now(),
+        session_id: session.sessionId,
+        progress_message: "Sub-agent session started.",
+      });
+      hooks.onStatus?.(run);
+      this.appendEvent(run, { type: "session_started", session_id: session.sessionId });
+
+      const unsubscribe = session.subscribe((event) => {
+        this.handleSessionEvent(run, event, hooks.onStatus);
+      });
+
+      try {
+        await session.prompt(this.buildPrompt(run));
+      } finally {
+        unsubscribe();
+        session.dispose();
+      }
+
+      const assistantText = session.getLastAssistantText()?.trim() ?? "";
+      writeFileSync(join(artifactDir, "outputs", "response.json"), this.ensureJsonText(assistantText), "utf8");
+
+      const result = this.parseResult(run, assistantText);
+      run = this.updateRun(run, {
+        status: result.status === "completed" ? "completed" : "error",
+        completed_at: this.now(),
+        progress_message: result.status === "completed" ? "Sub-agent completed." : "Sub-agent returned an error result.",
+        result,
+      });
+
+      this.writeSummary(run);
+      this.appendEvent(run, { type: "run_completed", result });
+      hooks.onStatus?.(run);
+      hooks.onResult?.(run);
+      return run;
+    } catch (error) {
+      const result: SubAgentResultEnvelope = {
+        run_id: run.run_id,
+        agent_type: run.agent_type,
+        status: "error",
+        summary: `Sub-agent failed before producing a valid result: ${this.getErrorMessage(error)}`,
+        confidence: "low",
+        findings: [],
+        errors: [{ code: "subagent_failed", message: this.getErrorMessage(error) }],
+      };
+
+      run = this.updateRun(run, {
+        status: "error",
+        completed_at: this.now(),
+        progress_message: "Sub-agent failed.",
+        result,
+      });
+      this.writeSummary(run);
+      this.appendEvent(run, { type: "run_failed", error: this.getErrorMessage(error), result });
+      hooks.onStatus?.(run);
+      hooks.onResult?.(run);
+      return run;
+    }
+  }
+
+  private buildPrompt(run: SubAgentRunRecord): string {
+    const role = this.getAgentRolePrompt(run.agent_type);
+    const focusPaths = run.focus_paths?.length ? run.focus_paths.map((path) => `- ${path}`).join("\n") : "- (none provided)";
+    const workItemIds = run.work_item_ids?.length ? run.work_item_ids.map((id) => `- ${id}`).join("\n") : "- (none provided)";
+
+    return [
+      `You are the ${run.agent_type} specialist for Escapement Studio.`,
+      role,
+      "",
+      "Boundaries:",
+      "- Stay focused on the requested task.",
+      "- Use repository inspection tools as needed, but keep evidence concise and bounded.",
+      "- Do not modify files.",
+      "- Return JSON only. No markdown fences, no commentary before or after the JSON.",
+      "",
+      "Return exactly this JSON envelope shape:",
+      JSON.stringify({
+        run_id: run.run_id,
+        agent_type: run.agent_type,
+        status: "completed",
+        summary: "Short result summary.",
+        confidence: "medium",
+        findings: [
+          {
+            kind: "file_impact",
+            file: "path/to/file.ts",
+            lines: "1-20",
+            summary: "Why this file matters.",
+            snippet: "short bounded snippet if useful",
+          },
+        ],
+        open_questions: [],
+        errors: [],
+      }, null, 2),
+      "",
+      "Task:",
+      run.task,
+      "",
+      `Repo: ${run.repo ?? "(not specified)"}`,
+      "",
+      "Focus paths:",
+      focusPaths,
+      "",
+      "Related work item IDs:",
+      workItemIds,
+      "",
+      `Additional notes: ${run.notes ?? "(none)"}`,
+    ].join("\n");
+  }
+
+  private getAgentRolePrompt(agentType: SubAgentType): string {
+    switch (agentType) {
+      case "code-crawler":
+        return [
+          "Your job is to inspect the codebase and report concrete implementation evidence.",
+          "Prioritize findings of kinds: file_impact, pattern_match, dependency, entrypoint, risk.",
+          "Trace imports, entrypoints, and nearby modules when relevant.",
+        ].join(" ");
+      case "scope-predictor":
+        return [
+          "Your job is to predict likely file/module impact for the requested change.",
+          "Prioritize findings of kinds: predicted_file, predicted_module, likely_dependency, uncertainty.",
+          "Focus on bounded predicted impact, not exhaustive dumps.",
+        ].join(" ");
+    }
+  }
+
+  private parseResult(run: SubAgentRunRecord, assistantText: string): SubAgentResultEnvelope {
+    const jsonText = this.ensureJsonText(assistantText);
+
+    try {
+      const parsed = JSON.parse(jsonText) as Record<string, unknown>;
+      const status = parsed.status === "error" ? "error" : "completed";
+      return {
+        run_id: run.run_id,
+        agent_type: run.agent_type,
+        status,
+        summary: typeof parsed.summary === "string" ? parsed.summary : "Sub-agent completed without a summary.",
+        confidence: parsed.confidence === "low" || parsed.confidence === "high" ? parsed.confidence : "medium",
+        findings: Array.isArray(parsed.findings)
+          ? parsed.findings.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object").map((item) => ({ ...item, kind: typeof item.kind === "string" ? item.kind : "finding" }))
+          : [],
+        open_questions: Array.isArray(parsed.open_questions)
+          ? parsed.open_questions.filter((item): item is string => typeof item === "string")
+          : [],
+        errors: Array.isArray(parsed.errors)
+          ? parsed.errors.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object").map((item) => ({
+              code: typeof item.code === "string" ? item.code : "subagent_error",
+              message: typeof item.message === "string" ? item.message : JSON.stringify(item),
+            }))
+          : [],
+      };
+    } catch (error) {
+      return {
+        run_id: run.run_id,
+        agent_type: run.agent_type,
+        status: "error",
+        summary: "Sub-agent returned a non-JSON response.",
+        confidence: "low",
+        findings: [],
+        errors: [{ code: "invalid_json", message: this.getErrorMessage(error) }],
+      };
+    }
+  }
+
+  private handleSessionEvent(run: SubAgentRunRecord, event: AgentSessionEvent, onStatus?: (run: SubAgentRunRecord) => void) {
+    if (event.type === "tool_execution_start") {
+      const nextRun = this.updateRun(run, {
+        progress_message: `${event.toolName ?? "tool"} running…`,
+      });
+      this.appendEvent(nextRun, { type: event.type, tool_name: event.toolName ?? null });
+      onStatus?.(nextRun);
+      return;
+    }
+
+    if (event.type === "tool_execution_end") {
+      const nextRun = this.updateRun(run, {
+        progress_message: `${event.toolName ?? "tool"} finished.`,
+      });
+      this.appendEvent(nextRun, { type: event.type, tool_name: event.toolName ?? null });
+      onStatus?.(nextRun);
+      return;
+    }
+
+    if (event.type === "message_end") {
+      this.appendEvent(run, { type: event.type });
+    }
+  }
+
+  private updateRun(run: SubAgentRunRecord, patch: Partial<SubAgentRunRecord>): SubAgentRunRecord {
+    const nextRun: SubAgentRunRecord = {
+      ...run,
+      ...patch,
+      updated_at: this.now(),
+    };
+    this.upsertRecentRun(nextRun);
+    this.writeStatus(nextRun);
+    return nextRun;
+  }
+
+  private upsertRecentRun(run: SubAgentRunRecord) {
+    const index = this.recentRuns.findIndex((candidate) => candidate.run_id === run.run_id);
+    if (index >= 0) {
+      this.recentRuns[index] = run;
+    } else {
+      this.recentRuns.unshift(run);
+    }
+    this.recentRuns.splice(this.recentRunLimit);
+  }
+
+  private writeMetadata(run: SubAgentRunRecord) {
+    mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
+    writeFileSync(join(run.artifact_dir, "metadata.json"), JSON.stringify({
+      run_id: run.run_id,
+      run_type: "subagent",
+      created_at: run.created_at,
+      agent_type: run.agent_type,
+      repo: run.repo ?? null,
+      work_item_ids: run.work_item_ids ?? [],
+      focus_paths: run.focus_paths ?? [],
+      task: run.task,
+      cwd: process.cwd(),
+    }, null, 2), "utf8");
+  }
+
+  private writeStatus(run: SubAgentRunRecord) {
+    writeFileSync(join(run.artifact_dir, "status.json"), JSON.stringify({
+      run_id: run.run_id,
+      status: run.status,
+      phase: this.getPhase(run.status),
+      started_at: run.started_at ?? null,
+      updated_at: run.updated_at,
+      completed_at: run.completed_at ?? null,
+      progress_message: run.progress_message ?? null,
+      result: run.result ?? null,
+    }, null, 2), "utf8");
+  }
+
+  private writeSummary(run: SubAgentRunRecord) {
+    const result = run.result;
+    if (!result) {
+      return;
+    }
+
+    const findings = result.findings.length === 0
+      ? "- None"
+      : result.findings.map((finding) => {
+          const location = typeof finding.file === "string" ? ` (${finding.file}${typeof finding.lines === "string" ? `:${finding.lines}` : ""})` : "";
+          return `- ${finding.kind}${location}: ${typeof finding.summary === "string" ? finding.summary : "(no summary)"}`;
+        }).join("\n");
+
+    writeFileSync(join(run.artifact_dir, "summary.md"), [
+      `# ${run.agent_type} run ${run.run_id}`,
+      "",
+      `- Status: ${run.status}`,
+      `- Confidence: ${result.confidence}`,
+      `- Task: ${run.task}`,
+      "",
+      "## Summary",
+      result.summary,
+      "",
+      "## Findings",
+      findings,
+      "",
+      "## Open Questions",
+      result.open_questions?.length ? result.open_questions.map((question) => `- ${question}`).join("\n") : "- None",
+      "",
+      "## Errors",
+      result.errors?.length ? result.errors.map((error) => `- ${error.code}: ${error.message}`).join("\n") : "- None",
+      "",
+    ].join("\n"), "utf8");
+  }
+
+  private appendEvent(run: SubAgentRunRecord, event: Record<string, unknown>) {
+    appendFileSync(join(run.artifact_dir, "events.jsonl"), `${JSON.stringify({ timestamp: this.now(), ...event })}\n`, "utf8");
+  }
+
+  private getPhase(status: SubAgentRunStatus): string {
+    switch (status) {
+      case "queued":
+        return "queued";
+      case "running":
+        return "analysis";
+      case "completed":
+        return "completed";
+      case "error":
+        return "failed";
+    }
+  }
+
+  private ensureJsonText(value: string): string {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("```") && trimmed.endsWith("```")) {
+      return trimmed.replace(/^```(?:json)?\s*/, "").replace(/```$/, "").trim();
+    }
+    return trimmed;
+  }
+
+  private now(): string {
+    return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -4,6 +4,9 @@ import type { ApplyGraphMutationsResult, EdgeRel, WorkItemKind, WorkItemState } 
 export type PlanningContextGraphMode = "default" | "focused" | "full";
 export type PlanningMutationType = "create_work_item" | "update_work_item" | "create_edge" | "delete_edge" | "delete_work_item";
 export type PlanningMemoryEditKind = "replace_text" | "insert_after_heading" | "delete_text";
+export type SubAgentType = "code-crawler" | "scope-predictor";
+export type SubAgentRunStatus = "queued" | "running" | "completed" | "error";
+export type SubAgentConfidence = "low" | "medium" | "high";
 
 export interface SendAgentMessageDto {
   message: string;
@@ -136,6 +139,59 @@ export interface PlanningMemoryWriteResult {
   memory: PlanningMemoryDocument;
 }
 
+export interface SubAgentFinding {
+  kind: string;
+  file?: string;
+  lines?: string;
+  summary?: string;
+  snippet?: string;
+  [key: string]: unknown;
+}
+
+export interface SubAgentError {
+  code: string;
+  message: string;
+}
+
+export interface SubAgentResultEnvelope {
+  run_id: string;
+  agent_type: SubAgentType;
+  status: "completed" | "error";
+  summary: string;
+  confidence: SubAgentConfidence;
+  findings: SubAgentFinding[];
+  open_questions?: string[];
+  errors?: SubAgentError[];
+}
+
+export interface DelegateSubAgentToolInput {
+  agent_type: SubAgentType;
+  task: string;
+  repo?: string;
+  focus_paths?: string[];
+  work_item_ids?: string[];
+  notes?: string;
+}
+
+export interface SubAgentRunRecord {
+  run_id: string;
+  agent_type: SubAgentType;
+  task: string;
+  status: SubAgentRunStatus;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+  session_id?: string;
+  repo?: string;
+  focus_paths?: string[];
+  work_item_ids?: string[];
+  notes?: string;
+  artifact_dir: string;
+  progress_message?: string;
+  result?: SubAgentResultEnvelope;
+}
+
 export interface PlanningSessionSnapshot {
   session_id: string;
   session_file?: string;
@@ -146,6 +202,7 @@ export interface PlanningSessionSnapshot {
   active_memory_change: PlanningMemoryChange | null;
   last_memory_write_result: PlanningMemoryWriteResult | null;
   memory: PlanningMemoryDocument;
+  recent_subagent_runs: SubAgentRunRecord[];
 }
 
 export interface StudioSseEnvelope {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -355,6 +355,29 @@ h2 {
   color: #f8fafc;
 }
 
+.subagent-panel {
+  border-top-style: dotted;
+}
+
+.subagent-card {
+  gap: 0.6rem;
+}
+
+.subagent-findings {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.subagent-findings li {
+  color: #cbd5e1;
+}
+
+.subagent-findings code {
+  margin-left: 0.35rem;
+}
+
 .inline-banner {
   width: 100%;
   margin: 0;

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -31,6 +31,7 @@
   let selectedMemoryEditIds = [];
   let lastMemoryWriteResult = null;
   let memoryDocument = null;
+  let recentSubagentRuns = [];
   let stream;
 
   function syncMutationSelection(proposal, preserve = false) {
@@ -60,6 +61,7 @@
     lastCommitResult = snapshot.last_commit_result ?? null;
     lastMemoryWriteResult = snapshot.last_memory_write_result ?? null;
     memoryDocument = snapshot.memory ?? null;
+    recentSubagentRuns = snapshot.recent_subagent_runs ?? [];
 
     const nextProposal = snapshot.active_proposal ?? null;
     const proposalChanged = nextProposal?.proposal_id !== activeProposal?.proposal_id;
@@ -127,6 +129,16 @@
       activeMemoryChange = event.payload?.active_memory_change ?? null;
       memoryDocument = event.payload?.memory ?? memoryDocument;
       syncMemorySelection(activeMemoryChange);
+      return;
+    }
+
+    if (event.event_type === "subagent_status" || event.event_type === "subagent_result") {
+      const nextRun = event.payload?.run;
+      if (!nextRun) {
+        return;
+      }
+
+      recentSubagentRuns = [nextRun, ...recentSubagentRuns.filter((run) => run.run_id !== nextRun.run_id)].slice(0, 12);
       return;
     }
 
@@ -542,10 +554,55 @@
     {/if}
   </section>
 
+  <section class="proposal-panel subagent-panel">
+    <div class="proposal-header">
+      <div>
+        <h3>Recent specialist runs</h3>
+        <p class="muted">Ephemeral code-crawler and scope-predictor runs delegated by the planner.</p>
+      </div>
+    </div>
+
+    {#if recentSubagentRuns.length === 0}
+      <p class="muted">No specialist runs yet.</p>
+    {:else}
+      <div class="proposal-list">
+        {#each recentSubagentRuns as run}
+          <article class="proposal-card subagent-card">
+            <div class="proposal-card-header">
+              <div>
+                <strong>{run.agent_type}</strong>
+                <span class="proposal-type">{run.status}</span>
+                <code>{run.run_id}</code>
+              </div>
+            </div>
+            <p>{run.task}</p>
+            {#if run.progress_message}<p class="muted">{run.progress_message}</p>{/if}
+            {#if run.result}
+              <p><strong>{run.result.summary}</strong></p>
+              <p class="muted">Confidence: {run.result.confidence}</p>
+              {#if run.result.findings?.length}
+                <ul class="subagent-findings">
+                  {#each run.result.findings.slice(0, 4) as finding}
+                    <li>
+                      <strong>{finding.kind}</strong>
+                      {#if finding.file}<code>{finding.file}{finding.lines ? `:${finding.lines}` : ''}</code>{/if}
+                      <div>{finding.summary || '(no summary)'}</div>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+            {/if}
+            <p class="muted">Artifacts: <code>{run.artifact_dir}</code></p>
+          </article>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
   <div class="planner-composer">
     <label>
       Message
-      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, propose memory updates, or explain blockers."></textarea>
+      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, delegate specialists, propose memory updates, or explain blockers."></textarea>
     </label>
     <div class="planner-actions">
       <button class="secondary" on:click={loadSnapshot} disabled={loading}>Refresh transcript</button>

--- a/web/src/lib/planner-chat.js
+++ b/web/src/lib/planner-chat.js
@@ -27,6 +27,8 @@ export function connectPlannerStream({ onEvent, onOpen, onError } = {}) {
     "graph_commit_result",
     "memory_change_proposal",
     "memory_write_result",
+    "subagent_status",
+    "subagent_result",
   ].forEach(forward);
 
   stream.onopen = () => onOpen?.();


### PR DESCRIPTION
## Summary
Add the first specialist sub-agent workflow so the root planner can delegate bounded repo research, surface live specialist status in the browser, and persist run artifacts under the external context root.

Closes #9

## Changes
- add `SubAgentService` for ephemeral specialist sessions and ADR 013 artifact persistence
- add `delegate_subagent` custom tool to the root planner
- add bounded `code-crawler` and `scope-predictor` specialist flows with structured JSON result normalization
- include recent specialist runs in `GET /api/agent/session`
- emit `subagent_status` and `subagent_result` SSE events
- render recent specialist runs in the browser planner workspace
- add configurable external artifact root support via `ARTIFACT_ROOT`
- update `README.md` with specialist delegation and artifact verification steps

## Testing
- `npm run build`
- manual `code-crawler` delegation through the root planner
- manual `scope-predictor` delegation through the root planner
- manual SSE/session snapshot verification for recent specialist runs
- manual Vite proxy verification for planner session reads
- manual artifact inspection under `/home/marc/escapement-studio-ctx/runs/<run_id>/`

## Notes
- specialist runs currently use ephemeral read-only pi sessions with `read`, `grep`, and `bash`
- artifact persistence goes to the external context root, not the repo
- browser rendering stays lightweight in V1 and shows recent runs/status/results inline in the planner workspace
