### PR TITLE
feat: add execution dispatch preview and isolated runs (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,19 @@ This runs the server TypeScript check plus the production frontend build.
 17. Ask the planner to use `github_read` and confirm issue details appear in the transcript/tool output.
 18. Ask the planner to stage a `github_sync` proposal and confirm a reviewable GitHub sync card appears in the browser.
 19. Approve the staged GitHub sync and confirm only the managed `studio-sync` issue body block changes.
-20. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
-21. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results and recent specialist runs are restored.
-22. Verify the graph view still loads data from `/api/graph`.
-23. Select a node to edit it in the sidebar.
-24. Create a new work item in the sidebar and confirm it appears in the graph.
-25. Create an edge between two nodes and confirm it appears in the graph and edge list.
-26. Delete an edge from the sidebar.
-27. Change repo/state/track/phase filters and confirm the rendered graph updates.
+20. Review the execution dispatch panel and confirm it loads a dispatch preview from `GET /api/execution/preview`.
+21. Confirm each dispatchable node shows worktree/branch safety checks before launch.
+22. Launch a dispatchable execution run and confirm status updates stream into the browser from `GET /api/execution/stream`.
+23. Confirm the launched run creates an isolated worktree under `/home/marc/escapement-studio-ctx/worktrees/` and artifacts under `/home/marc/escapement-studio-ctx/runs/`.
+24. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
+25. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
+26. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, and recent execution runs are restored.
+27. Verify the graph view still loads data from `/api/graph`.
+28. Select a node to edit it in the sidebar.
+29. Create a new work item in the sidebar and confirm it appears in the graph.
+30. Create an edge between two nodes and confirm it appears in the graph and edge list.
+31. Delete an edge from the sidebar.
+32. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -214,6 +219,7 @@ curl http://localhost:3000/api/agent/session
 ```
 
 The snapshot returns the recent planner transcript plus active proposal/memory/GitHub-sync state and recent specialist runs used by the browser to restore workspace state after refresh.
+Execution runs are restored separately from `GET /api/execution/runs`.
 
 ### Root planner message + stream
 
@@ -256,6 +262,52 @@ The assembled planner context includes:
 
 The stream should emit SDK-native event names like `agent_start`, `turn_start`, `message_update`, and `agent_end` inside the Studio SSE envelope.
 It also emits Studio workflow events: `mutation_proposal`, `graph_commit_result`, `memory_change_proposal`, `memory_write_result`, `github_sync_proposal`, `github_sync_result`, `subagent_status`, and `subagent_result`.
+
+Execution runs use a separate SSE channel:
+
+```bash
+curl -N http://localhost:3000/api/execution/stream
+```
+
+That stream emits `execution_status` and `execution_result` envelopes as runs move through safety checks, worktree preparation, active execution, and terminal states.
+
+### Preview execution dispatch
+
+```bash
+curl http://localhost:3000/api/execution/preview
+curl http://localhost:3000/api/execution/runs
+```
+
+The preview returns dispatchable frontier groups, per-node safety checks, and launch metadata such as the target branch and isolated worktree path.
+
+### Launch an execution run
+
+```bash
+curl -X POST http://localhost:3000/api/execution/launch \
+  -H 'content-type: application/json' \
+  -d '{
+    "work_item_id": "studio-10"
+  }'
+```
+
+A successful launch returns an accepted execution run record and starts work in an isolated git worktree under:
+
+```text
+/home/marc/escapement-studio-ctx/worktrees/<branch>/
+```
+
+Execution artifacts are persisted under:
+
+```text
+/home/marc/escapement-studio-ctx/runs/<run_id>/
+  metadata.json
+  status.json
+  events.jsonl
+  summary.md
+  outputs/
+```
+
+Blocked launches return `accepted: false` plus a run record with `status: "blocked"` and explicit safety check failures.
 
 ### Read a GitHub issue linked to a work item
 

--- a/docs/contracts/event-stream.md
+++ b/docs/contracts/event-stream.md
@@ -52,6 +52,12 @@ data: {"event_id":"evt_000123","stream_id":"planning-root","timestamp":"2026-04-
 - `mutation_proposal`
 - `subagent_status`
 - `graph_commit_result`
+- `memory_change_proposal`
+- `memory_write_result`
+- `github_sync_proposal`
+- `github_sync_result`
+- `execution_status`
+- `execution_result`
 
 ## V1 reconnect policy
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { ExecutionModule } from "./modules/execution/execution.module.js";
 import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { PlanningModule } from "./modules/planning/planning.module.js";
 
 @Module({
-  imports: [GraphModule, HealthModule, GitHubModule, PlanningModule],
+  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule],
 })
 export class AppModule {}

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Inject, Post, Query, Sse } from "@nestjs/common";
+import type { MessageEvent } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { ExecutionService } from "./execution.service.js";
+import type { LaunchExecutionRunDto } from "./types.js";
+
+@Controller("api/execution")
+export class ExecutionController {
+  constructor(@Inject(ExecutionService) private readonly executionService: ExecutionService) {}
+
+  @Get("preview")
+  getPreview(@Query("repo") repo?: string) {
+    return this.executionService.getPreview(repo);
+  }
+
+  @Get("runs")
+  getRecentRuns() {
+    return this.executionService.listRecentRuns();
+  }
+
+  @Post("launch")
+  launch(@Body() body: LaunchExecutionRunDto) {
+    return this.executionService.launch(body);
+  }
+
+  @Sse("stream")
+  stream(): Observable<MessageEvent> {
+    return this.executionService.stream();
+  }
+}

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { GraphModule } from "../graph/graph.module.js";
+import { ExecutionController } from "./execution.controller.js";
+import { ExecutionService } from "./execution.service.js";
+
+@Module({
+  imports: [GraphModule],
+  controllers: [ExecutionController],
+  providers: [ExecutionService],
+  exports: [ExecutionService],
+})
+export class ExecutionModule {}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,0 +1,523 @@
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent } from "@nestjs/common";
+import { createAgentSession, createCodingTools, SessionManager, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
+import { Observable, Subject } from "rxjs";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import { GraphService } from "../graph/graph.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { WorkItemRecord } from "../graph/types.js";
+import type {
+  ExecutionDispatchGroupPreview,
+  ExecutionDispatchNodePreview,
+  ExecutionDispatchPreview,
+  ExecutionRunRecord,
+  ExecutionSafetyCheck,
+  ExecutionStatusEvent,
+  LaunchExecutionRunDto,
+  LaunchExecutionRunResult,
+} from "./types.js";
+
+@Injectable()
+export class ExecutionService {
+  private readonly logger = new Logger(ExecutionService.name);
+  private readonly streamId = "execution-runs";
+  private readonly eventSubject = new Subject<MessageEvent>();
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+  private readonly worktreeRoot = join(this.artifactRoot, "worktrees");
+  private readonly recentRuns: ExecutionRunRecord[] = [];
+  private readonly recentRunLimit = 16;
+  private eventCounter = 0;
+
+  constructor(
+    @Inject(GraphService) private readonly graphService: GraphService,
+    @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+  ) {}
+
+  stream(): Observable<MessageEvent> {
+    return new Observable<MessageEvent>((subscriber) => {
+      const subscription = this.eventSubject.subscribe(subscriber);
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  listRecentRuns(): ExecutionRunRecord[] {
+    return [...this.recentRuns].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  }
+
+  getPreview(repo?: string): ExecutionDispatchPreview {
+    const plan = this.graphService.getPlan(repo);
+    const groups: ExecutionDispatchGroupPreview[] = plan.parallel_groups.map((group, index) => ({
+      group_id: `group_${index + 1}`,
+      repo: group.repo,
+      merge_order: group.merge_order,
+      nodes: group.nodes.map((node) => {
+        const workItem = this.safeGetWorkItem(node.id);
+        const worktreePath = this.getWorktreePath(node.branch);
+        const safetyChecks = this.evaluateSafety(node.branch, worktreePath);
+        return {
+          id: node.id,
+          name: node.name,
+          repo: group.repo === "unknown" ? null : group.repo,
+          branch: node.branch,
+          issue_url: node.issue_url,
+          scope_hint: workItem?.scope_hint ?? null,
+          files_owned: node.files_owned,
+          files_shared: node.files_shared,
+          files_forbidden: node.files_forbidden,
+          worktree_path: worktreePath,
+          safety_checks: safetyChecks,
+          can_launch: !safetyChecks.some((check) => check.status === "fail"),
+        } satisfies ExecutionDispatchNodePreview;
+      }),
+    }));
+
+    return {
+      generated_at: plan.generated_at,
+      assumptions: plan.assumptions,
+      validation_policy: plan.validation_policy,
+      summary: plan.summary,
+      groups,
+      blocked: plan.sequential,
+    };
+  }
+
+  async launch(input: LaunchExecutionRunDto): Promise<LaunchExecutionRunResult> {
+    const workItemId = input.work_item_id?.trim();
+    if (!workItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+
+    const preview = this.getPreview();
+    const node = preview.groups.flatMap((group) => group.nodes).find((candidate) => candidate.id === workItemId);
+    const workItem = this.workItemsService.get(workItemId);
+    const baseRef = input.base_ref?.trim() || "develop";
+
+    if (!node) {
+      const run = this.createRunRecord({
+        workItem,
+        branch: workItem.branch ?? `${workItem.id}-branch`,
+        baseRef,
+        worktreePath: this.getWorktreePath(workItem.branch ?? `${workItem.id}-branch`),
+        safetyChecks: [{ code: "not_dispatchable", status: "fail", message: "Work item is not currently dispatchable from the frontier." }],
+        prompt: input.prompt?.trim() || "",
+        status: "blocked",
+        resultSummary: "Launch blocked because the work item is not currently dispatchable.",
+        errors: [{ code: "not_dispatchable", message: "Work item is not currently dispatchable from the frontier." }],
+      });
+      this.persistRun(run);
+      this.emitRun("execution_result", run);
+      return { accepted: false, run };
+    }
+
+    const safetyChecks = this.evaluateSafety(node.branch, node.worktree_path, baseRef);
+    if (safetyChecks.some((check) => check.status === "fail")) {
+      const run = this.createRunRecord({
+        workItem,
+        branch: node.branch,
+        baseRef,
+        worktreePath: node.worktree_path,
+        safetyChecks,
+        prompt: input.prompt?.trim() || this.buildPrompt(workItem, node),
+        status: "blocked",
+        resultSummary: "Launch blocked by execution safety checks.",
+        errors: safetyChecks.filter((check) => check.status === "fail").map((check) => ({ code: check.code, message: check.message })),
+      });
+      this.persistRun(run);
+      this.emitRun("execution_result", run);
+      return { accepted: false, run };
+    }
+
+    const run = this.createRunRecord({
+      workItem,
+      branch: node.branch,
+      baseRef,
+      worktreePath: node.worktree_path,
+      safetyChecks,
+      prompt: input.prompt?.trim() || this.buildPrompt(workItem, node),
+      status: "queued",
+      resultSummary: undefined,
+      errors: [],
+    });
+
+    this.persistRun(run);
+    void this.executeRun(run, node).catch((error) => {
+      const failedRun = this.updateRun(run.run_id, {
+        status: "error",
+        completed_at: this.now(),
+        progress_message: `Execution failed: ${this.getErrorMessage(error)}`,
+        result_summary: `Execution failed: ${this.getErrorMessage(error)}`,
+        errors: [{ code: "execution_failed", message: this.getErrorMessage(error) }],
+      });
+      if (failedRun) {
+        this.writeSummary(failedRun);
+        this.appendEvent(failedRun, { type: "run_failed", error: this.getErrorMessage(error) });
+        this.emitRun("execution_result", failedRun);
+      }
+    });
+
+    return { accepted: true, run };
+  }
+
+  private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview) {
+    let run = this.updateRun(initialRun.run_id, {
+      status: "preparing",
+      progress_message: "Creating isolated git worktree.",
+    });
+    if (!run) {
+      return;
+    }
+    this.appendEvent(run, { type: "run_preparing" });
+
+    this.runGit(["worktree", "add", run.worktree_path, "-b", run.branch, run.base_ref]);
+    this.appendEvent(run, { type: "worktree_created", worktree_path: run.worktree_path, branch: run.branch, base_ref: run.base_ref });
+
+    const { session, modelFallbackMessage } = await createAgentSession({
+      cwd: run.worktree_path,
+      sessionManager: SessionManager.inMemory(run.worktree_path),
+      tools: createCodingTools(run.worktree_path),
+    });
+
+    if (modelFallbackMessage) {
+      this.logger.warn(modelFallbackMessage);
+    }
+
+    run = this.updateRun(initialRun.run_id, {
+      status: "running",
+      started_at: this.now(),
+      session_id: session.sessionId,
+      progress_message: "Execution agent running in isolated worktree.",
+    })!;
+    this.appendEvent(run, { type: "session_started", session_id: session.sessionId });
+
+    const runId = run.run_id;
+    const unsubscribe = session.subscribe((event) => {
+      this.handleSessionEvent(runId, event);
+    });
+
+    try {
+      await session.prompt(run.prompt);
+    } finally {
+      unsubscribe();
+      session.dispose();
+    }
+
+    const assistantText = session.getLastAssistantText()?.trim() ?? "Execution run completed without a terminal summary.";
+    const changedFiles = this.listChangedFiles(run.worktree_path);
+    mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
+    writeFileSync(join(run.artifact_dir, "outputs", "response.json"), JSON.stringify({ assistant_text: assistantText, changed_files: changedFiles }, null, 2), "utf8");
+
+    run = this.updateRun(initialRun.run_id, {
+      status: "completed",
+      completed_at: this.now(),
+      progress_message: "Execution run completed.",
+      result_summary: assistantText,
+      changed_files: changedFiles,
+    })!;
+    this.writeSummary(run, node);
+    this.appendEvent(run, { type: "run_completed", changed_files: changedFiles });
+    this.emitRun("execution_result", run);
+  }
+
+  private handleSessionEvent(runId: string, event: AgentSessionEvent) {
+    const run = this.getRun(runId);
+    if (!run) {
+      return;
+    }
+
+    const toolName = "toolName" in event ? event.toolName ?? null : null;
+    if (event.type === "tool_execution_start") {
+      this.appendEvent(run, { type: event.type, tool_name: toolName });
+      this.updateRun(runId, { progress_message: `${toolName ?? "tool"} running…` });
+      return;
+    }
+
+    if (event.type === "tool_execution_end") {
+      this.appendEvent(run, { type: event.type, tool_name: toolName });
+      this.updateRun(runId, { progress_message: `${toolName ?? "tool"} finished.` });
+      return;
+    }
+
+    if (event.type === "message_end") {
+      this.appendEvent(run, { type: event.type });
+      return;
+    }
+
+    if (event.type === "agent_start" || event.type === "turn_start") {
+      this.appendEvent(run, { type: event.type });
+      this.updateRun(runId, { progress_message: "Execution turn started." });
+      return;
+    }
+
+    if (event.type === "agent_end" || event.type === "turn_end") {
+      this.appendEvent(run, { type: event.type });
+      this.updateRun(runId, { progress_message: "Execution turn completed." });
+    }
+  }
+
+  private evaluateSafety(branch: string, worktreePath: string, baseRef = "develop"): ExecutionSafetyCheck[] {
+    const checks: ExecutionSafetyCheck[] = [];
+    checks.push(this.checkTrackedRepoClean());
+    checks.push(this.checkBaseRef(baseRef));
+    checks.push(this.checkBranchAvailable(branch));
+    checks.push(this.checkWorktreePathAvailable(worktreePath));
+    checks.push(this.checkPathBounded(worktreePath));
+    return checks;
+  }
+
+  private checkTrackedRepoClean(): ExecutionSafetyCheck {
+    const output = this.runGit(["status", "--porcelain", "--untracked-files=no"], { allowFailure: true });
+    return output.trim().length === 0
+      ? { code: "tracked_repo_clean", status: "pass", message: "Repo has no tracked changes that would interfere with dispatch." }
+      : { code: "tracked_repo_clean", status: "warn", message: "Repo has tracked local changes, but execution still uses an isolated worktree and will not mutate the main checkout." };
+  }
+
+  private checkBaseRef(baseRef: string): ExecutionSafetyCheck {
+    const ok = this.runGit(["rev-parse", "--verify", baseRef], { allowFailure: true }).trim().length > 0;
+    return ok
+      ? { code: "base_ref_exists", status: "pass", message: `Base ref ${baseRef} is available.` }
+      : { code: "base_ref_exists", status: "fail", message: `Base ref ${baseRef} was not found.` };
+  }
+
+  private checkBranchAvailable(branch: string): ExecutionSafetyCheck {
+    const existing = this.runGit(["branch", "--list", branch], { allowFailure: true }).trim();
+    return existing.length === 0
+      ? { code: "branch_available", status: "pass", message: `Branch ${branch} is available for a new worktree.` }
+      : { code: "branch_available", status: "fail", message: `Branch ${branch} already exists locally.` };
+  }
+
+  private checkWorktreePathAvailable(worktreePath: string): ExecutionSafetyCheck {
+    const listed = this.runGit(["worktree", "list", "--porcelain"], { allowFailure: true });
+    return listed.includes(`worktree ${worktreePath}`)
+      ? { code: "worktree_path_available", status: "fail", message: `Worktree path ${worktreePath} is already in use.` }
+      : { code: "worktree_path_available", status: "pass", message: "Target worktree path is available." };
+  }
+
+  private checkPathBounded(worktreePath: string): ExecutionSafetyCheck {
+    const boundedRoot = resolve(this.worktreeRoot);
+    const target = resolve(worktreePath);
+    return target.startsWith(`${boundedRoot}/`) || target === boundedRoot
+      ? { code: "worktree_path_bounded", status: "pass", message: "Target worktree path is inside the configured execution worktree root." }
+      : { code: "worktree_path_bounded", status: "fail", message: "Target worktree path escaped the configured execution worktree root." };
+  }
+
+  private buildPrompt(workItem: WorkItemRecord, node: ExecutionDispatchNodePreview): string {
+    const owned = node.files_owned.length ? node.files_owned.map((path) => `- ${path}`).join("\n") : "- (none predicted)";
+    const shared = node.files_shared.length
+      ? node.files_shared.map((file) => `- ${file.path} (${file.assessment}/${file.confidence})`).join("\n")
+      : "- (none)";
+    const forbidden = node.files_forbidden.length ? node.files_forbidden.map((path) => `- ${path}`).join("\n") : "- (none)";
+
+    return [
+      `You are executing Studio work item ${workItem.id}: ${workItem.name}.`,
+      "You are running inside a dedicated git worktree created by Escapement Studio.",
+      "Make concrete implementation progress for this work item while staying inside the predicted scope.",
+      "Prefer focused changes over broad refactors.",
+      "At the end, summarize what you changed, any tests/run checks you performed, and any remaining blockers.",
+      "",
+      `Repo: ${workItem.repo ?? "(not set)"}`,
+      `Issue URL: ${workItem.issue_url ?? "(not set)"}`,
+      `Scope hint: ${workItem.scope_hint ?? "(not set)"}`,
+      `Suggested execution branch: ${node.branch}`,
+      "",
+      "Files owned:",
+      owned,
+      "",
+      "Files shared:",
+      shared,
+      "",
+      "Files forbidden:",
+      forbidden,
+      "",
+      "If you must go beyond the predicted scope, explain why in the final summary.",
+    ].join("\n");
+  }
+
+  private createRunRecord(input: {
+    workItem: WorkItemRecord;
+    branch: string;
+    baseRef: string;
+    worktreePath: string;
+    safetyChecks: ExecutionSafetyCheck[];
+    prompt: string;
+    status: ExecutionRunRecord["status"];
+    resultSummary?: string;
+    errors?: Array<{ code: string; message: string }>;
+  }): ExecutionRunRecord {
+    const runId = `exec_${Date.now()}`;
+    const createdAt = this.now();
+    return {
+      run_id: runId,
+      run_type: "execution",
+      work_item_id: input.workItem.id,
+      work_item_name: input.workItem.name,
+      status: input.status,
+      created_at: createdAt,
+      updated_at: createdAt,
+      repo: input.workItem.repo,
+      issue_url: input.workItem.issue_url,
+      branch: input.branch,
+      base_ref: input.baseRef,
+      worktree_path: input.worktreePath,
+      artifact_dir: join(this.artifactRoot, "runs", runId),
+      prompt: input.prompt,
+      progress_message: input.resultSummary ?? (input.status === "queued" ? "Execution run queued." : undefined),
+      result_summary: input.resultSummary,
+      safety_checks: input.safetyChecks,
+      errors: input.errors,
+    };
+  }
+
+  private persistRun(run: ExecutionRunRecord) {
+    mkdirSync(run.artifact_dir, { recursive: true });
+    mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
+    this.upsertRecentRun(run);
+    this.writeMetadata(run);
+    this.writeStatus(run);
+    this.appendEvent(run, { type: "run_created", status: run.status });
+    this.emitRun(run.status === "blocked" ? "execution_result" : "execution_status", run);
+  }
+
+  private updateRun(runId: string, patch: Partial<ExecutionRunRecord>): ExecutionRunRecord | null {
+    const index = this.recentRuns.findIndex((run) => run.run_id === runId);
+    if (index === -1) {
+      return null;
+    }
+
+    const nextRun: ExecutionRunRecord = {
+      ...this.recentRuns[index],
+      ...patch,
+      updated_at: this.now(),
+    };
+    this.recentRuns[index] = nextRun;
+    this.writeStatus(nextRun);
+    this.emitRun(nextRun.status === "completed" || nextRun.status === "error" || nextRun.status === "blocked" ? "execution_result" : "execution_status", nextRun);
+    return nextRun;
+  }
+
+  private getRun(runId: string): ExecutionRunRecord | null {
+    return this.recentRuns.find((run) => run.run_id === runId) ?? null;
+  }
+
+  private upsertRecentRun(run: ExecutionRunRecord) {
+    const existingIndex = this.recentRuns.findIndex((item) => item.run_id === run.run_id);
+    if (existingIndex >= 0) {
+      this.recentRuns[existingIndex] = run;
+    } else {
+      this.recentRuns.unshift(run);
+      this.recentRuns.splice(this.recentRunLimit);
+    }
+  }
+
+  private writeMetadata(run: ExecutionRunRecord) {
+    writeFileSync(join(run.artifact_dir, "metadata.json"), JSON.stringify({
+      run_id: run.run_id,
+      run_type: run.run_type,
+      created_at: run.created_at,
+      work_item_id: run.work_item_id,
+      work_item_name: run.work_item_name,
+      repo: run.repo,
+      issue_url: run.issue_url,
+      branch: run.branch,
+      base_ref: run.base_ref,
+      worktree_path: run.worktree_path,
+      artifact_dir: run.artifact_dir,
+    }, null, 2), "utf8");
+  }
+
+  private writeStatus(run: ExecutionRunRecord) {
+    writeFileSync(join(run.artifact_dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+  }
+
+  private writeSummary(run: ExecutionRunRecord, node?: ExecutionDispatchNodePreview) {
+    const lines = [
+      `# Execution run ${run.run_id}`,
+      "",
+      `- Work item: ${run.work_item_id} — ${run.work_item_name}`,
+      `- Status: ${run.status}`,
+      `- Branch: ${run.branch}`,
+      `- Base ref: ${run.base_ref}`,
+      `- Worktree: ${run.worktree_path}`,
+      `- Artifact dir: ${run.artifact_dir}`,
+      `- Created: ${run.created_at}`,
+      `- Updated: ${run.updated_at}`,
+      ...(run.started_at ? [`- Started: ${run.started_at}`] : []),
+      ...(run.completed_at ? [`- Completed: ${run.completed_at}`] : []),
+      "",
+      "## Safety checks",
+      ...run.safety_checks.map((check) => `- [${check.status}] ${check.code}: ${check.message}`),
+      "",
+      ...(node ? ["## Dispatch scope", ...(node.files_owned.length ? ["Owned files:", ...node.files_owned.map((path) => `- ${path}`)] : ["Owned files: (none predicted)"]), ""] : []),
+      "## Result",
+      run.result_summary ?? run.progress_message ?? "No summary available.",
+      "",
+      ...(run.changed_files?.length ? ["## Changed files", ...run.changed_files.map((path) => `- ${path}`), ""] : []),
+    ];
+
+    writeFileSync(join(run.artifact_dir, "summary.md"), lines.join("\n"), "utf8");
+  }
+
+  private appendEvent(run: ExecutionRunRecord, payload: Record<string, unknown>) {
+    appendFileSync(join(run.artifact_dir, "events.jsonl"), `${JSON.stringify({ timestamp: this.now(), run_id: run.run_id, ...payload })}\n`, "utf8");
+  }
+
+  private emitRun(eventType: "execution_status" | "execution_result", run: ExecutionRunRecord) {
+    const envelope = {
+      event_id: `evt_${++this.eventCounter}`,
+      stream_id: this.streamId,
+      timestamp: this.now(),
+      event_type: eventType,
+      session_id: run.run_id,
+      turn_id: null,
+      payload: { run } satisfies ExecutionStatusEvent,
+    };
+
+    this.eventSubject.next({
+      type: envelope.event_type,
+      data: JSON.stringify(envelope),
+      id: envelope.event_id,
+    });
+  }
+
+  private runGit(args: string[], options: { allowFailure?: boolean } = {}): string {
+    try {
+      return execFileSync("git", args, { cwd: process.cwd(), encoding: "utf8" });
+    } catch (error) {
+      if (options.allowFailure) {
+        return "";
+      }
+      throw error;
+    }
+  }
+
+  private listChangedFiles(worktreePath: string): string[] {
+    const output = execFileSync("git", ["status", "--short"], { cwd: worktreePath, encoding: "utf8" });
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.slice(3).trim());
+  }
+
+  private getWorktreePath(branch: string): string {
+    const safeBranch = branch.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "execution-run";
+    return join(this.worktreeRoot, safeBranch);
+  }
+
+  private safeGetWorkItem(id: string): WorkItemRecord | null {
+    try {
+      return this.workItemsService.get(id);
+    } catch {
+      return null;
+    }
+  }
+
+  private now(): string {
+    return new Date().toISOString();
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -1,0 +1,97 @@
+export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "running" | "completed" | "error";
+export type ExecutionSafetyStatus = "pass" | "warn" | "fail";
+
+export interface ExecutionSafetyCheck {
+  code: string;
+  status: ExecutionSafetyStatus;
+  message: string;
+}
+
+export interface ExecutionDispatchNodePreview {
+  id: string;
+  name: string;
+  repo: string | null;
+  branch: string;
+  issue_url?: string;
+  scope_hint?: string | null;
+  files_owned: string[];
+  files_shared: Array<{
+    path: string;
+    assessment: string;
+    confidence: string;
+    notes: string;
+  }>;
+  files_forbidden: string[];
+  worktree_path: string;
+  safety_checks: ExecutionSafetyCheck[];
+  can_launch: boolean;
+}
+
+export interface ExecutionDispatchGroupPreview {
+  group_id: string;
+  repo: string;
+  merge_order?: string[];
+  nodes: ExecutionDispatchNodePreview[];
+}
+
+export interface ExecutionDispatchPreview {
+  generated_at: string;
+  assumptions: string[];
+  validation_policy: {
+    max_concurrent_node_heavy_tasks: number;
+    serialized_checks: string[];
+  };
+  summary: {
+    frontier_count: number;
+    dispatchable_now: number;
+    blocked_count: number;
+    human_gate_count: number;
+  };
+  groups: ExecutionDispatchGroupPreview[];
+  blocked: Array<{
+    id: string;
+    name: string;
+    blocked_by: string[];
+    reason: string;
+  }>;
+}
+
+export interface LaunchExecutionRunDto {
+  work_item_id: string;
+  base_ref?: string;
+  prompt?: string;
+}
+
+export interface ExecutionRunRecord {
+  run_id: string;
+  run_type: "execution";
+  work_item_id: string;
+  work_item_name: string;
+  status: ExecutionRunStatus;
+  created_at: string;
+  updated_at: string;
+  started_at?: string;
+  completed_at?: string;
+  repo?: string | null;
+  issue_url?: string | null;
+  branch: string;
+  base_ref: string;
+  worktree_path: string;
+  artifact_dir: string;
+  session_id?: string;
+  prompt: string;
+  progress_message?: string;
+  result_summary?: string;
+  changed_files?: string[];
+  safety_checks: ExecutionSafetyCheck[];
+  errors?: Array<{ code: string; message: string }>;
+}
+
+export interface LaunchExecutionRunResult {
+  accepted: boolean;
+  run: ExecutionRunRecord;
+}
+
+export interface ExecutionStatusEvent {
+  run: ExecutionRunRecord;
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,5 +1,6 @@
 <script>
   import PlannerChatAdapter from "./components/PlannerChatAdapter.svelte";
+  import ExecutionDispatchPanel from "./components/ExecutionDispatchPanel.svelte";
   import GraphView from "./components/GraphView.svelte";
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
@@ -175,6 +176,7 @@
   </header>
 
   <PlannerChatAdapter on:graphChanged={refresh} />
+  <ExecutionDispatchPanel />
 
   <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -401,6 +401,129 @@ h2 {
   margin: 0;
 }
 
+.execution-panel {
+  width: min(1500px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.execution-header {
+  margin: 0;
+}
+
+.execution-summary-grid,
+.dispatch-scope-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.execution-summary-card,
+.dispatch-group-card,
+.dispatch-node-card,
+.execution-check {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(2, 6, 23, 0.4);
+}
+
+.execution-summary-card {
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.execution-summary-card span {
+  font-size: 1.35rem;
+  color: #f8fafc;
+}
+
+.execution-assumptions summary,
+.dispatch-node-card summary {
+  cursor: pointer;
+}
+
+.execution-assumptions ul {
+  margin: 0.6rem 0 0;
+}
+
+.execution-groups,
+.dispatch-node-list,
+.execution-check-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dispatch-group-card {
+  padding: 1rem;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.dispatch-group-header,
+.dispatch-node-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.dispatch-group-header h3 {
+  margin: 0;
+}
+
+.dispatch-node-card {
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.dispatch-scope-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0.75rem 0;
+}
+
+.dispatch-scope-grid ul,
+.execution-assumptions ul,
+.execution-run-card ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+}
+
+.execution-check-list {
+  margin-top: 0.5rem;
+}
+
+.execution-check {
+  padding: 0.65rem 0.75rem;
+  display: grid;
+}
+
+.execution-check.pass strong {
+  color: #86efac;
+}
+
+.execution-check.fail strong {
+  color: #fca5a5;
+}
+
+.execution-check.warn strong {
+  color: #fde68a;
+}
+
+.small-text {
+  font-size: 0.85rem;
+}
+
+.execution-run-card pre {
+  margin: 0.5rem 0 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.8rem;
+}
+
 .compact {
   min-height: 140px;
 }
@@ -525,7 +648,9 @@ h2 {
 
   .planner-controls,
   .toolbar,
-  .sync-preview-grid {
+  .sync-preview-grid,
+  .execution-summary-grid,
+  .dispatch-scope-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -544,7 +669,9 @@ h2 {
   .planner-controls,
   .toolbar,
   .planner-actions,
-  .sync-preview-grid {
+  .sync-preview-grid,
+  .execution-summary-grid,
+  .dispatch-scope-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,0 +1,264 @@
+<script>
+  import { onMount } from "svelte";
+  import { getExecutionPreview, launchExecutionRun, listExecutionRuns } from "../lib/api.js";
+
+  let preview = null;
+  let runs = [];
+  let loading = true;
+  let refreshing = false;
+  let connected = false;
+  let error = "";
+  let stream;
+  let launchingIds = [];
+
+  function mergeRun(run) {
+    if (!run) {
+      return;
+    }
+
+    const existingIndex = runs.findIndex((item) => item.run_id === run.run_id);
+    if (existingIndex >= 0) {
+      runs = runs.map((item, index) => (index === existingIndex ? run : item));
+      return;
+    }
+
+    runs = [run, ...runs].slice(0, 16);
+  }
+
+  async function loadData({ quiet = false } = {}) {
+    if (quiet) {
+      refreshing = true;
+    } else {
+      loading = true;
+    }
+    error = "";
+
+    try {
+      const [nextPreview, nextRuns] = await Promise.all([getExecutionPreview(), listExecutionRuns()]);
+      preview = nextPreview;
+      runs = nextRuns;
+    } catch (loadError) {
+      error = loadError.message;
+    } finally {
+      loading = false;
+      refreshing = false;
+    }
+  }
+
+  async function launchNode(node) {
+    launchingIds = [...launchingIds, node.id];
+    error = "";
+
+    try {
+      const result = await launchExecutionRun({ work_item_id: node.id });
+      mergeRun(result.run);
+      await loadData({ quiet: true });
+    } catch (launchError) {
+      error = launchError.message;
+    } finally {
+      launchingIds = launchingIds.filter((id) => id !== node.id);
+    }
+  }
+
+  onMount(() => {
+    loadData();
+
+    stream = new EventSource("/api/execution/stream");
+    stream.addEventListener("open", () => {
+      connected = true;
+    });
+    stream.addEventListener("error", () => {
+      connected = false;
+    });
+
+    const handleEnvelope = (event) => {
+      try {
+        const envelope = JSON.parse(event.data);
+        mergeRun(envelope.payload?.run);
+      } catch (streamError) {
+        console.error("Failed to parse execution SSE event", streamError);
+      }
+    };
+
+    stream.addEventListener("execution_status", handleEnvelope);
+    stream.addEventListener("execution_result", handleEnvelope);
+
+    return () => {
+      stream?.close();
+    };
+  });
+</script>
+
+<section class="card execution-panel">
+  <div class="panel-header execution-header">
+    <div>
+      <h2>Execution dispatch</h2>
+      <p class="muted">Preview dispatchable work, launch isolated execution runs, and watch recent run state.</p>
+    </div>
+    <div class="status-cluster">
+      <span class:healthy={connected} class="status-pill">{connected ? "Execution stream connected" : "Execution stream reconnecting"}</span>
+      <button class="secondary" on:click={() => loadData({ quiet: true })} disabled={refreshing || loading}>{refreshing ? "Refreshing..." : "Refresh dispatch"}</button>
+    </div>
+  </div>
+
+  {#if error}
+    <div class="banner error">{error}</div>
+  {/if}
+
+  {#if loading}
+    <div class="empty-state">Loading execution dispatch preview…</div>
+  {:else if !preview}
+    <div class="empty-state">Execution preview unavailable.</div>
+  {:else}
+    <div class="execution-summary-grid">
+      <div class="execution-summary-card">
+        <strong>Dispatchable now</strong>
+        <span>{preview.summary.dispatchable_now}</span>
+      </div>
+      <div class="execution-summary-card">
+        <strong>Blocked</strong>
+        <span>{preview.summary.blocked_count}</span>
+      </div>
+      <div class="execution-summary-card">
+        <strong>Parallel groups</strong>
+        <span>{preview.groups.length}</span>
+      </div>
+      <div class="execution-summary-card">
+        <strong>Max concurrent heavy tasks</strong>
+        <span>{preview.validation_policy.max_concurrent_node_heavy_tasks}</span>
+      </div>
+    </div>
+
+    {#if preview.assumptions?.length}
+      <details class="execution-assumptions">
+        <summary>Dispatch assumptions</summary>
+        <ul>
+          {#each preview.assumptions as assumption}
+            <li>{assumption}</li>
+          {/each}
+        </ul>
+      </details>
+    {/if}
+
+    <div class="execution-groups">
+      {#if preview.groups.length === 0}
+        <p class="muted">No dispatchable execution groups yet.</p>
+      {/if}
+
+      {#each preview.groups as group}
+        <section class="dispatch-group-card">
+          <div class="dispatch-group-header">
+            <div>
+              <h3>{group.group_id}</h3>
+              <p class="muted">Repo: {group.repo} · {group.nodes.length} launchable node(s)</p>
+            </div>
+            {#if group.merge_order?.length}
+              <span class="proposal-type">Merge order: {group.merge_order.join(" → ")}</span>
+            {/if}
+          </div>
+
+          <div class="dispatch-node-list">
+            {#each group.nodes as node}
+              <article class="dispatch-node-card">
+                <div class="dispatch-node-header">
+                  <div>
+                    <strong>{node.id}</strong>
+                    <div>{node.name}</div>
+                  </div>
+                  <button on:click={() => launchNode(node)} disabled={!node.can_launch || launchingIds.includes(node.id)}>
+                    {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? "Launch" : "Blocked"}
+                  </button>
+                </div>
+
+                <div class="muted small-text">{node.branch} · {node.worktree_path}</div>
+                {#if node.scope_hint}
+                  <p>{node.scope_hint}</p>
+                {/if}
+
+                <details>
+                  <summary>Scope and safety</summary>
+                  <div class="dispatch-scope-grid">
+                    <div>
+                      <div class="muted">Owned files</div>
+                      <ul>
+                        {#if node.files_owned.length}
+                          {#each node.files_owned as path}<li>{path}</li>{/each}
+                        {:else}
+                          <li>(none predicted)</li>
+                        {/if}
+                      </ul>
+                    </div>
+                    <div>
+                      <div class="muted">Forbidden files</div>
+                      <ul>
+                        {#if node.files_forbidden.length}
+                          {#each node.files_forbidden as path}<li>{path}</li>{/each}
+                        {:else}
+                          <li>(none)</li>
+                        {/if}
+                      </ul>
+                    </div>
+                  </div>
+                  <div class="execution-check-list">
+                    {#each node.safety_checks as check}
+                      <div class="execution-check {check.status}">
+                        <strong>{check.code}</strong>
+                        <span>{check.message}</span>
+                      </div>
+                    {/each}
+                  </div>
+                </details>
+              </article>
+            {/each}
+          </div>
+        </section>
+      {/each}
+    </div>
+
+    <section class="dispatch-group-card">
+      <div class="dispatch-group-header">
+        <div>
+          <h3>Recent execution runs</h3>
+          <p class="muted">Status snapshots persist under the external artifact root.</p>
+        </div>
+      </div>
+
+      {#if runs.length === 0}
+        <p class="muted">No execution runs launched yet.</p>
+      {:else}
+        <div class="dispatch-node-list">
+          {#each runs as run}
+            <article class="dispatch-node-card execution-run-card">
+              <div class="dispatch-node-header">
+                <div>
+                  <strong>{run.work_item_id}</strong>
+                  <div>{run.work_item_name}</div>
+                </div>
+                <span class="proposal-type">{run.status}</span>
+              </div>
+              <div class="muted small-text">{run.branch} · {run.worktree_path}</div>
+              <div class="muted small-text">Artifacts: {run.artifact_dir}</div>
+              {#if run.progress_message}
+                <p>{run.progress_message}</p>
+              {/if}
+              {#if run.result_summary}
+                <details>
+                  <summary>Result summary</summary>
+                  <pre>{run.result_summary}</pre>
+                </details>
+              {/if}
+              {#if run.changed_files?.length}
+                <details>
+                  <summary>Changed files</summary>
+                  <ul>
+                    {#each run.changed_files as path}<li>{path}</li>{/each}
+                  </ul>
+                </details>
+              {/if}
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
+</section>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -62,6 +62,30 @@ export function getGitHubIssueDetails({ repo, issue_number }) {
   return request(`/api/github/issue?${query.toString()}`);
 }
 
+export function getExecutionPreview(params = {}) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const search = query.toString();
+  return request(`/api/execution/preview${search ? `?${search}` : ""}`);
+}
+
+export function listExecutionRuns() {
+  return request("/api/execution/runs");
+}
+
+export function launchExecutionRun(payload) {
+  return request("/api/execution/launch", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {


### PR DESCRIPTION
## Summary
Add the first Studio-owned execution dispatch layer so the browser can preview dispatchable frontier work, inspect launch safety, start isolated worktree-backed execution runs, stream run status, and inspect persisted execution artifacts.

Closes #11

## Changes
- add `ExecutionModule` with preview, launch, recent-runs, and SSE endpoints
- derive dispatch preview from the graph plan and annotate per-node worktree/branch safety checks
- launch coding-agent sessions in isolated git worktrees under `/home/marc/escapement-studio-ctx/worktrees/`
- persist execution run artifacts under `/home/marc/escapement-studio-ctx/runs/<run_id>/`
- add browser dispatch preview, launch controls, and recent execution run UI
- document execution endpoints and stream events in `README.md` and `docs/contracts/event-stream.md`

## Testing
- `npm run build`
- manual `GET /api/execution/preview`
- manual `GET /api/execution/runs`
- manual `POST /api/execution/launch`
- manual `GET /api/execution/stream`
- manual successful isolated execution run verification
- manual blocked relaunch verification for existing branch/worktree collision
- manual artifact inspection for `metadata.json`, `status.json`, `events.jsonl`, `summary.md`, and `outputs/response.json`
- manual Vite proxy verification for `/api/execution/preview`

## Notes
- launch safety currently warns on tracked changes in the main checkout because execution still runs in an isolated worktree and does not mutate the active repo state
- successful runs currently retain their worktrees for inspection under the external context root
