### PR TITLE
feat: add reconciliation workflow and drift reporting (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,17 @@ This runs the server TypeScript check plus the production frontend build.
 22. Launch a dispatchable execution run and confirm status updates stream into the browser from `GET /api/execution/stream`.
 23. Confirm the launched run creates an isolated worktree under `/home/marc/escapement-studio-ctx/worktrees/` and artifacts under `/home/marc/escapement-studio-ctx/runs/`.
 24. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
-25. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
-26. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, and recent execution runs are restored.
-27. Verify the graph view still loads data from `/api/graph`.
-28. Select a node to edit it in the sidebar.
-29. Create a new work item in the sidebar and confirm it appears in the graph.
-30. Create an edge between two nodes and confirm it appears in the graph and edge list.
-31. Delete an edge from the sidebar.
-32. Change repo/state/track/phase filters and confirm the rendered graph updates.
+25. Confirm the completed execution run auto-populates the related work item `actual_files` from the recorded `changed_files`.
+26. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
+27. Ask the planner to delegate a `reconciliation-analyst` or call `reconciliation_query`, then stage a planning-memory update based on the reported drift and approve it through the existing memory approval flow.
+28. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
+29. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
+30. Verify the graph view still loads data from `/api/graph`.
+31. Select a node to edit it in the sidebar.
+32. Create a new work item in the sidebar and confirm it appears in the graph.
+33. Create an edge between two nodes and confirm it appears in the graph and edge list.
+34. Delete an edge from the sidebar.
+35. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -220,6 +223,7 @@ curl http://localhost:3000/api/agent/session
 
 The snapshot returns the recent planner transcript plus active proposal/memory/GitHub-sync state and recent specialist runs used by the browser to restore workspace state after refresh.
 Execution runs are restored separately from `GET /api/execution/runs`.
+Reconciliation reports are restored from `GET /api/reconciliation/reports`.
 
 ### Root planner message + stream
 
@@ -308,6 +312,15 @@ Execution artifacts are persisted under:
 ```
 
 Blocked launches return `accepted: false` plus a run record with `status: "blocked"` and explicit safety check failures.
+
+### Read reconciliation reports
+
+```bash
+curl http://localhost:3000/api/reconciliation/reports
+curl http://localhost:3000/api/reconciliation/reports?work_item_id=studio-10
+```
+
+Each report compares `predicted_files` to the work item's recorded `actual_files`, links back to recent completed execution runs when available, and summarizes drift/overlap patterns that can be fed back into planning memory.
 
 ### Read a GitHub issue linked to a work item
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,8 +4,9 @@ import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { PlanningModule } from "./modules/planning/planning.module.js";
+import { ReconciliationModule } from "./modules/reconciliation/reconciliation.module.js";
 
 @Module({
-  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule],
+  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, ReconciliationModule],
 })
 export class AppModule {}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -205,18 +205,19 @@ export class ExecutionService {
 
     const assistantText = session.getLastAssistantText()?.trim() ?? "Execution run completed without a terminal summary.";
     const changedFiles = this.listChangedFiles(run.worktree_path);
+    const actualFilesSync = this.syncActualFiles(run.work_item_id, changedFiles);
     mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
-    writeFileSync(join(run.artifact_dir, "outputs", "response.json"), JSON.stringify({ assistant_text: assistantText, changed_files: changedFiles }, null, 2), "utf8");
+    writeFileSync(join(run.artifact_dir, "outputs", "response.json"), JSON.stringify({ assistant_text: assistantText, changed_files: changedFiles, actual_files_sync: actualFilesSync }, null, 2), "utf8");
 
     run = this.updateRun(initialRun.run_id, {
       status: "completed",
       completed_at: this.now(),
-      progress_message: "Execution run completed.",
-      result_summary: assistantText,
+      progress_message: actualFilesSync.ok ? "Execution run completed. actual_files updated on the work item." : "Execution run completed.",
+      result_summary: actualFilesSync.ok ? `${assistantText}\n\nactual_files synced: ${changedFiles.length} file(s).` : assistantText,
       changed_files: changedFiles,
     })!;
     this.writeSummary(run, node);
-    this.appendEvent(run, { type: "run_completed", changed_files: changedFiles });
+    this.appendEvent(run, { type: "run_completed", changed_files: changedFiles, actual_files_sync: actualFilesSync });
     this.emitRun("execution_result", run);
   }
 
@@ -498,6 +499,17 @@ export class ExecutionService {
       .map((line) => line.trim())
       .filter(Boolean)
       .map((line) => line.slice(3).trim());
+  }
+
+  private syncActualFiles(workItemId: string, changedFiles: string[]): { ok: true; actual_files: string[] } | { ok: false; message: string } {
+    try {
+      const actualFiles = [...new Set(changedFiles.filter(Boolean))].sort();
+      this.workItemsService.update(workItemId, { actual_files: actualFiles });
+      return { ok: true, actual_files: actualFiles };
+    } catch (error) {
+      this.logger.warn(`Failed to sync actual_files for ${workItemId}: ${this.getErrorMessage(error)}`);
+      return { ok: false, message: this.getErrorMessage(error) };
+    }
   }
 
   private getWorktreePath(branch: string): string {

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -6,9 +6,10 @@ import { MemoryService } from "./memory.service.js";
 import { PlanningController } from "./planning.controller.js";
 import { PlanningService } from "./planning.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
+import { ReconciliationModule } from "../reconciliation/reconciliation.module.js";
 
 @Module({
-  imports: [GraphModule, GitHubModule],
+  imports: [GraphModule, GitHubModule, ReconciliationModule],
   controllers: [PlanningController],
   providers: [PlanningService, ContextService, MemoryService, SubAgentService],
   exports: [PlanningService, ContextService, MemoryService, SubAgentService],

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -20,6 +20,7 @@ import type {
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
+import { ReconciliationService } from "../reconciliation/reconciliation.service.js";
 import type {
   ApproveGitHubSyncDto,
   ApproveMutationProposalDto,
@@ -46,6 +47,7 @@ import type {
   SendAgentMessageResult,
   StudioSseEnvelope,
   UpdateWorkItemPayload,
+  ReconciliationQueryToolInput,
 } from "./types.js";
 
 @Injectable()
@@ -78,6 +80,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     @Inject(MemoryService) private readonly memoryService: MemoryService,
     @Inject(SubAgentService) private readonly subAgentService: SubAgentService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(ReconciliationService) private readonly reconciliationService: ReconciliationService,
   ) {}
 
   async onModuleInit() {
@@ -297,6 +300,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         this.createDelegateSubAgentTool(),
         this.createGitHubReadTool(),
         this.createGitHubSyncTool(),
+        this.createReconciliationQueryTool(),
       ],
     });
 
@@ -544,7 +548,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         "Keep the delegated task narrow and include focus paths or work item ids when useful.",
       ],
       parameters: Type.Object({
-        agent_type: Type.Union([Type.Literal("code-crawler"), Type.Literal("scope-predictor")]),
+        agent_type: Type.Union([Type.Literal("code-crawler"), Type.Literal("scope-predictor"), Type.Literal("reconciliation-analyst")]),
         task: Type.String(),
         repo: Type.Optional(Type.String()),
         focus_paths: Type.Optional(Type.Array(Type.String())),
@@ -621,6 +625,32 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         return {
           content: [{ type: "text", text: `Staged GitHub sync ${sync.sync_id} with ${sync.operations.length} operation(s).` }],
           details: { sync },
+        };
+      },
+    });
+  }
+
+  private createReconciliationQueryTool() {
+    return defineTool({
+      name: "reconciliation_query",
+      label: "Reconciliation Query",
+      description: "Read deterministic predicted-vs-actual reconciliation reports for recent or specific work items.",
+      promptSnippet: "reconciliation_query: inspect reconciliation reports before explaining drift or proposing planning memory learnings.",
+      promptGuidelines: [
+        "Use reconciliation_query when you need deterministic predicted-vs-actual comparison data.",
+        "Prefer a specific work_item_id when discussing one execution run or one work item's drift.",
+      ],
+      parameters: Type.Object({
+        work_item_id: Type.Optional(Type.String()),
+      }),
+      execute: async (_toolCallId, params: ReconciliationQueryToolInput) => {
+        const result = params.work_item_id
+          ? this.reconciliationService.getReport(params.work_item_id)
+          : this.reconciliationService.listReports();
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
         };
       },
     });

--- a/src/modules/planning/sub-agent.service.ts
+++ b/src/modules/planning/sub-agent.service.ts
@@ -201,6 +201,12 @@ export class SubAgentService {
           "Prioritize findings of kinds: predicted_file, predicted_module, likely_dependency, uncertainty.",
           "Focus on bounded predicted impact, not exhaustive dumps.",
         ].join(" ");
+      case "reconciliation-analyst":
+        return [
+          "Your job is to compare predicted scope to actual execution results and explain planning drift clearly.",
+          "Prioritize findings of kinds: prediction_match, prediction_miss, overprediction, drift_pattern, recommendation.",
+          "Focus on concise reconciliation learnings that can improve future planning and memory.",
+        ].join(" ");
     }
   }
 

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -4,7 +4,7 @@ import type { ApplyGraphMutationsResult, EdgeRel, WorkItemKind, WorkItemState } 
 export type PlanningContextGraphMode = "default" | "focused" | "full";
 export type PlanningMutationType = "create_work_item" | "update_work_item" | "create_edge" | "delete_edge" | "delete_work_item";
 export type PlanningMemoryEditKind = "replace_text" | "insert_after_heading" | "delete_text";
-export type SubAgentType = "code-crawler" | "scope-predictor";
+export type SubAgentType = "code-crawler" | "scope-predictor" | "reconciliation-analyst";
 export type SubAgentRunStatus = "queued" | "running" | "completed" | "error";
 export type SubAgentConfidence = "low" | "medium" | "high";
 export type GitHubSyncOperationKind = "update_managed_body_block";
@@ -413,6 +413,10 @@ export interface GraphQueryToolInput {
   state?: WorkItemState;
   track?: string;
   phase?: string;
+}
+
+export interface ReconciliationQueryToolInput {
+  work_item_id?: string;
 }
 
 export interface CreateWorkItemPayload {

--- a/src/modules/reconciliation/reconciliation.controller.ts
+++ b/src/modules/reconciliation/reconciliation.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Inject, Query } from "@nestjs/common";
+import { ReconciliationService } from "./reconciliation.service.js";
+
+@Controller("api/reconciliation")
+export class ReconciliationController {
+  constructor(@Inject(ReconciliationService) private readonly reconciliationService: ReconciliationService) {}
+
+  @Get("reports")
+  listReports(@Query("work_item_id") workItemId?: string) {
+    return workItemId
+      ? this.reconciliationService.getReport(workItemId)
+      : this.reconciliationService.listReports();
+  }
+}

--- a/src/modules/reconciliation/reconciliation.module.ts
+++ b/src/modules/reconciliation/reconciliation.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { ExecutionModule } from "../execution/execution.module.js";
+import { GraphModule } from "../graph/graph.module.js";
+import { ReconciliationController } from "./reconciliation.controller.js";
+import { ReconciliationService } from "./reconciliation.service.js";
+
+@Module({
+  imports: [GraphModule, ExecutionModule],
+  controllers: [ReconciliationController],
+  providers: [ReconciliationService],
+  exports: [ReconciliationService],
+})
+export class ReconciliationModule {}

--- a/src/modules/reconciliation/reconciliation.service.ts
+++ b/src/modules/reconciliation/reconciliation.service.ts
@@ -1,0 +1,181 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { ExecutionService } from "../execution/execution.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { WorkItemRecord } from "../graph/types.js";
+import type { ExecutionRunRecord } from "../execution/types.js";
+import type {
+  ReconciliationDriftPattern,
+  ReconciliationOverlap,
+  ReconciliationReport,
+  ReconciliationRunReference,
+} from "./types.js";
+
+@Injectable()
+export class ReconciliationService {
+  constructor(
+    @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(ExecutionService) private readonly executionService: ExecutionService,
+  ) {}
+
+  listReports(workItemId?: string): ReconciliationReport[] {
+    const workItems = workItemId
+      ? [this.workItemsService.get(workItemId)]
+      : this.workItemsService.list().filter((item) => item.actual_files.length > 0 || item.predicted_files.length > 0);
+
+    const allWorkItems = this.workItemsService.list();
+    const completedRuns = this.executionService.listRecentRuns().filter((run) => run.status === "completed");
+
+    return workItems
+      .map((workItem) => this.buildReport(workItem, allWorkItems, completedRuns))
+      .sort((a, b) => {
+        const aTime = a.latest_run?.completed_at ?? "";
+        const bTime = b.latest_run?.completed_at ?? "";
+        return bTime.localeCompare(aTime) || a.work_item_id.localeCompare(b.work_item_id);
+      });
+  }
+
+  getReport(workItemId: string): ReconciliationReport {
+    return this.listReports(workItemId)[0];
+  }
+
+  private buildReport(
+    workItem: WorkItemRecord,
+    allWorkItems: WorkItemRecord[],
+    completedRuns: ExecutionRunRecord[],
+  ): ReconciliationReport {
+    const predictedFiles = this.uniqueSorted(workItem.predicted_files);
+    const actualFiles = this.uniqueSorted(workItem.actual_files);
+    const matched = predictedFiles.filter((file) => actualFiles.includes(file));
+    const missed = predictedFiles.filter((file) => !actualFiles.includes(file));
+    const unpredicted = actualFiles.filter((file) => !predictedFiles.includes(file));
+    const overlapCandidates = this.computeOverlapCandidates(workItem, allWorkItems, actualFiles);
+    const recentRuns = completedRuns
+      .filter((run) => run.work_item_id === workItem.id)
+      .map((run) => this.toRunReference(run));
+    const latestRun = recentRuns[0] ?? null;
+    const driftPatterns = this.computeDriftPatterns(predictedFiles, actualFiles, matched, missed, unpredicted, overlapCandidates);
+
+    return {
+      work_item_id: workItem.id,
+      work_item_name: workItem.name,
+      repo: workItem.repo,
+      issue_url: workItem.issue_url,
+      predicted_files: predictedFiles,
+      actual_files: actualFiles,
+      comparison: {
+        matched_files: matched,
+        missed_predicted_files: missed,
+        unpredicted_actual_files: unpredicted,
+      },
+      overlap_candidates: overlapCandidates,
+      drift_patterns: driftPatterns,
+      latest_run: latestRun,
+      recent_runs: recentRuns,
+      stats: {
+        predicted_count: predictedFiles.length,
+        actual_count: actualFiles.length,
+        matched_count: matched.length,
+        missed_count: missed.length,
+        unpredicted_count: unpredicted.length,
+        overlap_count: overlapCandidates.length,
+      },
+    };
+  }
+
+  private computeOverlapCandidates(
+    workItem: WorkItemRecord,
+    allWorkItems: WorkItemRecord[],
+    actualFiles: string[],
+  ): ReconciliationOverlap[] {
+    return actualFiles
+      .map((file) => {
+        const overlappingWorkItemIds = allWorkItems
+          .filter((candidate) => candidate.id !== workItem.id)
+          .filter((candidate) => candidate.predicted_files.includes(file))
+          .map((candidate) => candidate.id)
+          .sort();
+
+        return {
+          file,
+          overlapping_work_item_ids: overlappingWorkItemIds,
+        } satisfies ReconciliationOverlap;
+      })
+      .filter((item) => item.overlapping_work_item_ids.length > 0);
+  }
+
+  private computeDriftPatterns(
+    predictedFiles: string[],
+    actualFiles: string[],
+    matched: string[],
+    missed: string[],
+    unpredicted: string[],
+    overlapCandidates: ReconciliationOverlap[],
+  ): ReconciliationDriftPattern[] {
+    const patterns: ReconciliationDriftPattern[] = [];
+
+    if (predictedFiles.length === 0 && actualFiles.length > 0) {
+      patterns.push({
+        kind: "no_prediction",
+        summary: `Execution changed ${actualFiles.length} file(s) without any predicted file scope recorded on the work item.`,
+      });
+    }
+
+    if (predictedFiles.length > 0 && actualFiles.length === 0) {
+      patterns.push({
+        kind: "no_actual_changes",
+        summary: `The work item predicted ${predictedFiles.length} file(s), but no actual changed files were recorded yet.`,
+      });
+    }
+
+    if (missed.length === 0 && unpredicted.length === 0 && predictedFiles.length > 0 && actualFiles.length > 0) {
+      patterns.push({
+        kind: "exact_match",
+        summary: `Predicted and actual file scope matched exactly across ${matched.length} file(s).`,
+      });
+    }
+
+    if (missed.length > 0 && unpredicted.length === 0) {
+      patterns.push({
+        kind: "overprediction",
+        summary: `${missed.length} predicted file(s) were not actually touched. Planning may be overestimating implementation scope.`,
+      });
+    }
+
+    if (unpredicted.length > 0 && missed.length === 0) {
+      patterns.push({
+        kind: "unpredicted_change",
+        summary: `${unpredicted.length} changed file(s) were outside the predicted scope. Planning may be missing downstream impact.`,
+      });
+    }
+
+    if (unpredicted.length > 0 && missed.length > 0) {
+      patterns.push({
+        kind: "mixed_drift",
+        summary: `Prediction drift was mixed: ${missed.length} predicted file(s) were untouched and ${unpredicted.length} actual file(s) were unpredicted.`,
+      });
+    }
+
+    if (overlapCandidates.length > 0) {
+      patterns.push({
+        kind: "mixed_drift",
+        summary: `${overlapCandidates.length} changed file(s) also appear in other work items' predicted scope, suggesting overlap risk.`,
+      });
+    }
+
+    return patterns;
+  }
+
+  private toRunReference(run: ExecutionRunRecord): ReconciliationRunReference {
+    return {
+      run_id: run.run_id,
+      status: run.status,
+      completed_at: run.completed_at,
+      artifact_dir: run.artifact_dir,
+      changed_files: run.changed_files ?? [],
+    };
+  }
+
+  private uniqueSorted(values: string[]): string[] {
+    return [...new Set(values.filter(Boolean))].sort();
+  }
+}

