### PR TITLE
feat(execution): add one-click Open PR action (#54)

### DIFF
--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -194,6 +194,12 @@ export class ExecutionService {
 
     const workItem = this.workItemsService.get(run.work_item_id);
     const baseRef = input.base_ref?.trim() || run.base_ref || getDefaultWorkingBranch(workItem.repo);
+
+    // Auto-stage and commit if requested and worktree has uncommitted changes
+    if (input.auto_commit !== false) {
+      this.autoStageAndCommit(run, workItem, input.commit_message);
+    }
+
     const title = input.title?.trim() || this.buildPullRequestTitle(workItem);
     const body = input.body?.trim() || this.buildPullRequestBody(run, workItem, baseRef);
     const aheadCount = this.countCommitsAhead(run.worktree_path, baseRef, run.branch);
@@ -829,6 +835,30 @@ export class ExecutionService {
     }
 
     return lines.join("\n");
+  }
+
+  private autoStageAndCommit(run: ExecutionRunRecord, workItem: WorkItemRecord, commitMessage?: string): void {
+    const status = this.runGitIn(run.worktree_path, ["status", "--porcelain"], { allowFailure: true }).trim();
+    if (!status) {
+      return; // working tree is clean, nothing to commit
+    }
+
+    this.logger.log(`Auto-staging and committing changes in ${run.worktree_path}`);
+    this.runGitIn(run.worktree_path, ["add", "-A"]);
+
+    const message = commitMessage?.trim() || this.buildCommitMessage(workItem);
+    this.runGitIn(run.worktree_path, ["commit", "-m", message]);
+
+    // Refresh changed files after commit
+    const changedFiles = this.listChangedFiles(run.worktree_path);
+    if (changedFiles.length > 0) {
+      this.updateRun(run.run_id, { changed_files: changedFiles });
+    }
+  }
+
+  private buildCommitMessage(workItem: WorkItemRecord): string {
+    const issueRef = workItem.issue_number ? ` (#${workItem.issue_number})` : "";
+    return `${workItem.name}${issueRef}`;
   }
 
   private syncActualFiles(workItemId: string, changedFiles: string[]): { ok: true; actual_files: string[] } | { ok: false; message: string } {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -114,6 +114,8 @@ export interface CreateExecutionPullRequestDto {
   body?: string;
   base_ref?: string;
   draft?: boolean;
+  auto_commit?: boolean;
+  commit_message?: string;
 }
 
 export interface CreateExecutionPullRequestResult {

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { getExecutionPreview, launchExecutionRun, listExecutionRuns } from "../lib/api.js";
+  import { getExecutionPreview, launchExecutionRun, listExecutionRuns, openPullRequest } from "../lib/api.js";
 
   let preview = null;
   let runs = [];
@@ -12,6 +12,8 @@
   let copyTimer;
   let stream;
   let launchingIds = [];
+  let openingPrRunIds = [];
+  let prResults = {};
 
   $: activeRuns = runs.filter((run) => ["queued", "preparing", "running"].includes(run.status));
   $: completedRuns = runs.filter((run) => run.status === "completed");
@@ -114,6 +116,20 @@
     } finally {
       loading = false;
       refreshing = false;
+    }
+  }
+
+  async function handleOpenPR(run) {
+    openingPrRunIds = [...openingPrRunIds, run.run_id];
+    error = "";
+    try {
+      const result = await openPullRequest({ run_id: run.run_id, auto_commit: true });
+      mergeRun(result.run);
+      prResults = { ...prResults, [run.run_id]: result.pull_request };
+    } catch (prError) {
+      error = prError.message;
+    } finally {
+      openingPrRunIds = openingPrRunIds.filter((id) => id !== run.run_id);
     }
   }
 
@@ -423,7 +439,15 @@
                     <button class="secondary small" on:click={() => copyValue(run.branch, `Copied branch ${run.branch}`)}>Copy branch</button>
                     <button class="secondary small" on:click={() => copyValue(run.worktree_path, `Copied worktree for ${run.work_item_id}`)}>Copy worktree</button>
                     {#if run.status === "completed"}
-                      <button class="secondary small" on:click={() => copyValue(buildPrCommand(run), `Copied PR command for ${run.work_item_id}`)}>Copy PR command</button>
+                      {#if run.pull_request}
+                        <a class="ghost-link small" href={run.pull_request.url} target="_blank" rel="noreferrer">PR #{run.pull_request.number}</a>
+                      {:else if prResults[run.run_id]}
+                        <a class="ghost-link small" href={prResults[run.run_id].url} target="_blank" rel="noreferrer">PR #{prResults[run.run_id].number}</a>
+                      {:else}
+                        <button on:click={() => handleOpenPR(run)} disabled={openingPrRunIds.includes(run.run_id)}>
+                          {openingPrRunIds.includes(run.run_id) ? 'Opening PR…' : 'Open PR'}
+                        </button>
+                      {/if}
                       <a class="ghost-link small" href="#reconciliation-panel">Review reconciliation</a>
                     {/if}
                   </div>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -86,6 +86,14 @@ export function launchExecutionRun(payload) {
   });
 }
 
+export function openPullRequest(payload) {
+  return request("/api/execution/pull-request", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getReconciliationReports(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary
Add a one-click Open PR button in the Execute UI that stages, commits, pushes, and creates the PR automatically.

Closes #54

## What's new

### Backend
- Extended `createPullRequest` to auto-stage (`git add -A`) and commit when the worktree has uncommitted changes
- Added `auto_commit` and `commit_message` fields to `CreateExecutionPullRequestDto`
- Auto-generates commit message from work item name + issue number
- Existing endpoint `POST /api/execution/pull-request` — no new routes

### Frontend
- Added `openPullRequest()` API call
- Added **Open PR** button on completed run cards in Execute UI
- Shows resulting PR link after creation
- Shows existing PR link if already opened
- Failures surfaced via error banner

## Files changed
- `src/modules/execution/execution.service.ts` — autoStageAndCommit, buildCommitMessage
- `src/modules/execution/types.ts` — auto_commit, commit_message on DTO
- `web/src/lib/api.js` — openPullRequest function
- `web/src/components/ExecutionDispatchPanel.svelte` — Open PR button + state

## Testing
```
npm run check  # clean
npm test       # 38 passed
npm run build  # clean
```