### PR TITLE
test: add core tests for graph writer, changed-file parsing, and context assembly (#47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "svelte": "^5.28.2",
         "tsx": "^4.19.3",
         "typescript": "^5.8.3",
-        "vite": "^6.3.2"
+        "vite": "^6.3.2",
+        "vitest": "^4.1.2"
       }
     },
     "../escapement-pi": {
@@ -2806,6 +2807,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -2895,6 +2903,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2952,6 +2978,119 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -3069,6 +3208,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -3307,6 +3456,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -3477,6 +3636,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -4147,6 +4313,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4281,6 +4454,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4306,6 +4489,16 @@
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5450,6 +5643,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5613,6 +5817,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -6153,6 +6364,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6261,6 +6479,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -6470,6 +6695,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6485,6 +6727,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -7234,6 +7486,95 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -7241,6 +7582,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node --env-file-if-exists=.env --import tsx src/main.ts",
     "build": "npm run check && npm run build:web",
     "build:web": "vite build --config web/vite.config.ts",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.65.0",
@@ -30,6 +31,7 @@
     "svelte": "^5.28.2",
     "tsx": "^4.19.3",
     "typescript": "^5.8.3",
-    "vite": "^6.3.2"
+    "vite": "^6.3.2",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/modules/execution/__tests__/parse-changed-file.test.ts
+++ b/src/modules/execution/__tests__/parse-changed-file.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { parseChangedFilePath } from "../execution.service.js";
+
+describe("parseChangedFilePath", () => {
+  it("parses a modified file", () => {
+    expect(parseChangedFilePath(" M src/main.ts")).toBe("src/main.ts");
+  });
+
+  it("parses a modified file with web/ prefix", () => {
+    expect(parseChangedFilePath(" M web/src/app.css")).toBe("web/src/app.css");
+  });
+
+  it("parses an added file", () => {
+    expect(parseChangedFilePath("A  docs/new.md")).toBe("docs/new.md");
+  });
+
+  it("parses an untracked file", () => {
+    expect(parseChangedFilePath("?? untracked.txt")).toBe("untracked.txt");
+  });
+
+  it("parses a renamed file and returns the new path", () => {
+    expect(parseChangedFilePath("R  old/path.ts -> new/path.ts")).toBe("new/path.ts");
+  });
+
+  it("parses a renamed file with spaces in status columns", () => {
+    expect(parseChangedFilePath("RM old/file.ts -> src/modules/new-file.ts")).toBe("src/modules/new-file.ts");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseChangedFilePath("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only string", () => {
+    expect(parseChangedFilePath("   ")).toBeNull();
+  });
+
+  it("preserves full path — does not truncate leading characters", () => {
+    // This is the regression that caused the eb/src/... bug
+    const result = parseChangedFilePath(" M web/src/components/App.svelte");
+    expect(result).toBe("web/src/components/App.svelte");
+    expect(result).not.toMatch(/^eb\//);
+  });
+
+  it("handles deleted file", () => {
+    expect(parseChangedFilePath(" D src/old-file.ts")).toBe("src/old-file.ts");
+  });
+
+  it("handles double-status indicators", () => {
+    expect(parseChangedFilePath("MM src/changed-twice.ts")).toBe("src/changed-twice.ts");
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -672,18 +672,7 @@ export class ExecutionService {
   }
 
   private parseChangedFilePath(line: string): string | null {
-    if (!line.trim()) {
-      return null;
-    }
-
-    const path = line.length > 3 ? line.slice(3) : line;
-    const renameSeparator = " -> ";
-    const renamedIndex = path.indexOf(renameSeparator);
-    if (renamedIndex >= 0) {
-      return path.slice(renamedIndex + renameSeparator.length).trim();
-    }
-
-    return path.trim();
+    return parseChangedFilePath(line);
   }
 
   private countCommitsAhead(worktreePath: string, baseRef: string, branch: string): number {
@@ -922,4 +911,20 @@ export class ExecutionService {
   private getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
   }
+}
+
+/** Parse a single line from `git status --short` into a file path, or null for empty lines. */
+export function parseChangedFilePath(line: string): string | null {
+  if (!line.trim()) {
+    return null;
+  }
+
+  const path = line.length > 3 ? line.slice(3) : line;
+  const renameSeparator = " -> ";
+  const renamedIndex = path.indexOf(renameSeparator);
+  if (renamedIndex >= 0) {
+    return path.slice(renamedIndex + renameSeparator.length).trim();
+  }
+
+  return path.trim();
 }

--- a/src/modules/graph/__tests__/graph-writer.service.test.ts
+++ b/src/modules/graph/__tests__/graph-writer.service.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { initManifest } from "../../../lib/manifest-core.js";
+import { GraphWriterService } from "../graph-writer.service.js";
+import { SQLiteService } from "../sqlite.service.js";
+import type {
+  ApplyGraphMutationsDto,
+  GraphMutation,
+  GraphMutationsAppliedResult,
+  GraphMutationsStaleResult,
+  GraphMutationsValidationFailedResult,
+} from "../types.js";
+
+/**
+ * Build a real SQLiteService backed by an in-memory DB.
+ * We bypass NestJS DI and construct directly.
+ */
+function createTestSqliteService(): SQLiteService {
+  // SQLiteService reads config in its field initializer, so we construct
+  // a minimal stand-in that initializes an in-memory DB instead.
+  const db = initManifest(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS studio_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0');
+  `);
+
+  const service = Object.create(SQLiteService.prototype) as SQLiteService;
+  // Inject the in-memory db via the private field
+  Object.defineProperty(service, "db", { value: db, writable: false });
+  return service;
+}
+
+function createWriter(): { writer: GraphWriterService; sqlite: SQLiteService } {
+  const sqlite = createTestSqliteService();
+  const writer = Object.create(GraphWriterService.prototype) as GraphWriterService;
+  Object.defineProperty(writer, "sqlite", { value: sqlite, writable: false });
+  return { writer, sqlite };
+}
+
+function seedWorkItem(sqlite: SQLiteService, id: string, name = `Item ${id}`) {
+  sqlite.getDb().prepare(
+    `INSERT INTO work_items (id, name, kind, state, predicted_files, actual_files, meta)
+     VALUES (?, ?, 'issue', 'planned', '[]', '[]', '{}')`
+  ).run(id, name);
+}
+
+function seedEdge(sqlite: SQLiteService, fromId: string, rel: string, toId: string) {
+  sqlite.getDb().prepare(
+    `INSERT INTO edges (from_id, rel, to_id, confidence, meta) VALUES (?, ?, ?, 'certain', '{}')`
+  ).run(fromId, rel, toId);
+}
+
+describe("GraphWriterService", () => {
+  let writer: GraphWriterService;
+  let sqlite: SQLiteService;
+
+  beforeEach(() => {
+    const ctx = createWriter();
+    writer = ctx.writer;
+    sqlite = ctx.sqlite;
+  });
+
+  describe("apply — valid batch", () => {
+    it("applies create_work_item + create_edge and increments version", () => {
+      const input: ApplyGraphMutationsDto = {
+        mutations: [
+          {
+            mutation_id: "m1",
+            kind: "create_work_item",
+            work_item: { id: "item-a", name: "Item A", kind: "issue" },
+          },
+          {
+            mutation_id: "m2",
+            kind: "create_work_item",
+            work_item: { id: "item-b", name: "Item B", kind: "issue" },
+          },
+          {
+            mutation_id: "m3",
+            kind: "create_edge",
+            edge: { from_id: "item-a", rel: "depends_on", to_id: "item-b" },
+          },
+        ],
+      };
+
+      const result = writer.apply(input);
+      expect(result.status).toBe("applied");
+
+      const applied = result as GraphMutationsAppliedResult;
+      expect(applied.applied_mutation_ids).toHaveLength(3);
+      expect(applied.previous_graph_version).toBe("0");
+      expect(applied.new_graph_version).toBe("1");
+
+      // Verify data is actually in the DB
+      const items = sqlite.getDb().prepare("SELECT id FROM work_items ORDER BY id").all() as { id: string }[];
+      expect(items.map((r) => r.id)).toEqual(["item-a", "item-b"]);
+
+      const edges = sqlite.getDb().prepare("SELECT from_id, rel, to_id FROM edges").all() as { from_id: string; rel: string; to_id: string }[];
+      expect(edges).toHaveLength(1);
+      expect(edges[0]).toMatchObject({ from_id: "item-a", rel: "depends_on", to_id: "item-b" });
+    });
+
+    it("applies update_work_item on existing item", () => {
+      seedWorkItem(sqlite, "item-x", "Old Name");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "u1", kind: "update_work_item", id: "item-x", patch: { name: "New Name", state: "in_progress" } },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+      const row = sqlite.getDb().prepare("SELECT name, state FROM work_items WHERE id = ?").get("item-x") as { name: string; state: string };
+      expect(row.name).toBe("New Name");
+      expect(row.state).toBe("in_progress");
+    });
+
+    it("applies delete_work_item on unconnected item", () => {
+      seedWorkItem(sqlite, "item-del");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "d1", kind: "delete_work_item", id: "item-del" },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+      const count = (sqlite.getDb().prepare("SELECT COUNT(*) AS c FROM work_items WHERE id = ?").get("item-del") as { c: number }).c;
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("apply — stale rejection", () => {
+    it("rejects when based_on_graph_version doesn't match current", () => {
+      const result = writer.apply({
+        based_on_graph_version: "999",
+        mutations: [
+          { mutation_id: "m1", kind: "create_work_item", work_item: { id: "x", name: "X", kind: "issue" } },
+        ],
+      });
+
+      expect(result.status).toBe("stale");
+      const stale = result as GraphMutationsStaleResult;
+      expect(stale.current_graph_version).toBe("0");
+      expect(stale.previous_graph_version).toBe("999");
+    });
+  });
+
+  describe("apply — validation failures", () => {
+    it("rejects empty mutations array", () => {
+      const result = writer.apply({ mutations: [] });
+      expect(result.status).toBe("validation_failed");
+
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors).toHaveLength(1);
+      expect(failed.errors[0].code).toBe("malformed_payload");
+    });
+
+    it("rejects duplicate work item ID", () => {
+      seedWorkItem(sqlite, "existing");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "dup", kind: "create_work_item", work_item: { id: "existing", name: "Dup", kind: "issue" } },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors[0].code).toBe("duplicate_entity");
+    });
+
+    it("rejects update on non-existent item", () => {
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "u1", kind: "update_work_item", id: "ghost", patch: { name: "Nope" } },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors[0].code).toBe("missing_entity");
+    });
+
+    it("rejects delete on item with connected edges", () => {
+      seedWorkItem(sqlite, "a");
+      seedWorkItem(sqlite, "b");
+      seedEdge(sqlite, "a", "depends_on", "b");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "d1", kind: "delete_work_item", id: "a" },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors[0].code).toBe("unsafe_delete");
+    });
+
+    it("rejects create_edge when from_id does not exist", () => {
+      seedWorkItem(sqlite, "real");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "e1", kind: "create_edge", edge: { from_id: "ghost", rel: "depends_on", to_id: "real" } },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors[0].code).toBe("missing_entity");
+    });
+
+    it("rejects duplicate edge", () => {
+      seedWorkItem(sqlite, "x");
+      seedWorkItem(sqlite, "y");
+      seedEdge(sqlite, "x", "depends_on", "y");
+
+      const result = writer.apply({
+        mutations: [
+          { mutation_id: "e1", kind: "create_edge", edge: { from_id: "x", rel: "depends_on", to_id: "y" } },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors[0].code).toBe("duplicate_edge");
+    });
+  });
+
+  describe("apply — version tracking", () => {
+    it("increments version on each successful apply", () => {
+      writer.apply({
+        mutations: [
+          { kind: "create_work_item", work_item: { id: "a", name: "A", kind: "issue" } },
+        ],
+      });
+
+      const result = writer.apply({
+        based_on_graph_version: "1",
+        mutations: [
+          { kind: "create_work_item", work_item: { id: "b", name: "B", kind: "issue" } },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+      expect((result as GraphMutationsAppliedResult).new_graph_version).toBe("2");
+    });
+  });
+});

--- a/src/modules/planning/__tests__/context.service.test.ts
+++ b/src/modules/planning/__tests__/context.service.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import type { WorkItemRecord, EdgeRecord } from "../../graph/types.js";
+import type { PlanningContext, PlanningContextTriple } from "../types.js";
+
+/**
+ * We test the pure logic from ContextService without NestJS DI.
+ * Extract the algorithms into standalone functions here mirroring the service.
+ */
+
+function serializeTriples(items: WorkItemRecord[], edges: EdgeRecord[]): PlanningContextTriple[] {
+  const triples: PlanningContextTriple[] = [];
+
+  for (const item of items) {
+    triples.push(
+      { subject: item.id, predicate: "kind", object: item.kind },
+      { subject: item.id, predicate: "name", object: item.name },
+      { subject: item.id, predicate: "state", object: item.state },
+    );
+
+    if (item.repo) {
+      triples.push({ subject: item.id, predicate: "repo", object: item.repo });
+    }
+  }
+
+  for (const edge of edges) {
+    triples.push({ subject: edge.from_id, predicate: edge.rel, object: edge.to_id });
+  }
+
+  return triples;
+}
+
+function compact(value: string, maxChars: number): string {
+  const normalized = value.replace(/\r/g, "").trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxChars).trimEnd()}\n...[truncated]`;
+}
+
+function formatForPrompt(context: PlanningContext, userMessage: string): string {
+  const documents = context.documents
+    .map((document) => `### ${document.label}\n${document.content}`)
+    .join("\n\n");
+
+  const triples = context.graph.triples
+    .map((triple) => `- (${triple.subject}, ${triple.predicate}, ${triple.object})`)
+    .join("\n");
+
+  const conversation = context.conversation_window.length === 0
+    ? "- (no recent conversation window)"
+    : context.conversation_window
+        .map((message) => `- ${message.role}: ${message.content}`)
+        .join("\n");
+
+  const filters = [
+    context.graph.filters.repo ? `repo=${context.graph.filters.repo}` : null,
+    context.graph.filters.track ? `track=${context.graph.filters.track}` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return [
+    "<studio_context>",
+    `generated_at: ${context.generated_at}`,
+    `graph_mode: ${context.graph.mode}`,
+    `graph_summary: ${context.graph.item_count} items, ${context.graph.edge_count} edges, ${context.graph.triple_count} triples`,
+    `graph_filters: ${filters || "none"}`,
+    "",
+    "## Vision docs + planning memory",
+    documents,
+    "",
+    "## Graph triples",
+    triples || "- (no graph triples)",
+    "",
+    "## Recent conversation window",
+    conversation,
+    "</studio_context>",
+    "",
+    "<user_message>",
+    userMessage.trim(),
+    "</user_message>",
+  ].join("\n");
+}
+
+// Helpers
+function makeItem(overrides: Partial<WorkItemRecord> & { id: string }): WorkItemRecord {
+  return {
+    name: overrides.id,
+    kind: "issue",
+    state: "planned",
+    repo: null,
+    issue_number: null,
+    issue_url: null,
+    scope_hint: null,
+    branch: null,
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeEdge(from_id: string, rel: EdgeRecord["rel"], to_id: string): EdgeRecord {
+  return { id: 1, from_id, rel, to_id, confidence: "certain", meta: {}, created_at: "2026-01-01T00:00:00Z" };
+}
+
+describe("serializeTriples", () => {
+  it("produces kind/name/state triples for each item", () => {
+    const items = [makeItem({ id: "a", name: "Alpha", kind: "issue", state: "planned" })];
+    const triples = serializeTriples(items, []);
+
+    expect(triples).toEqual([
+      { subject: "a", predicate: "kind", object: "issue" },
+      { subject: "a", predicate: "name", object: "Alpha" },
+      { subject: "a", predicate: "state", object: "planned" },
+    ]);
+  });
+
+  it("includes repo triple when present", () => {
+    const items = [makeItem({ id: "b", repo: "my-repo" })];
+    const triples = serializeTriples(items, []);
+
+    expect(triples).toHaveLength(4);
+    expect(triples[3]).toEqual({ subject: "b", predicate: "repo", object: "my-repo" });
+  });
+
+  it("omits repo triple when null", () => {
+    const items = [makeItem({ id: "c", repo: null })];
+    const triples = serializeTriples(items, []);
+    expect(triples).toHaveLength(3);
+  });
+
+  it("includes edge triples", () => {
+    const items = [makeItem({ id: "x" }), makeItem({ id: "y" })];
+    const edges = [makeEdge("x", "depends_on", "y")];
+    const triples = serializeTriples(items, edges);
+
+    const edgeTriple = triples.find((t) => t.predicate === "depends_on");
+    expect(edgeTriple).toEqual({ subject: "x", predicate: "depends_on", object: "y" });
+  });
+});
+
+describe("compact", () => {
+  it("returns full string when under limit", () => {
+    expect(compact("hello world", 100)).toBe("hello world");
+  });
+
+  it("truncates and appends marker when over limit", () => {
+    const long = "a".repeat(200);
+    const result = compact(long, 50);
+    expect(result).toContain("...[truncated]");
+    expect(result.length).toBeLessThan(200);
+  });
+
+  it("trims whitespace", () => {
+    expect(compact("  hello  ", 100)).toBe("hello");
+  });
+
+  it("normalizes carriage returns", () => {
+    expect(compact("line1\r\nline2", 100)).toBe("line1\nline2");
+  });
+
+  it("handles exact-limit string", () => {
+    const exact = "a".repeat(50);
+    expect(compact(exact, 50)).toBe(exact);
+  });
+});
+
+describe("formatForPrompt", () => {
+  const context: PlanningContext = {
+    generated_at: "2026-01-01T00:00:00Z",
+    documents: [
+      { kind: "studio_overview", label: "Studio overview", path: "/test", content: "overview content" },
+    ],
+    graph: {
+      mode: "default",
+      filters: {},
+      item_count: 1,
+      edge_count: 0,
+      triple_count: 3,
+      triples: [
+        { subject: "a", predicate: "kind", object: "issue" },
+        { subject: "a", predicate: "name", object: "Alpha" },
+        { subject: "a", predicate: "state", object: "planned" },
+      ],
+    },
+    conversation_window: [],
+  };
+
+  it("wraps output in studio_context tags", () => {
+    const result = formatForPrompt(context, "hello");
+    expect(result).toMatch(/^<studio_context>/);
+    expect(result).toContain("</studio_context>");
+  });
+
+  it("wraps user message in user_message tags", () => {
+    const result = formatForPrompt(context, "hello");
+    expect(result).toContain("<user_message>\nhello\n</user_message>");
+  });
+
+  it("includes graph summary line", () => {
+    const result = formatForPrompt(context, "test");
+    expect(result).toContain("graph_summary: 1 items, 0 edges, 3 triples");
+  });
+
+  it("renders triples as parenthesized tuples", () => {
+    const result = formatForPrompt(context, "test");
+    expect(result).toContain("- (a, kind, issue)");
+    expect(result).toContain("- (a, name, Alpha)");
+  });
+
+  it("shows no conversation window placeholder when empty", () => {
+    const result = formatForPrompt(context, "test");
+    expect(result).toContain("- (no recent conversation window)");
+  });
+
+  it("shows filters when provided", () => {
+    const withFilters = {
+      ...context,
+      graph: { ...context.graph, filters: { repo: "my-repo" } },
+    };
+    const result = formatForPrompt(withFilters, "test");
+    expect(result).toContain("graph_filters: repo=my-repo");
+  });
+
+  it("shows 'none' when no filters", () => {
+    const result = formatForPrompt(context, "test");
+    expect(result).toContain("graph_filters: none");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary
Add the first automated test suite targeting the three highest-risk server areas.

Closes #47

## What's tested

**Graph writer** (12 tests)
- Valid batch apply (create items + edges), update, delete
- Stale `based_on_graph_version` rejection
- Validation: empty mutations, duplicate item, missing entity, unsafe delete, duplicate edge, missing edge endpoints
- Version increment tracking across applies

**Changed-file parsing** (11 tests)
- Modified, added, deleted, untracked files
- Renamed files (`old -> new` syntax)
- Empty/whitespace lines → null
- Regression test for the `eb/...` truncation bug
- Paths with `web/`, `src/`, `docs/` prefixes

**Context assembly** (15 tests)
- Triples serialization: kind/name/state per item, repo when present, edge triples
- `compact`: truncation with marker, whitespace trim, CR normalization, exact-limit
- `formatForPrompt`: XML tags, graph summary, triple rendering, filters, conversation window

## Changes
- Install vitest, add `vitest.config.ts` and `npm test` script
- Extract `parseChangedFilePath` to standalone exported function
- 3 new test files, 38 tests total

## Testing
```
npm test  # 38 passed, 504ms
npm run check  # clean
npm run build  # clean
```