--- a/src/modules/reconciliation/types.ts
+++ b/src/modules/reconciliation/types.ts
@@ -1,0 +1,45 @@
+export interface ReconciliationFileComparison {
+  matched_files: string[];
+  missed_predicted_files: string[];
+  unpredicted_actual_files: string[];
+}
+
+export interface ReconciliationOverlap {
+  file: string;
+  overlapping_work_item_ids: string[];
+}
+
+export interface ReconciliationDriftPattern {
+  kind: "exact_match" | "overprediction" | "unpredicted_change" | "mixed_drift" | "no_prediction" | "no_actual_changes";
+  summary: string;
+}
+
+export interface ReconciliationRunReference {
+  run_id: string;
+  status: string;
+  completed_at?: string;
+  artifact_dir: string;
+  changed_files: string[];
+}
+
+export interface ReconciliationReport {
+  work_item_id: string;
+  work_item_name: string;
+  repo: string | null;
+  issue_url: string | null;
+  predicted_files: string[];
+  actual_files: string[];
+  comparison: ReconciliationFileComparison;
+  overlap_candidates: ReconciliationOverlap[];
+  drift_patterns: ReconciliationDriftPattern[];
+  latest_run: ReconciliationRunReference | null;
+  recent_runs: ReconciliationRunReference[];
+  stats: {
+    predicted_count: number;
+    actual_count: number;
+    matched_count: number;
+    missed_count: number;
+    unpredicted_count: number;
+    overlap_count: number;
+  };
+}

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,6 +1,7 @@
 <script>
   import PlannerChatAdapter from "./components/PlannerChatAdapter.svelte";
   import ExecutionDispatchPanel from "./components/ExecutionDispatchPanel.svelte";
