### PR TITLE
feat: split workspace into planning and execute tabs (#33)

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -5,6 +5,7 @@
   import GraphView from "./components/GraphView.svelte";
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
+  import WorkspaceTabs from "./components/WorkspaceTabs.svelte";
   import {
     createEdge,
     createWorkItem,
@@ -27,6 +28,20 @@
   let error = "";
   let health = null;
   let selectedIssueDetails = null;
+  let activeTab = "planning";
+
+  const workspaceTabs = [
+    {
+      id: "planning",
+      label: "Planning",
+      description: "Planner chat, filters, dependency graph, and work item editor.",
+    },
+    {
+      id: "execute",
+      label: "Execute",
+      description: "Dispatch execution work and review reconciliation output.",
+    },
+  ];
 
   $: selectedItem = graph.items.find((item) => item.id === selectedId) ?? null;
   $: filterOptions = {
@@ -158,60 +173,89 @@
 </script>
 
 <svelte:head>
-  <title>Escapement Studio Graph Workspace</title>
+  <title>Escapement Studio Workspace</title>
 </svelte:head>
 
 <div class="app-shell">
   <header class="app-header">
     <div>
       <p class="eyebrow">Escapement Studio</p>
-      <h1>Graph workspace</h1>
-      <p class="muted">Live graph view and editor backed by the Studio API.</p>
+      <h1>Studio workspace</h1>
+      <p class="muted">
+        {activeTab === "planning"
+          ? "Plan work in the graph-backed workspace and keep edits synchronized with the Studio API."
+          : "Launch execution work and compare predicted scope with recorded execution results."}
+      </p>
     </div>
     <div class="status-cluster">
       <span class:healthy={health?.ok} class="status-pill">
         {health?.ok ? "API healthy" : "API unavailable"}
       </span>
-      <button class="secondary" on:click={refresh} disabled={loading}>Refresh</button>
+      {#if activeTab === "planning"}
+        <button class="secondary" on:click={refresh} disabled={loading}>Refresh graph</button>
+      {/if}
     </div>
   </header>
 
-  <PlannerChatAdapter on:graphChanged={refresh} />
-  <ExecutionDispatchPanel />
-  <ReconciliationPanel />
+  <WorkspaceTabs tabs={workspaceTabs} bind:activeTab />
 
-  <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
+  <section id="planning-panel" aria-labelledby="planning-tab" hidden={activeTab !== "planning"} class="workspace-panel">
+    <div class="planning-workspace">
+      <PlannerChatAdapter on:graphChanged={refresh} />
 
-  {#if error}
-    <div class="banner error">{error}</div>
-  {/if}
+      <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 
-  <main class="layout">
-    <section class="graph-panel card">
-      <div class="panel-header">
-        <div>
-          <h2>Dependency graph</h2>
-          <p class="muted">{graph.items.length} items · {graph.edges.length} edges</p>
-        </div>
-      </div>
-
-      {#if loading}
-        <div class="empty-state">Loading graph from the Studio server…</div>
-      {:else}
-        <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item.id)} />
+      {#if error}
+        <div class="banner error">{error}</div>
       {/if}
-    </section>
 
-    <Sidebar
-      {selectedItem}
-      issueDetails={selectedIssueDetails}
-      {graph}
-      {saving}
-      {edgeSaving}
-      onSaveItem={handleSaveItem}
-      onCreateItem={handleCreateItem}
-      onCreateEdge={handleCreateEdge}
-      onDeleteEdge={handleDeleteEdge}
-    />
-  </main>
+      <main class="layout">
+        <section class="graph-panel card">
+          <div class="panel-header">
+            <div>
+              <h2>Dependency graph</h2>
+              <p class="muted">{graph.items.length} items · {graph.edges.length} edges</p>
+            </div>
+          </div>
+
+          {#if loading}
+            <div class="empty-state">Loading graph from the Studio server…</div>
+          {:else}
+            <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item.id)} />
+          {/if}
+        </section>
+
+        <Sidebar
+          {selectedItem}
+          issueDetails={selectedIssueDetails}
+          {graph}
+          {saving}
+          {edgeSaving}
+          onSaveItem={handleSaveItem}
+          onCreateItem={handleCreateItem}
+          onCreateEdge={handleCreateEdge}
+          onDeleteEdge={handleDeleteEdge}
+        />
+      </main>
+    </div>
+  </section>
+
+  <section id="execute-panel" aria-labelledby="execute-tab" hidden={activeTab !== "execute"} class="workspace-panel">
+    <div class="execute-workspace">
+      <ExecutionDispatchPanel />
+      <ReconciliationPanel />
+    </div>
+  </section>
 </div>
+
+<style>
+  .workspace-panel {
+    display: grid;
+  }
+
+  .planning-workspace,
+  .execute-workspace {
+    display: grid;
+    gap: 1rem;
+  }
+</style>

--- a/web/src/components/WorkspaceTabs.svelte
+++ b/web/src/components/WorkspaceTabs.svelte
@@ -1,0 +1,83 @@
+<script>
+  export let tabs = [];
+  export let activeTab = tabs[0]?.id ?? "";
+
+  function handleKeydown(event, index) {
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+      return;
+    }
+
+    event.preventDefault();
+
+    const direction = event.key === "ArrowRight" ? 1 : -1;
+    const nextIndex = (index + direction + tabs.length) % tabs.length;
+    activeTab = tabs[nextIndex]?.id ?? activeTab;
+  }
+</script>
+
+<nav class="workspace-tabs" aria-label="Studio workspace sections">
+  <div class="workspace-tab-list" role="tablist" aria-orientation="horizontal">
+    {#each tabs as tab, index}
+      <button
+        id={`${tab.id}-tab`}
+        type="button"
+        role="tab"
+        class:active={activeTab === tab.id}
+        aria-controls={`${tab.id}-panel`}
+        aria-selected={activeTab === tab.id}
+        tabindex={activeTab === tab.id ? 0 : -1}
+        on:click={() => (activeTab = tab.id)}
+        on:keydown={(event) => handleKeydown(event, index)}
+      >
+        <span>{tab.label}</span>
+        {#if tab.description}
+          <small>{tab.description}</small>
+        {/if}
+      </button>
+    {/each}
+  </div>
+</nav>
+
+<style>
+  .workspace-tabs {
+    width: min(1500px, 100%);
+    margin: 0 auto;
+  }
+
+  .workspace-tab-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  button[role="tab"] {
+    display: grid;
+    gap: 0.2rem;
+    justify-items: start;
+    text-align: left;
+    padding: 0.95rem 1rem;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    color: #cbd5e1;
+  }
+
+  button[role="tab"] small {
+    color: #94a3b8;
+  }
+
+  button[role="tab"].active {
+    background: linear-gradient(180deg, rgba(37, 99, 235, 0.22), rgba(15, 23, 42, 0.92));
+    border-color: rgba(96, 165, 250, 0.5);
+    color: #eff6ff;
+  }
+
+  button[role="tab"].active small {
+    color: #bfdbfe;
+  }
+
+  @media (max-width: 720px) {
+    .workspace-tab-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
Split the Studio workspace into dedicated Planning and Execute tabs so graph/planner work and execution/reconciliation work have clearer separation in the UI.

Closes #33

## Changes
- add a reusable `WorkspaceTabs.svelte` tab control
- split `App.svelte` into planning vs execute workspace panels
- keep graph/planner flows in the Planning tab
- keep execution dispatch and reconciliation in the Execute tab

## Testing
- not run in this worktree
