### PR TITLE
feat: support PR creation from completed execution work (#29)

### DIFF
--- a/docs/contracts/run-artifacts.md
+++ b/docs/contracts/run-artifacts.md
@@ -57,6 +57,11 @@ Human-readable completion summary where practical.
 ### `outputs/`
 Optional extra outputs and attachments.
 
+Common execution outputs may include:
+
+- `response.json` — captured execution-agent terminal response and changed-file sync result
+- `pull-request.json` — created PR metadata when Studio opens a PR from completed work
+
 ## Run types
 
 Suggested V1 types:
@@ -71,3 +76,4 @@ Suggested V1 types:
 - `status.json` and SSE serve different purposes: current durable snapshot vs live browser transport
 - artifacts should be retained by default in V1
 - failed runs should still write terminal status, terminal event, and best-effort summary
+- when a PR is opened from a completed execution run, the run summary/status may also include the created PR URL for later browser refreshes

--- a/src/modules/execution/configured-execution.service.ts
+++ b/src/modules/execution/configured-execution.service.ts
@@ -10,9 +10,12 @@ import { GraphService } from "../graph/graph.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { WorkItemRecord } from "../graph/types.js";
 import type {
+  CreateExecutionPullRequestDto,
+  CreateExecutionPullRequestResult,
   ExecutionDispatchGroupPreview,
   ExecutionDispatchNodePreview,
   ExecutionDispatchPreview,
+  ExecutionPullRequestRecord,
   ExecutionRunRecord,
   ExecutionSafetyCheck,
   ExecutionStatusEvent,
@@ -164,6 +167,57 @@ export class ExecutionService {
     });
 
     return { accepted: true, run };
+  }
+
+  async createPullRequest(input: CreateExecutionPullRequestDto): Promise<CreateExecutionPullRequestResult> {
+    const runId = input.run_id?.trim();
+    if (!runId) {
+      throw new BadRequestException("run_id is required");
+    }
+
+    const run = this.getRun(runId);
+    if (!run) {
+      throw new BadRequestException(`Unknown execution run: ${runId}`);
+    }
+    if (run.status !== "completed") {
+      throw new BadRequestException(`Execution run ${runId} must be completed before creating a pull request`);
+    }
+    if (run.pull_request) {
+      return { run, pull_request: run.pull_request };
+    }
+
+    const workItem = this.workItemsService.get(run.work_item_id);
+    const baseRef = input.base_ref?.trim() || run.base_ref || getDefaultWorkingBranch(workItem.repo);
+    const title = input.title?.trim() || this.buildPullRequestTitle(workItem);
+    const body = input.body?.trim() || this.buildPullRequestBody(run, workItem, baseRef);
+    const aheadCount = this.countCommitsAhead(run.worktree_path, baseRef, run.branch);
+    if (aheadCount === 0) {
+      throw new BadRequestException(`Branch ${run.branch} has no commits ahead of ${baseRef}; nothing is ready to open as a pull request`);
+    }
+
+    this.runGitIn(run.worktree_path, ["push", "--set-upstream", "origin", run.branch]);
+    this.runGhIn(run.worktree_path, [
+      "pr",
+      "create",
+      "--base",
+      baseRef,
+      "--head",
+      run.branch,
+      "--title",
+      title,
+      "--body-file",
+      "-",
+      ...(input.draft ? ["--draft"] : []),
+    ], body);
+
+    const pullRequest = this.readPullRequest(run.worktree_path, title, body);
+    const nextRun = this.updateRun(run.run_id, { pull_request: pullRequest }) ?? run;
+    mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
+    writeFileSync(join(run.artifact_dir, "outputs", "pull-request.json"), JSON.stringify(pullRequest, null, 2), "utf8");
+    this.appendEvent(nextRun, { type: "pull_request_created", pull_request: pullRequest });
+    this.writeSummary(nextRun);
+
+    return { run: nextRun, pull_request: pullRequest };
   }
 
   private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview) {
@@ -452,6 +506,7 @@ export class ExecutionService {
       `- Updated: ${run.updated_at}`,
       ...(run.started_at ? [`- Started: ${run.started_at}`] : []),
       ...(run.completed_at ? [`- Completed: ${run.completed_at}`] : []),
+      ...(run.pull_request ? [`- Pull request: ${run.pull_request.url}`] : []),
       "",
       "## Safety checks",
       ...run.safety_checks.map((check) => `- [${check.status}] ${check.code}: ${check.message}`),
@@ -461,6 +516,15 @@ export class ExecutionService {
       run.result_summary ?? run.progress_message ?? "No summary available.",
       "",
       ...(run.changed_files?.length ? ["## Changed files", ...run.changed_files.map((path) => `- ${path}`), ""] : []),
+      ...(run.pull_request ? [
+        "## Pull request",
+        `- Number: ${run.pull_request.number}`,
+        `- URL: ${run.pull_request.url}`,
+        `- Draft: ${run.pull_request.is_draft ? "yes" : "no"}`,
+        `- Base: ${run.pull_request.base_ref}`,
+        `- Head: ${run.pull_request.head_ref}`,
+        "",
+      ] : []),
     ];
 
     writeFileSync(join(run.artifact_dir, "summary.md"), lines.join("\n"), "utf8");
@@ -489,8 +553,25 @@ export class ExecutionService {
   }
 
   private runGit(args: string[], options: { allowFailure?: boolean } = {}): string {
+    return this.runCommand("git", args, { cwd: process.cwd(), allowFailure: options.allowFailure });
+  }
+
+  private runGitIn(cwd: string, args: string[], options: { allowFailure?: boolean } = {}): string {
+    return this.runCommand("git", args, { cwd, allowFailure: options.allowFailure });
+  }
+
+  private runGhIn(cwd: string, args: string[], stdin?: string): string {
+    return this.runCommand("gh", args, { cwd, stdin });
+  }
+
+  private runCommand(command: string, args: string[], options: { cwd: string; stdin?: string; allowFailure?: boolean }): string {
     try {
-      return execFileSync("git", args, { cwd: process.cwd(), encoding: "utf8" });
+      return execFileSync(command, args, {
+        cwd: options.cwd,
+        input: options.stdin,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 4,
+      });
     } catch (error) {
       if (options.allowFailure) {
         return "";
@@ -506,6 +587,73 @@ export class ExecutionService {
       .map((line) => line.trim())
       .filter(Boolean)
       .map((line) => line.slice(3).trim());
+  }
+
+  private countCommitsAhead(worktreePath: string, baseRef: string, branch: string): number {
+    const output = this.runGitIn(worktreePath, ["rev-list", "--count", `${baseRef}..${branch}`], { allowFailure: true }).trim();
+    const parsed = Number(output);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private readPullRequest(worktreePath: string, fallbackTitle: string, body: string): ExecutionPullRequestRecord {
+    const raw = this.runGhIn(worktreePath, ["pr", "view", "--json", "number,url,title,body,baseRefName,headRefName,isDraft"]);
+    const parsed = JSON.parse(raw) as {
+      number?: number;
+      url?: string;
+      title?: string;
+      body?: string;
+      baseRefName?: string;
+      headRefName?: string;
+      isDraft?: boolean;
+    };
+
+    if (!Number.isInteger(parsed.number) || !parsed.url || !parsed.baseRefName || !parsed.headRefName) {
+      throw new BadRequestException("Created pull request could not be read back from GitHub safely");
+    }
+
+    return {
+      number: parsed.number,
+      url: parsed.url,
+      title: parsed.title?.trim() || fallbackTitle,
+      body: parsed.body ?? body,
+      base_ref: parsed.baseRefName,
+      head_ref: parsed.headRefName,
+      is_draft: Boolean(parsed.isDraft),
+      created_at: this.now(),
+    };
+  }
+
+  private buildPullRequestTitle(workItem: WorkItemRecord): string {
+    const issuePrefix = workItem.issue_number ? `[#${workItem.issue_number}] ` : "";
+    return `${issuePrefix}${workItem.name}`;
+  }
+
+  private buildPullRequestBody(run: ExecutionRunRecord, workItem: WorkItemRecord, baseRef: string): string {
+    const lines = [
+      "## Summary",
+      run.result_summary ?? run.progress_message ?? `Completed Studio execution run ${run.run_id}.`,
+      "",
+      "## Context",
+      `- Work item: ${workItem.id}`,
+      `- Issue: ${workItem.issue_url ?? "(not linked)"}`,
+      `- Base branch: ${baseRef}`,
+      `- Head branch: ${run.branch}`,
+      `- Artifact dir: ${run.artifact_dir}`,
+      `- Worktree: ${run.worktree_path}`,
+    ];
+
+    if (workItem.scope_hint) {
+      lines.push(`- Scope hint: ${workItem.scope_hint}`);
+    }
+
+    lines.push("", "## Changed files");
+    if (run.changed_files?.length) {
+      lines.push(...run.changed_files.map((path) => `- \`${path}\``));
+    } else {
+      lines.push("- (not recorded)");
+    }
+
+    return lines.join("\n");
   }
 
   private syncActualFiles(workItemId: string, changedFiles: string[]): { ok: true; actual_files: string[] } | { ok: false; message: string } {

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Inject, Post, Query, Sse } from "@nestjs/common"
 import type { MessageEvent } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { ExecutionService } from "./configured-execution.service.js";
-import type { LaunchExecutionRunDto } from "./types.js";
+import type { CreateExecutionPullRequestDto, LaunchExecutionRunDto } from "./types.js";
 
 @Controller("api/execution")
 export class ExecutionController {
@@ -21,6 +21,11 @@ export class ExecutionController {
   @Post("launch")
   launch(@Body() body: LaunchExecutionRunDto) {
     return this.executionService.launch(body);
+  }
+
+  @Post("pull-request")
+  createPullRequest(@Body() body: CreateExecutionPullRequestDto) {
+    return this.executionService.createPullRequest(body);
   }
 
   @Sse("stream")

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -84,6 +84,7 @@ export interface ExecutionRunRecord {
   progress_message?: string;
   result_summary?: string;
   changed_files?: string[];
+  pull_request?: ExecutionPullRequestRecord;
   safety_checks: ExecutionSafetyCheck[];
   errors?: Array<{ code: string; message: string }>;
 }
@@ -91,6 +92,30 @@ export interface ExecutionRunRecord {
 export interface LaunchExecutionRunResult {
   accepted: boolean;
   run: ExecutionRunRecord;
+}
+
+export interface ExecutionPullRequestRecord {
+  number: number;
+  url: string;
+  title: string;
+  body: string;
+  base_ref: string;
+  head_ref: string;
+  is_draft: boolean;
+  created_at: string;
+}
+
+export interface CreateExecutionPullRequestDto {
+  run_id: string;
+  title?: string;
+  body?: string;
+  base_ref?: string;
+  draft?: boolean;
+}
+
+export interface CreateExecutionPullRequestResult {
+  run: ExecutionRunRecord;
+  pull_request: ExecutionPullRequestRecord;
 }
 
 export interface ExecutionStatusEvent {


### PR DESCRIPTION
## Summary
Add execution-side PR creation so Studio can open a pull request from completed work without leaving the execution workflow.

Closes #29

## Changes
- add `POST /api/execution/pull-request`
- extend execution run records/types with durable PR metadata
- persist created PR details into run artifacts/status
- document `pull-request.json` in run artifact contracts

## Testing
- not run in this worktree
