### PR TITLE
[#56] Studio: auto-stage graph representation when creating GitHub issues

### DIFF
--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -39,6 +39,20 @@ interface RawPullRequestResponse {
   mergeCommit?: { oid?: string | null } | null;
 }
 
+export interface GitHubCreateIssueInput {
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+}
+
+export interface GitHubCreatedIssue {
+  repo: string;
+  number: number;
+  url: string;
+  title: string;
+}
+
 export interface GitHubPullRequestDetails {
   repo: string;
   number: number;
@@ -62,6 +76,49 @@ export class GitHubService {
 
   private get db(): DatabaseType {
     return this.sqlite.getDb();
+  }
+
+  async createIssue(input: GitHubCreateIssueInput): Promise<GitHubCreatedIssue> {
+    const { repo, title, body, labels } = input;
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+    if (!title?.trim()) {
+      throw new BadRequestException("title is required");
+    }
+
+    const args = [
+      "issue",
+      "create",
+      "--repo",
+      repo,
+      "--title",
+      title,
+    ];
+
+    if (body) {
+      args.push("--body", body);
+    }
+
+    if (labels && labels.length > 0) {
+      args.push("--label", labels.join(","));
+    }
+
+    const stdout = this.runGh(args).trim();
+
+    // gh issue create outputs the issue URL, e.g. https://github.com/owner/repo/issues/42
+    const issueNumberMatch = stdout.match(/\/issues\/(\d+)\s*$/);
+    if (!issueNumberMatch) {
+      throw new BadRequestException(`Could not parse issue number from gh output: ${stdout}`);
+    }
+
+    const issueNumber = Number(issueNumberMatch[1]);
+    return {
+      repo,
+      number: issueNumber,
+      url: stdout,
+      title,
+    };
   }
 
   async readIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -48,6 +48,7 @@ import type {
   StudioSseEnvelope,
   UpdateWorkItemPayload,
   ReconciliationQueryToolInput,
+  GitHubCreateIssueToolInput,
 } from "./types.js";
 
 @Injectable()
@@ -299,6 +300,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         this.createMemoryWriteTool(),
         this.createDelegateSubAgentTool(),
         this.createGitHubReadTool(),
+        this.createGitHubCreateIssueTool(),
         this.createGitHubSyncTool(),
         this.createReconciliationQueryTool(),
       ],
@@ -588,6 +590,113 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
           details: issue,
+        };
+      },
+    });
+  }
+
+  private createGitHubCreateIssueTool() {
+    return defineTool({
+      name: "github_create_issue",
+      label: "GitHub Create Issue",
+      description: "Create a GitHub issue and automatically stage a graph work item proposal for browser approval.",
+      promptSnippet: "github_create_issue: create a GitHub issue and auto-stage the corresponding graph work item proposal in one step.",
+      promptGuidelines: [
+        "Use github_create_issue when the user asks to create a new issue — it handles both GitHub issue creation and graph proposal staging.",
+        "The graph mutation proposal is staged automatically for browser approval; no separate propose_mutations call is needed.",
+        "Provide a work_item_id that follows the project's naming convention (e.g. 'studio-57').",
+        "Include scope_hint and predicted_files when available to enrich the graph node.",
+        "Use parent_id and depends_on_ids to wire the new item into the graph hierarchy.",
+      ],
+      parameters: Type.Object({
+        repo: Type.String(),
+        title: Type.String(),
+        body: Type.Optional(Type.String()),
+        labels: Type.Optional(Type.Array(Type.String())),
+        work_item_id: Type.Optional(Type.String()),
+        scope_hint: Type.Optional(Type.String()),
+        predicted_files: Type.Optional(Type.Array(Type.String())),
+        parent_id: Type.Optional(Type.String()),
+        depends_on_ids: Type.Optional(Type.Array(Type.String())),
+      }),
+      execute: async (_toolCallId, params: GitHubCreateIssueToolInput) => {
+        const created = await this.githubService.createIssue({
+          repo: params.repo,
+          title: params.title,
+          body: params.body,
+          labels: params.labels,
+        });
+
+        const workItemId = params.work_item_id?.trim() || `studio-${created.number}`;
+
+        const mutations: ProposeMutationsToolInput["mutations"] = [
+          {
+            id: "m1",
+            type: "create_work_item",
+            entity_id: workItemId,
+            payload: {
+              id: workItemId,
+              name: created.title,
+              kind: "issue",
+              state: "planned",
+              repo: params.repo,
+              issue_number: created.number,
+              issue_url: created.url,
+              scope_hint: params.scope_hint ?? null,
+              predicted_files: params.predicted_files ?? [],
+            },
+            rationale: `Graph representation for newly created GitHub issue #${created.number}.`,
+          },
+        ];
+
+        let edgeIndex = 2;
+        if (params.parent_id?.trim()) {
+          mutations.push({
+            id: `m${edgeIndex++}`,
+            type: "create_edge",
+            payload: {
+              from_id: workItemId,
+              rel: "is_part_of",
+              to_id: params.parent_id.trim(),
+            },
+            rationale: `Attach ${workItemId} under parent ${params.parent_id.trim()}.`,
+          });
+        }
+
+        if (params.depends_on_ids) {
+          for (const depId of params.depends_on_ids) {
+            if (depId?.trim()) {
+              mutations.push({
+                id: `m${edgeIndex++}`,
+                type: "create_edge",
+                payload: {
+                  from_id: workItemId,
+                  rel: "depends_on",
+                  to_id: depId.trim(),
+                },
+                rationale: `${workItemId} depends on ${depId.trim()}.`,
+              });
+            }
+          }
+        }
+
+        const proposal = this.normalizeProposal({
+          summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
+          mutations,
+        });
+        this.proposals.set(proposal.proposal_id, proposal);
+        this.activeProposalId = proposal.proposal_id;
+        this.lastCommitResult = null;
+        this.emitStudioEvent("mutation_proposal", { proposal });
+
+        const summary = `Created GitHub issue #${created.number} (${created.url}) and staged graph proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s) for browser approval.`;
+
+        return {
+          content: [{ type: "text", text: summary }],
+          details: {
+            issue: created,
+            proposal,
+          },
         };
       },
     });

--- a/src/modules/planning/types.ts
+++ b/src/modules/planning/types.ts
@@ -303,6 +303,18 @@ export interface GitHubSyncToolInput {
   work_item_id: string;
 }
 
+export interface GitHubCreateIssueToolInput {
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  work_item_id?: string;
+  scope_hint?: string;
+  predicted_files?: string[];
+  parent_id?: string;
+  depends_on_ids?: string[];
+}
+
 export interface PlanningSessionSnapshot {
   session_id: string;
   session_file?: string;


### PR DESCRIPTION
## Summary
## Summary

### What changed

**3 files modified**, all within the owned `src/modules/planning` and `src/modules/github` directories:

1. **`src/modules/github/github.service.ts`** — Added `createIssue()` method that:
   - Creates a GitHub issue via `gh issue create` CLI
   - Parses the returned URL to extract the issue number
   - Returns a `GitHubCreatedIssue` with repo, number, url, title
   - Validates required inputs (repo, title)

2. **`src/modules/planning/planning.service.ts`** — Added `github_create_issue` tool that:
   - Creates the GitHub issue via `GitHubService.createIssue()`
   - Auto-stages a `create_work_item` graph mutation proposal with issue metadata (number, URL, repo, scope_hint, predicted_files)
   - Optionally adds `is_part_of` and `depends_on` edge mutations for graph wiring
   - Emits the `mutation_proposal` SSE event for browser approval rendering
   - Returns both the issue details and the staged proposal ID
   - Includes prompt guidelines instructing the LLM to use this single tool instead of separate create + propose_mutations calls

3. **`src/modules/planning/types.ts`** — Added `GitHubCreateIssueToolInput` interface

### Key design decisions
- Graph writes remain **approval-gated** in the browser (no auto-apply)
- The tool reuses the existing `normalizeProposal` flow, so the proposal appears in the browser exactly like any other mutation proposal
- Work item ID defaults to `studio-{issue_number}` if not provided by the planner

### Checks performed
- ✅ `tsc --noEmit` — clean compilation
- ✅ `vitest run` — all 38 existing tests pass
- ✅ Stayed within predicted file scope (`src/modules/planning`, `src/modules/github`)

### No remaining blockers
The feature is complete and ready for review.

actual_files synced: 0 file(s).

## Context
- Work item: studio-56
- Issue: https://github.com/fusupo/escapement-studio/issues/56
- Base branch: develop
- Head branch: studio-56-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775510276148
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-56-branch
- Scope hint: Automatically stage a browser-approval graph proposal for the corresponding issue-backed work item whenever Studio creates a GitHub issue.

## Changed files
- (not recorded)