+  import ReconciliationPanel from "./components/ReconciliationPanel.svelte";
   import GraphView from "./components/GraphView.svelte";
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
@@ -177,6 +178,7 @@
 
   <PlannerChatAdapter on:graphChanged={refresh} />
   <ExecutionDispatchPanel />
+  <ReconciliationPanel />
 
   <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -640,6 +640,44 @@ h2 {
   background: rgba(15, 23, 42, 0.4);
 }
 
+.reconciliation-panel {
+  width: min(1500px, 100%);
+  margin: 0 auto;
+  padding: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.reconciliation-report-list,
+.reconciliation-drift-list,
+.reconciliation-stat-pills {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.reconciliation-drift-list {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.reconciliation-drift-list li {
+  color: #cbd5e1;
+}
+
+.reconciliation-drift-list strong {
+  color: #f8fafc;
+  margin-right: 0.5rem;
+}
+
+.reconciliation-stat-pills {
+  grid-auto-flow: column;
+  justify-content: start;
+}
+
+.reconciliation-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 @media (max-width: 1200px) {
   .layout,
   .planner-body {
@@ -650,7 +688,8 @@ h2 {
   .toolbar,
   .sync-preview-grid,
   .execution-summary-grid,
-  .dispatch-scope-grid {
+  .dispatch-scope-grid,
+  .reconciliation-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
@@ -671,7 +710,8 @@ h2 {
   .planner-actions,
   .sync-preview-grid,
   .execution-summary-grid,
-  .dispatch-scope-grid {
+  .dispatch-scope-grid,
+  .reconciliation-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -707,7 +707,7 @@
     <div class="proposal-header">
       <div>
         <h3>Recent specialist runs</h3>
-        <p class="muted">Ephemeral code-crawler and scope-predictor runs delegated by the planner.</p>
+        <p class="muted">Ephemeral code-crawler, scope-predictor, and reconciliation-analyst runs delegated by the planner.</p>
       </div>
     </div>
 
@@ -751,7 +751,7 @@
   <div class="planner-composer">
     <label>
       Message
-      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, delegate specialists, propose memory updates, or explain blockers."></textarea>
+      <textarea bind:value={draft} rows="4" placeholder="Ask the planner to inspect the graph, delegate specialists, review reconciliation drift, propose memory updates, or explain blockers."></textarea>
     </label>
     <div class="planner-actions">
       <button class="secondary" on:click={loadSnapshot} disabled={loading}>Refresh transcript</button>

--- a/web/src/components/ReconciliationPanel.svelte
+++ b/web/src/components/ReconciliationPanel.svelte
@@ -1,0 +1,144 @@
+<script>
+  import { onMount } from "svelte";
+  import { getReconciliationReports } from "../lib/api.js";
+
+  let reports = [];
+  let loading = true;
+  let refreshing = false;
+  let error = "";
+
+  async function loadReports({ quiet = false } = {}) {
+    if (quiet) {
+      refreshing = true;
+    } else {
+      loading = true;
+    }
+    error = "";
+
+    try {
+      const result = await getReconciliationReports();
+      reports = Array.isArray(result) ? result : [result];
+    } catch (loadError) {
+      error = loadError.message;
+    } finally {
+      loading = false;
+      refreshing = false;
+    }
+  }
+
+  onMount(() => {
+    loadReports();
+  });
+</script>
+
+<section class="card reconciliation-panel">
+  <div class="panel-header execution-header">
+    <div>
+      <h2>Reconciliation</h2>
+      <p class="muted">Compare predicted scope to actual execution output and inspect drift patterns.</p>
+    </div>
+    <div class="status-cluster">
+      <button class="secondary" on:click={() => loadReports({ quiet: true })} disabled={loading || refreshing}>
+        {refreshing ? 'Refreshing...' : 'Refresh reconciliation'}
+      </button>
+    </div>
+  </div>
+
+  {#if error}
+    <div class="banner error">{error}</div>
+  {/if}
+
+  {#if loading}
+    <div class="empty-state">Loading reconciliation reports…</div>
+  {:else if reports.length === 0}
+    <div class="empty-state">No reconciliation reports yet. Complete an execution run to populate actual file data.</div>
+  {:else}
+    <div class="reconciliation-report-list">
+      {#each reports as report}
+        <article class="dispatch-group-card reconciliation-report-card">
+          <div class="dispatch-group-header">
+            <div>
+              <h3>{report.work_item_id}</h3>
+              <p class="muted">{report.work_item_name}</p>
+            </div>
+            <div class="reconciliation-stat-pills">
+              <span class="status-pill healthy">matched {report.stats.matched_count}</span>
+              <span class="status-pill">missed {report.stats.missed_count}</span>
+              <span class="status-pill">unpredicted {report.stats.unpredicted_count}</span>
+            </div>
+          </div>
+
+          {#if report.latest_run}
+            <p class="muted small-text">
+              Latest run: <code>{report.latest_run.run_id}</code>
+              {#if report.latest_run.completed_at} · {new Date(report.latest_run.completed_at).toLocaleString()}{/if}
+            </p>
+            <p class="muted small-text">Artifacts: <code>{report.latest_run.artifact_dir}</code></p>
+          {/if}
+
+          {#if report.drift_patterns?.length}
+            <ul class="reconciliation-drift-list">
+              {#each report.drift_patterns as pattern}
+                <li>
+                  <strong>{pattern.kind}</strong>
+                  <span>{pattern.summary}</span>
+                </li>
+              {/each}
+            </ul>
+          {/if}
+
+          <div class="dispatch-scope-grid reconciliation-grid">
+            <div>
+              <div class="muted">Matched files</div>
+              <ul>
+                {#if report.comparison.matched_files.length}
+                  {#each report.comparison.matched_files as file}<li>{file}</li>{/each}
+                {:else}
+                  <li>(none)</li>
+                {/if}
+              </ul>
+            </div>
+            <div>
+              <div class="muted">Missed predicted files</div>
+              <ul>
+                {#if report.comparison.missed_predicted_files.length}
+                  {#each report.comparison.missed_predicted_files as file}<li>{file}</li>{/each}
+                {:else}
+                  <li>(none)</li>
+                {/if}
+              </ul>
+            </div>
+            <div>
+              <div class="muted">Unpredicted actual files</div>
+              <ul>
+                {#if report.comparison.unpredicted_actual_files.length}
+                  {#each report.comparison.unpredicted_actual_files as file}<li>{file}</li>{/each}
+                {:else}
+                  <li>(none)</li>
+                {/if}
+              </ul>
+            </div>
+          </div>
+
+          {#if report.overlap_candidates?.length}
+            <details>
+              <summary>Overlap candidates</summary>
+              <ul class="subagent-findings">
+                {#each report.overlap_candidates as overlap}
+                  <li>
+                    <code>{overlap.file}</code>
+                    <div>Also predicted by: {overlap.overlapping_work_item_ids.join(', ')}</div>
+                  </li>
+                {/each}
+              </ul>
+            </details>
+          {/if}
+
+          {#if report.issue_url}
+            <p><a href={report.issue_url} target="_blank" rel="noreferrer">Open linked issue</a></p>
+          {/if}
+        </article>
+      {/each}
+    </div>
+  {/if}
+</section>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -86,6 +86,18 @@ export function launchExecutionRun(payload) {
   });
 }
 
+export function getReconciliationReports(params = {}) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const search = query.toString();
+  return request(`/api/reconciliation/reports${search ? `?${search}` : ""}`);
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {


### PR DESCRIPTION
## Summary
Add the first Studio reconciliation layer so completed execution runs can write back actual file impact, deterministic services can compare predicted vs actual scope, the planner can inspect and delegate reconciliation analysis, and the browser can review drift patterns.

Closes #12

## Changes
- add `ReconciliationModule` with deterministic report contracts, service logic, and `GET /api/reconciliation/reports`
- auto-sync successful execution `changed_files` into work item `actual_files`
- add planner `reconciliation_query` plus `reconciliation-analyst` specialist support
- add browser reconciliation UI for matches, misses, unpredicted files, overlap candidates, and drift summaries
- document reconciliation workflow, endpoints, and manual verification in `README.md`

## Testing
- `npm run build`
- manual successful execution run verification with automatic `actual_files` sync
- manual `GET /api/reconciliation/reports`
- manual planner `reconciliation_query`
- manual delegated `reconciliation-analyst` specialist run
- manual planning-memory staging from reconciliation output

## Notes
- reconciliation reports are deterministic and derived from work item predicted/actual files plus recent completed execution runs
- execution success now updates the related work item's `actual_files` automatically to keep reconciliation inspectable after refresh
