### PR TITLE
[#57] Studio: make chat composer submit on Enter and insert newline on Shift+Enter

### DIFF
--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -655,7 +655,7 @@
     <div class="planner-composer">
       <label>
         Message
-        <textarea bind:value={draft} rows="2" placeholder="Ask the planner to inspect the graph, delegate specialists, review reconciliation drift, propose memory updates, or explain blockers."></textarea>
+        <textarea bind:value={draft} rows="2" placeholder="Ask the planner to inspect the graph, delegate specialists, review reconciliation drift, propose memory updates, or explain blockers." on:keydown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); if (draft.trim() && !sending) submitMessage(); } }}></textarea>
       </label>
       <div class="planner-actions">
         <button class="secondary" on:click={loadSnapshot} disabled={loading}>Refresh transcript</button>


### PR DESCRIPTION
## Summary
## Summary

**What changed:**
- `web/src/components/PlannerChatAdapter.svelte` — Added a `keydown` handler to the chat composer `<textarea>`:
  - **Enter** (without Shift): prevents default newline, calls `submitMessage()` if the draft is non-empty and not already sending.
  - **Shift+Enter**: default behavior preserved (inserts a newline).

**Verification:**
- `npm run build:web` passes successfully. The only warning is a pre-existing a11y issue on the approval overlay.

**Scope:**
- Single file, single line change — exactly within the predicted scope.

**Remaining blockers:** None. Ready for review/commit.

actual_files synced: 1 file(s).

## Context
- Work item: studio-57
- Issue: https://github.com/fusupo/escapement-studio/issues/57
- Base branch: develop
- Head branch: studio-57-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775510281589
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-57-branch
- Scope hint: Update the chat composer so Enter submits valid messages and Shift+Enter inserts a newline without submitting.

## Changed files
- `web/src/components/PlannerChatAdapter.svelte`