### PR TITLE
fix: preserve execution changed file paths for reconciliation

### DIFF
--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -496,9 +496,23 @@ export class ExecutionService {
     const output = execFileSync("git", ["status", "--short"], { cwd: worktreePath, encoding: "utf8" });
     return output
       .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => line.slice(3).trim());
+      .map((line) => this.parseChangedFilePath(line))
+      .filter((path): path is string => Boolean(path));
+  }
+
+  private parseChangedFilePath(line: string): string | null {
+    if (!line.trim()) {
+      return null;
+    }
+
+    const path = line.length > 3 ? line.slice(3) : line;
+    const renameSeparator = " -> ";
+    const renamedIndex = path.indexOf(renameSeparator);
+    if (renamedIndex >= 0) {
+      return path.slice(renamedIndex + renameSeparator.length).trim();
+    }
+
+    return path.trim();
   }
 
   private syncActualFiles(workItemId: string, changedFiles: string[]): { ok: true; actual_files: string[] } | { ok: false; message: string } {


### PR DESCRIPTION
## Summary
Fix execution changed-file parsing so recorded `changed_files` and reconciled `actual_files` preserve correct worktree-relative paths.

## Changes
- stop trimming git status lines before extracting the changed path
- add a dedicated changed-path parser for execution worktree status output
- handle rename output by recording the destination path after `old -> new`

## Testing
- `npm run check` *(currently fails in this isolated worktree because local dependencies/types are not installed here: `Cannot find type definition file for 'node'`)*

## Notes
- this fixes the `eb/...` path truncation bug seen in execution/reconciliation output for worktree changes under `web/...`
