### PR TITLE
feat: move execution surfaces under execute tab (#40)

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -199,53 +199,55 @@
 
   <WorkspaceTabs tabs={workspaceTabs} bind:activeTab />
 
-  <section id="planning-panel" aria-labelledby="planning-tab" hidden={activeTab !== "planning"} class="workspace-panel">
-    <div class="planning-workspace">
-      <PlannerChatAdapter on:graphChanged={refresh} />
+  {#if activeTab === "planning"}
+    <section id="planning-panel" role="tabpanel" aria-labelledby="planning-tab" class="workspace-panel">
+      <div class="planning-workspace">
+        <PlannerChatAdapter on:graphChanged={refresh} />
 
-      <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
+        <FiltersToolbar {filters} options={filterOptions} onChange={handleFilterChange} onReset={resetFilters} />
 
-      {#if error}
-        <div class="banner error">{error}</div>
-      {/if}
+        {#if error}
+          <div class="banner error">{error}</div>
+        {/if}
 
-      <main class="layout">
-        <section class="graph-panel card">
-          <div class="panel-header">
-            <div>
-              <h2>Dependency graph</h2>
-              <p class="muted">{graph.items.length} items · {graph.edges.length} edges</p>
+        <main class="layout">
+          <section class="graph-panel card">
+            <div class="panel-header">
+              <div>
+                <h2>Dependency graph</h2>
+                <p class="muted">{graph.items.length} items · {graph.edges.length} edges</p>
+              </div>
             </div>
-          </div>
 
-          {#if loading}
-            <div class="empty-state">Loading graph from the Studio server…</div>
-          {:else}
-            <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item.id)} />
-          {/if}
-        </section>
+            {#if loading}
+              <div class="empty-state">Loading graph from the Studio server…</div>
+            {:else}
+              <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item.id)} />
+            {/if}
+          </section>
 
-        <Sidebar
-          {selectedItem}
-          issueDetails={selectedIssueDetails}
-          {graph}
-          {saving}
-          {edgeSaving}
-          onSaveItem={handleSaveItem}
-          onCreateItem={handleCreateItem}
-          onCreateEdge={handleCreateEdge}
-          onDeleteEdge={handleDeleteEdge}
-        />
-      </main>
-    </div>
-  </section>
-
-  <section id="execute-panel" aria-labelledby="execute-tab" hidden={activeTab !== "execute"} class="workspace-panel">
-    <div class="execute-workspace">
-      <ExecutionDispatchPanel />
-      <ReconciliationPanel />
-    </div>
-  </section>
+          <Sidebar
+            {selectedItem}
+            issueDetails={selectedIssueDetails}
+            {graph}
+            {saving}
+            {edgeSaving}
+            onSaveItem={handleSaveItem}
+            onCreateItem={handleCreateItem}
+            onCreateEdge={handleCreateEdge}
+            onDeleteEdge={handleDeleteEdge}
+          />
+        </main>
+      </div>
+    </section>
+  {:else if activeTab === "execute"}
+    <section id="execute-panel" role="tabpanel" aria-labelledby="execute-tab" class="workspace-panel">
+      <div class="execute-workspace">
+        <ExecutionDispatchPanel />
+        <ReconciliationPanel />
+      </div>
+    </section>
+  {/if}
 </div>
 
 <style>

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -165,8 +165,8 @@
 <section class="card execution-panel">
   <div class="panel-header execution-header">
     <div>
-      <h2>Execute workspace</h2>
-      <p class="muted">Launch dispatchable work, track live runs, inspect worktree and branch context, and prep PR or sync follow-up without leaving this view.</p>
+      <h2>Dispatch execution work</h2>
+      <p class="muted">Launch dispatchable work, track live runs, inspect worktree and branch context, and prep PR or sync follow-up without leaving the Execute tab.</p>
     </div>
     <div class="status-cluster execution-toolbar">
       <span class:healthy={connected} class="status-pill">{connected ? "Execution stream connected" : "Execution stream reconnecting"}</span>

--- a/web/src/components/WorkspaceTabs.svelte
+++ b/web/src/components/WorkspaceTabs.svelte
@@ -3,6 +3,18 @@
   export let activeTab = tabs[0]?.id ?? "";
 
   function handleKeydown(event, index) {
+    if (event.key === "Home") {
+      event.preventDefault();
+      activeTab = tabs[0]?.id ?? activeTab;
+      return;
+    }
+
+    if (event.key === "End") {
+      event.preventDefault();
+      activeTab = tabs[tabs.length - 1]?.id ?? activeTab;
+      return;
+    }
+
     if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
       return;
     }
@@ -16,7 +28,7 @@
 </script>
 
 <nav class="workspace-tabs" aria-label="Studio workspace sections">
-  <div class="workspace-tab-list" role="tablist" aria-orientation="horizontal">
+  <div class="workspace-tab-list" role="tablist" aria-orientation="horizontal" style={`--tab-count: ${Math.max(tabs.length, 1)}`}>
     {#each tabs as tab, index}
       <button
         id={`${tab.id}-tab`}
@@ -46,7 +58,7 @@
 
   .workspace-tab-list {
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(var(--tab-count), minmax(0, 1fr));
     gap: 0.75rem;
   }
 
@@ -59,6 +71,13 @@
     background: rgba(15, 23, 42, 0.72);
     border: 1px solid rgba(148, 163, 184, 0.16);
     color: #cbd5e1;
+    transition: border-color 140ms ease, background 140ms ease, color 140ms ease, box-shadow 140ms ease;
+  }
+
+  button[role="tab"]:focus-visible {
+    outline: none;
+    border-color: rgba(147, 197, 253, 0.72);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.22);
   }
 
   button[role="tab"] small {


### PR DESCRIPTION
## Summary
Move execution-specific surfaces fully under the Execute tab now that the workspace is split into Planning and Execute views.

Closes #40

## Changes
- adjust `App.svelte` tabbed layout to keep execution UI scoped to the Execute tab
- refine `WorkspaceTabs.svelte` for the updated split-workspace behavior
- update `ExecutionDispatchPanel.svelte` integration to match the tabbed workspace flow

## Testing
- not run in this worktree
