### PR TITLE
feat: add approval-gated GitHub sync (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,18 @@ This runs the server TypeScript check plus the production frontend build.
 13. Approve the staged memory change and confirm `PLANNING_MEMORY.md` updates only after approval.
 14. Ask the planner to delegate a `code-crawler` or `scope-predictor` specialist and confirm a visible specialist run appears in the browser.
 15. Confirm the specialist run finishes with a structured summary/findings payload and an artifact directory under `/home/marc/escapement-studio-ctx/runs/`.
-16. Ask the planner to revise or reject the current graph or memory proposal from the browser and confirm the follow-up stays in the same planner conversation.
-17. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/commit results and recent specialist runs are restored.
-18. Verify the graph view still loads data from `/api/graph`.
-19. Select a node to edit it in the sidebar.
-20. Create a new work item in the sidebar and confirm it appears in the graph.
-21. Create an edge between two nodes and confirm it appears in the graph and edge list.
-22. Delete an edge from the sidebar.
-23. Change repo/state/track/phase filters and confirm the rendered graph updates.
+16. Select an issue-backed work item and confirm the sidebar loads GitHub issue details plus the issue link.
+17. Ask the planner to use `github_read` and confirm issue details appear in the transcript/tool output.
+18. Ask the planner to stage a `github_sync` proposal and confirm a reviewable GitHub sync card appears in the browser.
+19. Approve the staged GitHub sync and confirm only the managed `studio-sync` issue body block changes.
+20. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
+21. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results and recent specialist runs are restored.
+22. Verify the graph view still loads data from `/api/graph`.
+23. Select a node to edit it in the sidebar.
+24. Create a new work item in the sidebar and confirm it appears in the graph.
+25. Create an edge between two nodes and confirm it appears in the graph and edge list.
+26. Delete an edge from the sidebar.
+27. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -209,7 +213,7 @@ The server validates the full batch, applies it transactionally, and returns eit
 curl http://localhost:3000/api/agent/session
 ```
 
-The snapshot returns the recent planner transcript plus active proposal/memory state and recent specialist runs used by the browser to restore workspace state after refresh.
+The snapshot returns the recent planner transcript plus active proposal/memory/GitHub-sync state and recent specialist runs used by the browser to restore workspace state after refresh.
 
 ### Root planner message + stream
 
@@ -251,7 +255,15 @@ The assembled planner context includes:
 - a small recent conversation window
 
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
-It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, `memory_write_result`, `subagent_status`, and `subagent_result`.
+It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, `memory_write_result`, `github_sync_proposal`, `github_sync_result`, `subagent_status`, and `subagent_result`.
+
+### Read a GitHub issue linked to a work item
+
+```bash
+curl "http://localhost:3000/api/github/issue?repo=fusupo/escapement-studio&issue_number=10"
+```
+
+This returns issue details plus the current managed `studio-sync` block, if present.
 
 ### Delegate a specialist sub-agent
 
@@ -281,6 +293,45 @@ Each completed run should also persist artifacts under:
   summary.md
   outputs/
 ```
+
+### Stage and approve a GitHub sync
+
+First ensure the target issue body already contains a managed block bounded by:
+
+```md
+<!-- studio-sync:start -->
+...
+<!-- studio-sync:end -->
+```
+
+Then ask the planner to stage a GitHub sync for an issue-backed work item:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/message \
+  -H 'content-type: application/json' \
+  -d '{
+    "message":"Use github_sync for work_item_id `studio-10` and stage a managed-block sync proposal"
+  }'
+```
+
+Inspect the staged GitHub sync proposal in the planner session snapshot:
+
+```bash
+curl http://localhost:3000/api/agent/session
+```
+
+Approve selected GitHub sync operations:
+
+```bash
+curl -X POST http://localhost:3000/api/agent/github/approve \
+  -H 'content-type: application/json' \
+  -d '{
+    "sync_id": "ghsync_123",
+    "approved_operation_ids": ["op1"]
+  }'
+```
+
+The result returns `applied`, `validation_failed`, or `stale`. If the issue body changed since staging, the sync is rejected as stale. If the managed block is missing or ambiguous, sync fails safely.
 
 ### Stage and approve a planning memory change
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
+import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { PlanningModule } from "./modules/planning/planning.module.js";
 
 @Module({
-  imports: [GraphModule, HealthModule, PlanningModule],
+  imports: [GraphModule, HealthModule, GitHubModule, PlanningModule],
 })
 export class AppModule {}

--- a/src/modules/github/github.controller.ts
+++ b/src/modules/github/github.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Inject, Query } from "@nestjs/common";
+import { GitHubService } from "./github.service.js";
+
+@Controller("api/github")
+export class GitHubController {
+  constructor(@Inject(GitHubService) private readonly githubService: GitHubService) {}
+
+  @Get("issue")
+  getIssue(
+    @Query("repo") repo?: string,
+    @Query("issue_number") issueNumber?: string,
+  ) {
+    return this.githubService.readIssue(repo ?? "", Number(issueNumber));
+  }
+}

--- a/src/modules/github/github.module.ts
+++ b/src/modules/github/github.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { GraphModule } from "../graph/graph.module.js";
+import { GitHubController } from "./github.controller.js";
+import { GitHubService } from "./github.service.js";
+
+@Module({
+  imports: [GraphModule],
+  controllers: [GitHubController],
+  providers: [GitHubService],
+  exports: [GitHubService],
+})
+export class GitHubModule {}

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -1,0 +1,311 @@
+import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { SQLiteService } from "../graph/sqlite.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type {
+  GitHubIssueDetails,
+  GitHubIssueAssignee,
+  GitHubIssueLabel,
+  GitHubSyncApplyResult,
+  GitHubSyncOperation,
+  GitHubSyncProposal,
+} from "../planning/types.js";
+
+const START_MARKER = "<!-- studio-sync:start -->";
+const END_MARKER = "<!-- studio-sync:end -->";
+
+interface RawIssueResponse {
+  number: number;
+  title: string;
+  body: string | null;
+  url: string;
+  state: string;
+  labels?: Array<{ name?: string; description?: string; color?: string }>;
+  assignees?: Array<{ login?: string; name?: string }>;
+}
+
+@Injectable()
+export class GitHubService {
+  constructor(
+    @Inject(SQLiteService) private readonly sqlite: SQLiteService,
+    @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
+  ) {}
+
+  private get db(): DatabaseType {
+    return this.sqlite.getDb();
+  }
+
+  async readIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new BadRequestException("issue_number must be a positive integer");
+    }
+
+    const raw = await this.runGhJson<RawIssueResponse>([
+      "issue",
+      "view",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--json",
+      "number,title,body,url,state,labels,assignees",
+    ]);
+
+    const body = raw.body ?? "";
+    const managedBlock = this.extractManagedBlock(body);
+
+    return {
+      repo,
+      number: raw.number,
+      title: raw.title,
+      body,
+      url: raw.url,
+      state: raw.state,
+      labels: (raw.labels ?? []).map((label): GitHubIssueLabel => ({
+        name: label.name ?? "",
+        description: label.description,
+        color: label.color,
+      })).filter((label) => Boolean(label.name)),
+      assignees: (raw.assignees ?? []).map((assignee): GitHubIssueAssignee => ({
+        login: assignee.login ?? "",
+        name: assignee.name,
+      })).filter((assignee) => Boolean(assignee.login)),
+      body_hash: this.hash(body),
+      managed_block: managedBlock,
+    };
+  }
+
+  async stageManagedBlockSync(workItemId: string) {
+    const workItem = this.workItems.get(workItemId);
+    if (!workItem.repo || !workItem.issue_number || !workItem.issue_url) {
+      throw new BadRequestException(`Work item ${workItemId} is not linked to a GitHub issue`);
+    }
+
+    const issue = await this.readIssue(workItem.repo, workItem.issue_number);
+    const replacement = this.replaceManagedBlock(issue.body, this.renderManagedBlock(workItemId));
+
+    if (!replacement.ok) {
+      throw new BadRequestException(replacement.message);
+    }
+
+    const operation: GitHubSyncOperation = {
+      id: "op1",
+      kind: "update_managed_body_block",
+      summary: `Update managed Studio planning block for issue #${issue.number}`,
+      rationale: `Sync planning metadata from Studio work item ${workItemId} into the machine-managed issue body block.`,
+      target: {
+        repo: workItem.repo,
+        issue_number: workItem.issue_number,
+        work_item_id: workItemId,
+      },
+      preview: {
+        before: replacement.currentBlock,
+        after: replacement.nextBlock,
+      },
+    };
+
+    return {
+      issue,
+      work_item_id: workItemId,
+      based_on_body_hash: issue.body_hash,
+      operations: [operation],
+    };
+  }
+
+  async applySyncProposal(proposal: GitHubSyncProposal, approvedOperationIds: string[]): Promise<{ result: GitHubSyncApplyResult; issue: GitHubIssueDetails | null }> {
+    const uniqueIds = Array.from(new Set(approvedOperationIds));
+    const operations = uniqueIds.map((id) => {
+      const operation = proposal.operations.find((candidate) => candidate.id === id);
+      if (!operation) {
+        throw new BadRequestException(`Unknown GitHub sync operation id: ${id}`);
+      }
+      return operation;
+    });
+
+    if (operations.length === 0) {
+      throw new BadRequestException("approved_operation_ids must contain at least one operation id");
+    }
+
+    const issue = await this.readIssue(proposal.issue.repo, proposal.issue.issue_number);
+    if (issue.body_hash !== proposal.based_on_body_hash) {
+      return {
+        result: {
+          status: "stale",
+          previous_body_hash: proposal.based_on_body_hash,
+          current_body_hash: issue.body_hash,
+          message: "GitHub issue body changed since this sync was staged and must be regenerated.",
+        },
+        issue,
+      };
+    }
+
+    const errors: Array<{ operation_id: string; message: string }> = [];
+    let nextBody = issue.body;
+
+    for (const operation of operations) {
+      if (operation.kind !== "update_managed_body_block") {
+        errors.push({ operation_id: operation.id, message: `Unsupported GitHub sync operation kind: ${operation.kind}` });
+        continue;
+      }
+
+      const replacement = this.replaceManagedBlock(nextBody, operation.preview.after);
+      if (!replacement.ok) {
+        errors.push({ operation_id: operation.id, message: replacement.message });
+        continue;
+      }
+      nextBody = replacement.body;
+    }
+
+    if (errors.length > 0) {
+      return {
+        result: {
+          status: "validation_failed",
+          errors,
+        },
+        issue,
+      };
+    }
+
+    await this.runGh([
+      "issue",
+      "edit",
+      String(proposal.issue.issue_number),
+      "--repo",
+      proposal.issue.repo,
+      "--body-file",
+      "-",
+    ], nextBody);
+
+    const updatedIssue = await this.readIssue(proposal.issue.repo, proposal.issue.issue_number);
+    return {
+      result: {
+        status: "applied",
+        applied_operation_ids: uniqueIds,
+        previous_body_hash: issue.body_hash,
+        new_body_hash: updatedIssue.body_hash,
+      },
+      issue: updatedIssue,
+    };
+  }
+
+  private renderManagedBlock(workItemId: string): string {
+    const workItem = this.workItems.get(workItemId);
+    const dependsOn = this.listRelatedIds(workItemId, "depends_on", "to_id");
+    const partOf = this.listRelatedIds(workItemId, "is_part_of", "to_id");
+    const predictedFiles = workItem.predicted_files ?? [];
+
+    const lines = [
+      START_MARKER,
+      "## Studio Planning Metadata",
+      `- State: ${workItem.state}`,
+    ];
+
+    if (workItem.scope_hint) {
+      lines.push(`- Scope hint: ${workItem.scope_hint}`);
+    }
+
+    lines.push("- Predicted files:");
+    if (predictedFiles.length === 0) {
+      lines.push("  - (none)");
+    } else {
+      for (const file of predictedFiles) {
+        lines.push(`  - \`${file}\``);
+      }
+    }
+
+    lines.push("- Depends on:");
+    if (dependsOn.length === 0) {
+      lines.push("  - (none)");
+    } else {
+      for (const id of dependsOn) {
+        lines.push(`  - ${id}`);
+      }
+    }
+
+    lines.push("- Part of:");
+    if (partOf.length === 0) {
+      lines.push("  - (none)");
+    } else {
+      for (const id of partOf) {
+        lines.push(`  - ${id}`);
+      }
+    }
+
+    lines.push(END_MARKER);
+    return lines.join("\n");
+  }
+
+  private listRelatedIds(workItemId: string, rel: string, column: "to_id" | "from_id"): string[] {
+    const rows = this.db
+      .prepare(`SELECT ${column} FROM edges WHERE ${column === "to_id" ? "from_id" : "to_id"} = ? AND rel = ? ORDER BY ${column}`)
+      .all(workItemId, rel) as Array<{ to_id?: string; from_id?: string }>;
+
+    return rows
+      .map((row) => row[column])
+      .filter((value): value is string => typeof value === "string");
+  }
+
+  private extractManagedBlock(body: string) {
+    const matches = [...body.matchAll(new RegExp(`${this.escapeRegExp(START_MARKER)}[\\s\\S]*?${this.escapeRegExp(END_MARKER)}`, "g"))];
+    if (matches.length === 0) {
+      return null;
+    }
+    if (matches.length > 1) {
+      throw new BadRequestException("GitHub issue body has multiple studio-sync blocks and cannot be updated safely");
+    }
+
+    return {
+      content: matches[0][0],
+      start_marker: START_MARKER,
+      end_marker: END_MARKER,
+    };
+  }
+
+  private replaceManagedBlock(body: string, nextBlock: string): { ok: true; body: string; currentBlock: string; nextBlock: string } | { ok: false; message: string } {
+    const matches = [...body.matchAll(new RegExp(`${this.escapeRegExp(START_MARKER)}[\\s\\S]*?${this.escapeRegExp(END_MARKER)}`, "g"))];
+    if (matches.length === 0) {
+      return { ok: false, message: "GitHub issue body is missing the managed studio-sync block and cannot be synced safely." };
+    }
+    if (matches.length > 1) {
+      return { ok: false, message: "GitHub issue body has multiple managed studio-sync blocks and cannot be synced safely." };
+    }
+
+    const currentBlock = matches[0][0];
+    return {
+      ok: true,
+      body: body.replace(currentBlock, nextBlock),
+      currentBlock,
+      nextBlock,
+    };
+  }
+
+  private async runGhJson<T>(args: string[]): Promise<T> {
+    const stdout = this.runGh(args);
+    return JSON.parse(stdout) as T;
+  }
+
+  private runGh(args: string[], stdin?: string): string {
+    try {
+      return execFileSync("gh", args, {
+        input: stdin,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 4,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BadRequestException(`gh command failed: ${message}`);
+    }
+  }
+
+  private hash(value: string): string {
+    return createHash("sha1").update(value).digest("hex");
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+}

--- a/src/modules/planning/planning.controller.ts
+++ b/src/modules/planning/planning.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Inject, MessageEvent, Post, Sse } from "@nestjs/
 import { Observable } from "rxjs";
 import { PlanningService } from "./planning.service.js";
 import type {
+  ApproveGitHubSyncDto,
   ApproveMutationProposalDto,
   ApprovePlanningMemoryChangeDto,
   SendAgentMessageDto,
@@ -29,6 +30,11 @@ export class PlanningController {
   @Post("memory/approve")
   approveMemoryChange(@Body() body: ApprovePlanningMemoryChangeDto) {
     return this.planningService.approveMemoryChange(body);
+  }
+
+  @Post("github/approve")
+  approveGitHubSync(@Body() body: ApproveGitHubSyncDto) {
+    return this.planningService.approveGitHubSync(body);
   }
 
   @Sse("stream")

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
@@ -7,7 +8,7 @@ import { PlanningService } from "./planning.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 
 @Module({
-  imports: [GraphModule],
+  imports: [GraphModule, GitHubModule],
   controllers: [PlanningController],
   providers: [PlanningService, ContextService, MemoryService, SubAgentService],
   exports: [PlanningService, ContextService, MemoryService, SubAgentService],

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -5,6 +5,7 @@ import { Observable, Subject } from "rxjs";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
+import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { GraphWriterService } from "../graph/graph-writer.service.js";
 import type {
@@ -20,11 +21,16 @@ import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 import type {
+  ApproveGitHubSyncDto,
   ApproveMutationProposalDto,
   ApprovePlanningMemoryChangeDto,
   CreateEdgePayload,
   CreateWorkItemPayload,
   DelegateSubAgentToolInput,
+  GitHubReadToolInput,
+  GitHubSyncProposal,
+  GitHubSyncResult,
+  GitHubSyncToolInput,
   GraphQueryToolInput,
   PlanningGraphCommitResult,
   PlanningMemoryChange,
@@ -50,6 +56,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private readonly sessionDir = resolve(process.cwd(), getConfig().planningSessionDir);
   private readonly proposals = new Map<string, PlanningMutationProposal>();
   private readonly memoryChanges = new Map<string, PlanningMemoryChange>();
+  private readonly githubSyncs = new Map<string, GitHubSyncProposal>();
 
   private session?: AgentSession;
   private sessionPromise?: Promise<AgentSession>;
@@ -61,6 +68,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private lastCommitResult: PlanningGraphCommitResult | null = null;
   private activeMemoryChangeId: string | null = null;
   private lastMemoryWriteResult: PlanningMemoryWriteResult | null = null;
+  private activeGitHubSyncId: string | null = null;
+  private lastGitHubSyncResult: GitHubSyncResult | null = null;
 
   constructor(
     @Inject(ContextService) private readonly contextService: ContextService,
@@ -68,6 +77,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
     @Inject(MemoryService) private readonly memoryService: MemoryService,
     @Inject(SubAgentService) private readonly subAgentService: SubAgentService,
+    @Inject(GitHubService) private readonly githubService: GitHubService,
   ) {}
 
   async onModuleInit() {
@@ -101,6 +111,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       last_commit_result: this.lastCommitResult,
       active_memory_change: this.getActiveMemoryChange(),
       last_memory_write_result: this.lastMemoryWriteResult,
+      active_github_sync: this.getActiveGitHubSync(),
+      last_github_sync_result: this.lastGitHubSyncResult,
       memory: this.memoryService.read(),
       recent_subagent_runs: this.subAgentService.listRecentRuns(),
     };
@@ -220,6 +232,40 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     return writeResult;
   }
 
+  async approveGitHubSync(input: ApproveGitHubSyncDto): Promise<GitHubSyncResult> {
+    const syncId = input.sync_id?.trim();
+    if (!syncId) {
+      throw new BadRequestException("sync_id is required");
+    }
+
+    const approvedOperationIds = Array.from(new Set((input.approved_operation_ids ?? []).filter((id) => typeof id === "string" && id.trim())));
+    if (approvedOperationIds.length === 0) {
+      throw new BadRequestException("approved_operation_ids must contain at least one operation id");
+    }
+
+    const proposal = this.githubSyncs.get(syncId);
+    if (!proposal) {
+      throw new BadRequestException(`Unknown GitHub sync proposal: ${syncId}`);
+    }
+
+    const { result, issue } = await this.githubService.applySyncProposal(proposal, approvedOperationIds);
+    const activeGitHubSync = result.status === "applied"
+      ? this.updateActiveGitHubSyncAfterApply(proposal, approvedOperationIds)
+      : this.getActiveGitHubSync();
+
+    const syncResult: GitHubSyncResult = {
+      sync_id: proposal.sync_id,
+      approved_operation_ids: approvedOperationIds,
+      result,
+      active_github_sync: activeGitHubSync,
+      issue,
+    };
+
+    this.lastGitHubSyncResult = syncResult;
+    this.emitStudioEvent("github_sync_result", syncResult);
+    return syncResult;
+  }
+
   private async ensureSession(): Promise<AgentSession> {
     if (this.session) {
       return this.session;
@@ -249,6 +295,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         this.createMemoryReadTool(),
         this.createMemoryWriteTool(),
         this.createDelegateSubAgentTool(),
+        this.createGitHubReadTool(),
+        this.createGitHubSyncTool(),
       ],
     });
 
@@ -517,6 +565,67 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     });
   }
 
+  private createGitHubReadTool() {
+    return defineTool({
+      name: "github_read",
+      label: "GitHub Read",
+      description: "Read GitHub issue details for an issue-backed work item or repo issue.",
+      promptSnippet: "github_read: inspect GitHub issue details before making GitHub sync recommendations.",
+      promptGuidelines: [
+        "Use github_read when you need grounded issue details from GitHub rather than relying only on graph metadata.",
+        "Prefer the work item's repo + issue_number when available.",
+      ],
+      parameters: Type.Object({
+        repo: Type.String(),
+        issue_number: Type.Number(),
+      }),
+      execute: async (_toolCallId, params: GitHubReadToolInput) => {
+        const issue = await this.githubService.readIssue(params.repo, params.issue_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+          details: issue,
+        };
+      },
+    });
+  }
+
+  private createGitHubSyncTool() {
+    return defineTool({
+      name: "github_sync",
+      label: "GitHub Sync",
+      description: "Stage an approval-gated GitHub sync proposal for a GitHub-backed work item.",
+      promptSnippet: "github_sync: stage a structured GitHub sync proposal for browser approval instead of mutating GitHub directly.",
+      promptGuidelines: [
+        "Use github_sync only for narrow, non-destructive GitHub updates.",
+        "V1 sync supports only the machine-managed issue body block bounded by studio-sync markers.",
+        "Do not attempt direct GitHub mutation outside the approval flow.",
+      ],
+      parameters: Type.Object({
+        sync_id: Type.Optional(Type.String()),
+        created_at: Type.Optional(Type.String()),
+        source: Type.Optional(Type.Object({
+          agent: Type.Optional(Type.String()),
+          turn_id: Type.Optional(Type.String()),
+          session_id: Type.Optional(Type.String()),
+        })),
+        summary: Type.String(),
+        work_item_id: Type.String(),
+      }),
+      execute: async (_toolCallId, params: GitHubSyncToolInput) => {
+        const sync = await this.normalizeGitHubSync(params);
+        this.githubSyncs.set(sync.sync_id, sync);
+        this.activeGitHubSyncId = sync.sync_id;
+        this.lastGitHubSyncResult = null;
+        this.emitStudioEvent("github_sync_proposal", { sync });
+
+        return {
+          content: [{ type: "text", text: `Staged GitHub sync ${sync.sync_id} with ${sync.operations.length} operation(s).` }],
+          details: { sync },
+        };
+      },
+    });
+  }
+
   private normalizeProposal(input: ProposeMutationsToolInput): PlanningMutationProposal {
     const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
     const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}`;
@@ -581,6 +690,29 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       summary: input.summary.trim(),
       based_on_content_hash: memory.content_hash,
       edits: input.edits.map((edit, index) => this.normalizeMemoryEdit(edit, index)),
+    };
+  }
+
+  private async normalizeGitHubSync(input: GitHubSyncToolInput): Promise<GitHubSyncProposal> {
+    const staged = await this.githubService.stageManagedBlockSync(input.work_item_id);
+    return {
+      sync_id: input.sync_id?.trim() || `ghsync_${Date.now()}`,
+      created_at: input.created_at?.trim() || this.now(),
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
+        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
+      },
+      summary: input.summary.trim(),
+      issue: {
+        repo: staged.issue.repo,
+        issue_number: staged.issue.number,
+        issue_url: staged.issue.url,
+        title: staged.issue.title,
+      },
+      work_item_id: staged.work_item_id,
+      based_on_body_hash: staged.based_on_body_hash,
+      operations: staged.operations,
     };
   }
 
@@ -732,12 +864,40 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     return nextChange;
   }
 
+  private updateActiveGitHubSyncAfterApply(
+    proposal: GitHubSyncProposal,
+    approvedOperationIds: string[],
+  ): GitHubSyncProposal | null {
+    const remainingOperations = proposal.operations.filter((operation) => !approvedOperationIds.includes(operation.id));
+
+    if (remainingOperations.length === 0) {
+      this.githubSyncs.delete(proposal.sync_id);
+      if (this.activeGitHubSyncId === proposal.sync_id) {
+        this.activeGitHubSyncId = null;
+      }
+      return null;
+    }
+
+    const nextProposal: GitHubSyncProposal = {
+      ...proposal,
+      summary: `${proposal.summary} (${remainingOperations.length} operation(s) remaining)`,
+      operations: remainingOperations,
+    };
+    this.githubSyncs.set(nextProposal.sync_id, nextProposal);
+    this.activeGitHubSyncId = nextProposal.sync_id;
+    return nextProposal;
+  }
+
   private getActiveProposal(): PlanningMutationProposal | null {
     return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
   }
 
   private getActiveMemoryChange(): PlanningMemoryChange | null {
     return this.activeMemoryChangeId ? this.memoryChanges.get(this.activeMemoryChangeId) ?? null : null;
+  }
+
+  private getActiveGitHubSync(): GitHubSyncProposal | null {
+    return this.activeGitHubSyncId ? this.githubSyncs.get(this.activeGitHubSyncId) ?? null : null;
   }
 
   private emitStudioEvent(eventType: string, payload: unknown) {

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -7,6 +7,7 @@ export type PlanningMemoryEditKind = "replace_text" | "insert_after_heading" | "
 export type SubAgentType = "code-crawler" | "scope-predictor";
 export type SubAgentRunStatus = "queued" | "running" | "completed" | "error";
 export type SubAgentConfidence = "low" | "medium" | "high";
+export type GitHubSyncOperationKind = "update_managed_body_block";
 
 export interface SendAgentMessageDto {
   message: string;
@@ -192,6 +193,116 @@ export interface SubAgentRunRecord {
   result?: SubAgentResultEnvelope;
 }
 
+export interface GitHubIssueLabel {
+  name: string;
+  description?: string;
+  color?: string;
+}
+
+export interface GitHubIssueAssignee {
+  login: string;
+  name?: string;
+}
+
+export interface GitHubIssueDetails {
+  repo: string;
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: string;
+  labels: GitHubIssueLabel[];
+  assignees: GitHubIssueAssignee[];
+  body_hash: string;
+  managed_block?: {
+    content: string;
+    start_marker: string;
+    end_marker: string;
+  } | null;
+}
+
+export interface GitHubSyncOperation {
+  id: string;
+  kind: GitHubSyncOperationKind;
+  summary: string;
+  rationale: string;
+  target: {
+    repo: string;
+    issue_number: number;
+    work_item_id: string;
+  };
+  preview: {
+    before: string;
+    after: string;
+  };
+}
+
+export interface GitHubSyncProposal {
+  sync_id: string;
+  created_at: string;
+  source: PlanningMutationProposalSource;
+  summary: string;
+  issue: {
+    repo: string;
+    issue_number: number;
+    issue_url: string;
+    title: string;
+  };
+  work_item_id: string;
+  based_on_body_hash: string;
+  operations: GitHubSyncOperation[];
+}
+
+export interface GitHubSyncApplySuccess {
+  status: "applied";
+  applied_operation_ids: string[];
+  previous_body_hash: string;
+  new_body_hash: string;
+}
+
+export interface GitHubSyncApplyValidationFailure {
+  status: "validation_failed";
+  errors: Array<{ operation_id: string; message: string }>;
+}
+
+export interface GitHubSyncApplyStale {
+  status: "stale";
+  previous_body_hash: string;
+  current_body_hash: string;
+  message: string;
+}
+
+export type GitHubSyncApplyResult =
+  | GitHubSyncApplySuccess
+  | GitHubSyncApplyValidationFailure
+  | GitHubSyncApplyStale;
+
+export interface GitHubSyncResult {
+  sync_id: string;
+  approved_operation_ids: string[];
+  result: GitHubSyncApplyResult;
+  active_github_sync: GitHubSyncProposal | null;
+  issue: GitHubIssueDetails | null;
+}
+
+export interface ApproveGitHubSyncDto {
+  sync_id: string;
+  approved_operation_ids: string[];
+}
+
+export interface GitHubReadToolInput {
+  repo: string;
+  issue_number: number;
+}
+
+export interface GitHubSyncToolInput {
+  sync_id?: string;
+  created_at?: string;
+  source?: Partial<PlanningMutationProposalSource>;
+  summary: string;
+  work_item_id: string;
+}
+
 export interface PlanningSessionSnapshot {
   session_id: string;
   session_file?: string;
@@ -201,6 +312,8 @@ export interface PlanningSessionSnapshot {
   last_commit_result: PlanningGraphCommitResult | null;
   active_memory_change: PlanningMemoryChange | null;
   last_memory_write_result: PlanningMemoryWriteResult | null;
+  active_github_sync: GitHubSyncProposal | null;
+  last_github_sync_result: GitHubSyncResult | null;
   memory: PlanningMemoryDocument;
   recent_subagent_runs: SubAgentRunRecord[];
 }

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -6,10 +6,11 @@
   import {
     createEdge,
     createWorkItem,
+    deleteEdge,
+    getGitHubIssueDetails,
     getGraph,
     getHealth,
     listWorkItems,
-    deleteEdge,
     updateWorkItem,
   } from "./lib/api.js";
 
@@ -23,6 +24,7 @@
   let edgeSaving = false;
   let error = "";
   let health = null;
+  let selectedIssueDetails = null;
 
   $: selectedItem = graph.items.find((item) => item.id === selectedId) ?? null;
   $: filterOptions = {
@@ -58,6 +60,29 @@
 
   async function refresh() {
     await loadGraph();
+  }
+
+  let issueLookupToken = 0;
+  $: void loadSelectedIssueDetails(selectedItem);
+
+  async function loadSelectedIssueDetails(item) {
+    const token = ++issueLookupToken;
+
+    if (!item?.repo || !item?.issue_number) {
+      selectedIssueDetails = null;
+      return;
+    }
+
+    try {
+      const details = await getGitHubIssueDetails({ repo: item.repo, issue_number: item.issue_number });
+      if (token === issueLookupToken) {
+        selectedIssueDetails = details;
+      }
+    } catch (lookupError) {
+      if (token === issueLookupToken) {
+        selectedIssueDetails = { error: lookupError.message, repo: item.repo, number: item.issue_number, url: item.issue_url };
+      }
+    }
   }
 
   async function handleSaveItem(payload) {
@@ -175,6 +200,7 @@
 
     <Sidebar
       {selectedItem}
+      issueDetails={selectedIssueDetails}
       {graph}
       {saving}
       {edgeSaving}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -355,6 +355,24 @@ h2 {
   color: #f8fafc;
 }
 
+.github-sync-panel {
+  border-top-style: double;
+}
+
+.github-sync-card pre,
+.issue-body-preview pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.8rem;
+}
+
+.sync-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
 .subagent-panel {
   border-top-style: dotted;
 }
@@ -431,6 +449,40 @@ h2 {
   gap: 0.75rem;
 }
 
+.issue-details-card {
+  display: grid;
+  gap: 0.65rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(96, 165, 250, 0.2);
+  border-radius: 14px;
+  background: rgba(2, 6, 23, 0.45);
+}
+
+.issue-details-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.issue-details-header h3 {
+  margin: 0;
+}
+
+.issue-details-card a {
+  color: #93c5fd;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.issue-body-preview summary {
+  cursor: pointer;
+}
+
 .stack {
   display: grid;
   gap: 0.75rem;
@@ -472,7 +524,8 @@ h2 {
   }
 
   .planner-controls,
-  .toolbar {
+  .toolbar,
+  .sync-preview-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -490,7 +543,8 @@ h2 {
 
   .planner-controls,
   .toolbar,
-  .planner-actions {
+  .planner-actions,
+  .sync-preview-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher, onMount } from "svelte";
   import {
+    approveGitHubSync,
     approveMemoryChange,
     approveMutationProposal,
     getPlannerSessionSnapshot,
@@ -30,6 +31,9 @@
   let activeMemoryChange = null;
   let selectedMemoryEditIds = [];
   let lastMemoryWriteResult = null;
+  let activeGitHubSync = null;
+  let selectedGitHubOperationIds = [];
+  let lastGitHubSyncResult = null;
   let memoryDocument = null;
   let recentSubagentRuns = [];
   let stream;
@@ -54,12 +58,23 @@
     selectedMemoryEditIds = preserve ? selectedMemoryEditIds.filter((id) => ids.includes(id)) : ids;
   }
 
+  function syncGitHubSelection(sync, preserve = false) {
+    if (!sync) {
+      selectedGitHubOperationIds = [];
+      return;
+    }
+
+    const ids = sync.operations?.map((operation) => operation.id) ?? [];
+    selectedGitHubOperationIds = preserve ? selectedGitHubOperationIds.filter((id) => ids.includes(id)) : ids;
+  }
+
   function mergeSnapshot(snapshot) {
     sessionId = snapshot.session_id;
     isStreaming = snapshot.is_streaming;
     messages = snapshot.messages ?? [];
     lastCommitResult = snapshot.last_commit_result ?? null;
     lastMemoryWriteResult = snapshot.last_memory_write_result ?? null;
+    lastGitHubSyncResult = snapshot.last_github_sync_result ?? null;
     memoryDocument = snapshot.memory ?? null;
     recentSubagentRuns = snapshot.recent_subagent_runs ?? [];
 
@@ -72,6 +87,11 @@
     const memoryChanged = nextMemoryChange?.change_id !== activeMemoryChange?.change_id;
     activeMemoryChange = nextMemoryChange;
     syncMemorySelection(activeMemoryChange, !memoryChanged);
+
+    const nextGitHubSync = snapshot.active_github_sync ?? null;
+    const githubChanged = nextGitHubSync?.sync_id !== activeGitHubSync?.sync_id;
+    activeGitHubSync = nextGitHubSync;
+    syncGitHubSelection(activeGitHubSync, !githubChanged);
   }
 
   async function loadSnapshot() {
@@ -121,6 +141,20 @@
       activeMemoryChange = event.payload?.change ?? null;
       lastMemoryWriteResult = null;
       syncMemorySelection(activeMemoryChange);
+      return;
+    }
+
+    if (event.event_type === "github_sync_proposal") {
+      activeGitHubSync = event.payload?.sync ?? null;
+      lastGitHubSyncResult = null;
+      syncGitHubSelection(activeGitHubSync);
+      return;
+    }
+
+    if (event.event_type === "github_sync_result") {
+      lastGitHubSyncResult = event.payload ?? null;
+      activeGitHubSync = event.payload?.active_github_sync ?? null;
+      syncGitHubSelection(activeGitHubSync);
       return;
     }
 
@@ -277,6 +311,28 @@
     }
   }
 
+  async function approveSelectedGitHubOperations() {
+    if (!activeGitHubSync || selectedGitHubOperationIds.length === 0 || approving) {
+      return;
+    }
+
+    approving = true;
+    error = "";
+    try {
+      const syncResult = await approveGitHubSync({
+        sync_id: activeGitHubSync.sync_id,
+        approved_operation_ids: selectedGitHubOperationIds,
+      });
+      lastGitHubSyncResult = syncResult;
+      activeGitHubSync = syncResult.active_github_sync;
+      syncGitHubSelection(activeGitHubSync);
+    } catch (approveError) {
+      error = approveError.message;
+    } finally {
+      approving = false;
+    }
+  }
+
   async function rejectProposal() {
     if (!activeProposal) {
       return;
@@ -333,12 +389,44 @@
     }
   }
 
+  async function rejectGitHubSync() {
+    if (!activeGitHubSync) {
+      return;
+    }
+
+    await sendPlannerMessage(`Reject GitHub sync proposal ${activeGitHubSync.sync_id}. Keep GitHub sync narrow and non-destructive, explain what was wrong, and restage a safer sync if appropriate.`);
+  }
+
+  async function reviseGitHubSync() {
+    if (!activeGitHubSync) {
+      return;
+    }
+
+    const revisionNote = draft.trim() || window.prompt("How should the planner revise this GitHub sync?", "");
+    if (!revisionNote?.trim()) {
+      return;
+    }
+
+    const sent = await sendPlannerMessage(
+      `Revise GitHub sync proposal ${activeGitHubSync.sync_id} for work item ${activeGitHubSync.work_item_id}. Keep the same sync goal, but adjust it as follows: ${revisionNote.trim()}`,
+      { clearDraft: draft.trim() === revisionNote.trim() },
+    );
+
+    if (sent && draft.trim() === revisionNote.trim()) {
+      draft = "";
+    }
+  }
+
   function toggleMutationSelection(mutationId, checked) {
     selectedMutationIds = checked ? [...selectedMutationIds, mutationId] : selectedMutationIds.filter((id) => id !== mutationId);
   }
 
   function toggleMemorySelection(editId, checked) {
     selectedMemoryEditIds = checked ? [...selectedMemoryEditIds, editId] : selectedMemoryEditIds.filter((id) => id !== editId);
+  }
+
+  function toggleGitHubSelection(operationId, checked) {
+    selectedGitHubOperationIds = checked ? [...selectedGitHubOperationIds, operationId] : selectedGitHubOperationIds.filter((id) => id !== operationId);
   }
 
   onMount(() => {
@@ -408,6 +496,18 @@
         Memory change {lastMemoryWriteResult.change_id} is stale. Current memory hash: {lastMemoryWriteResult.result.current_content_hash.slice(0, 8)}.
       {:else}
         Memory write failed: {lastMemoryWriteResult.result.errors.map((item) => item.message).join('; ')}
+      {/if}
+    </div>
+  {/if}
+
+  {#if lastGitHubSyncResult}
+    <div class="banner {lastGitHubSyncResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+      {#if lastGitHubSyncResult.result.status === 'applied'}
+        Applied {lastGitHubSyncResult.approved_operation_ids.length} GitHub sync operation(s). Body hash {lastGitHubSyncResult.result.previous_body_hash.slice(0, 8)} → {lastGitHubSyncResult.result.new_body_hash.slice(0, 8)}.
+      {:else if lastGitHubSyncResult.result.status === 'stale'}
+        GitHub sync {lastGitHubSyncResult.sync_id} is stale. Current body hash: {lastGitHubSyncResult.result.current_body_hash.slice(0, 8)}.
+      {:else}
+        GitHub sync failed: {lastGitHubSyncResult.result.errors.map((item) => item.message).join('; ')}
       {/if}
     </div>
   {/if}
@@ -550,6 +650,55 @@
         <button on:click={approveSelectedMemoryEdits} disabled={approving || selectedMemoryEditIds.length === 0}>{approving ? 'Applying...' : `Approve ${selectedMemoryEditIds.length} memory edit(s)`}</button>
         <button class="secondary" on:click={rejectMemoryChange} disabled={sending}>Reject via follow-up</button>
         <button class="secondary" on:click={reviseMemoryChange} disabled={sending}>Revise via follow-up</button>
+      </div>
+    {/if}
+  </section>
+
+  <section class="proposal-panel github-sync-panel">
+    <div class="proposal-header">
+      <div>
+        <h3>GitHub sync</h3>
+        <p class="muted">Approval-gated issue sync proposals for the managed <code>studio-sync</code> block.</p>
+      </div>
+      {#if activeGitHubSync}<span class="status-pill">{activeGitHubSync.issue.repo} #{activeGitHubSync.issue.issue_number}</span>{/if}
+    </div>
+
+    {#if !activeGitHubSync}
+      <p class="muted">No staged GitHub sync proposal yet.</p>
+    {:else}
+      <div class="proposal-summary">
+        <strong>{activeGitHubSync.sync_id}</strong>
+        <p>{activeGitHubSync.summary}</p>
+      </div>
+      <div class="proposal-list">
+        {#each activeGitHubSync.operations as operation}
+          <label class="proposal-card github-sync-card">
+            <div class="proposal-card-header">
+              <input type="checkbox" checked={selectedGitHubOperationIds.includes(operation.id)} on:change={(event) => toggleGitHubSelection(operation.id, event.currentTarget.checked)} />
+              <div>
+                <strong>{operation.id}</strong>
+                <span class="proposal-type">{operation.kind}</span>
+              </div>
+            </div>
+            <strong>{operation.summary}</strong>
+            <p>{operation.rationale}</p>
+            <div class="sync-preview-grid">
+              <div>
+                <div class="muted">Current block</div>
+                <pre>{operation.preview.before}</pre>
+              </div>
+              <div>
+                <div class="muted">Proposed block</div>
+                <pre>{operation.preview.after}</pre>
+              </div>
+            </div>
+          </label>
+        {/each}
+      </div>
+      <div class="planner-actions proposal-actions">
+        <button on:click={approveSelectedGitHubOperations} disabled={approving || selectedGitHubOperationIds.length === 0}>{approving ? 'Applying...' : `Approve ${selectedGitHubOperationIds.length} sync operation(s)`}</button>
+        <button class="secondary" on:click={rejectGitHubSync} disabled={sending}>Reject via follow-up</button>
+        <button class="secondary" on:click={reviseGitHubSync} disabled={sending}>Revise via follow-up</button>
       </div>
     {/if}
   </section>

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -17,6 +17,7 @@
   };
 
   export let selectedItem = null;
+  export let issueDetails = null;
   export let graph = { items: [], edges: [] };
   export let saving = false;
   export let edgeSaving = false;
@@ -135,6 +136,42 @@
         </label>
         <button on:click={submitEdit} disabled={saving}>{saving ? "Saving..." : "Save changes"}</button>
       </div>
+
+      {#if selectedItem.issue_number && selectedItem.repo}
+        <div class="issue-details-card">
+          <div class="issue-details-header">
+            <h3>GitHub issue</h3>
+            {#if (issueDetails?.url || selectedItem.issue_url)}
+              <a href={issueDetails?.url || selectedItem.issue_url} target="_blank" rel="noreferrer">Open</a>
+            {/if}
+          </div>
+
+          {#if issueDetails?.error}
+            <p class="muted">Failed to load issue details: {issueDetails.error}</p>
+          {:else if issueDetails}
+            <strong>#{issueDetails.number} {issueDetails.title}</strong>
+            <p class="muted">{issueDetails.state}</p>
+            {#if issueDetails.labels?.length}
+              <div class="tag-list">
+                {#each issueDetails.labels as label}
+                  <span class="status-pill">{label.name}</span>
+                {/each}
+              </div>
+            {/if}
+            {#if issueDetails.assignees?.length}
+              <p class="muted">Assignees: {issueDetails.assignees.map((assignee) => assignee.login).join(', ')}</p>
+            {/if}
+            {#if issueDetails.managed_block}
+              <details class="issue-body-preview">
+                <summary>Managed Studio block</summary>
+                <pre>{issueDetails.managed_block.content}</pre>
+              </details>
+            {/if}
+          {:else}
+            <p class="muted">Loading issue details…</p>
+          {/if}
+        </div>
+      {/if}
     {:else}
       <p class="muted">Select a node in the graph to inspect and edit it.</p>
     {/if}

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -49,6 +49,19 @@ export function approveMemoryChange(payload) {
   });
 }
 
+export function approveGitHubSync(payload) {
+  return request("/api/agent/github/approve", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getGitHubIssueDetails({ repo, issue_number }) {
+  const query = new URLSearchParams({ repo, issue_number: String(issue_number) });
+  return request(`/api/github/issue?${query.toString()}`);
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {

--- a/web/src/lib/planner-chat.js
+++ b/web/src/lib/planner-chat.js
@@ -27,6 +27,8 @@ export function connectPlannerStream({ onEvent, onOpen, onError } = {}) {
     "graph_commit_result",
     "memory_change_proposal",
     "memory_write_result",
+    "github_sync_proposal",
+    "github_sync_result",
     "subagent_status",
     "subagent_result",
   ].forEach(forward);


### PR DESCRIPTION
## Summary
Add the first GitHub integration layer so Studio can read issue details, surface them in the browser, and stage approval-gated sync proposals that update only the managed `studio-sync` issue body block.

Closes #10

## Changes
- add `GitHubModule` with `gh`-backed issue read and managed-block sync logic
- add `github_read` and approval-gated `github_sync` tools to the root planner
- add GitHub sync approval endpoint plus session snapshot and SSE state
- add sidebar GitHub issue detail/link rendering for issue-backed work items
- add planner GitHub sync review/apply UI
- update `README.md` with GitHub integration verification steps and curl examples

## Testing
- `npm run build`
- manual `GET /api/github/issue?repo=fusupo/escapement-studio&issue_number=10`
- manual planner `github_read` verification
- manual staged + approved `github_sync` verification
- manual stale GitHub sync rejection verification
- manual Vite proxy verification for `/api/github/issue`
- manual confirmation that sync changes only the managed `studio-sync` block

## Notes
- V1 sync supports only the managed issue-body block, but sync contracts are operation-based so labels/title/state can be added later without redesign
- safe sync requires the issue body to already contain a `studio-sync` managed block
- issue #10 was used for manual verification and now contains a managed Studio block
