### PR TITLE
[#62] Studio: move GitHub issue details above selected node details and add Close issue action

### DIFF
--- a/src/modules/github/github.controller.ts
+++ b/src/modules/github/github.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Inject, Query } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Post, Query } from "@nestjs/common";
 import { GitHubService } from "./github.service.js";
 
 @Controller("api/github")
@@ -11,6 +11,14 @@ export class GitHubController {
     @Query("issue_number") issueNumber?: string,
   ) {
     return this.githubService.readIssue(repo ?? "", Number(issueNumber));
+  }
+
+  @Post("issue/close")
+  closeIssue(
+    @Body("repo") repo: string,
+    @Body("issue_number") issueNumber: number,
+  ) {
+    return this.githubService.closeIssue(repo, Number(issueNumber));
   }
 
   @Get("pull-request")

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -121,6 +121,25 @@ export class GitHubService {
     };
   }
 
+  async closeIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new BadRequestException("issue_number must be a positive integer");
+    }
+
+    this.runGh([
+      "issue",
+      "close",
+      String(issueNumber),
+      "--repo",
+      repo,
+    ]);
+
+    return this.readIssue(repo, issueNumber);
+  }
+
   async readIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {
     if (!repo?.trim()) {
       throw new BadRequestException("repo is required");

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -6,6 +6,7 @@
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
   import {
+    closeGitHubIssue,
     createEdge,
     createWorkItem,
     deleteEdge,
@@ -28,6 +29,7 @@
   let health = null;
   let selectedIssueDetails = null;
   let activeTab = "planning";
+  let closingIssue = false;
 
   const workspaceTabs = [
     { id: "planning", label: "Planning" },
@@ -141,6 +143,21 @@
     }
   }
 
+  async function handleCloseIssue(item) {
+    if (!item?.repo || !item?.issue_number) return;
+    closingIssue = true;
+    error = "";
+    try {
+      await closeGitHubIssue({ repo: item.repo, issue_number: item.issue_number });
+      await updateWorkItem(item.id, { state: "done" });
+      await loadGraph();
+    } catch (closeError) {
+      error = closeError.message;
+    } finally {
+      closingIssue = false;
+    }
+  }
+
   function handleFilterChange(nextFilters) {
     filters = nextFilters;
     loadGraph();
@@ -225,6 +242,8 @@
             onCreateItem={handleCreateItem}
             onCreateEdge={handleCreateEdge}
             onDeleteEdge={handleDeleteEdge}
+            onCloseIssue={handleCloseIssue}
+            {closingIssue}
           />
         </div>
       </div>

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -25,6 +25,8 @@
   export let onCreateItem = () => {};
   export let onCreateEdge = () => {};
   export let onDeleteEdge = () => {};
+  export let onCloseIssue = () => {};
+  export let closingIssue = false;
 
   let editForm = { ...defaultWorkItem };
   let createForm = { ...defaultWorkItem };
@@ -90,6 +92,47 @@
   <section>
     <h2>Selected node</h2>
     {#if selectedItem}
+      {#if selectedItem.issue_number && selectedItem.repo}
+        <div class="issue-details-card">
+          <div class="issue-details-header">
+            <h3>GitHub issue</h3>
+            {#if (issueDetails?.url || selectedItem.issue_url)}
+              <a href={issueDetails?.url || selectedItem.issue_url} target="_blank" rel="noreferrer">Open</a>
+            {/if}
+          </div>
+
+          {#if issueDetails?.error}
+            <p class="muted">Failed to load issue details: {issueDetails.error}</p>
+          {:else if issueDetails}
+            <strong>#{issueDetails.number} {issueDetails.title}</strong>
+            <p class="muted">{issueDetails.state}</p>
+            {#if issueDetails.labels?.length}
+              <div class="tag-list">
+                {#each issueDetails.labels as label}
+                  <span class="status-pill">{label.name}</span>
+                {/each}
+              </div>
+            {/if}
+            {#if issueDetails.assignees?.length}
+              <p class="muted">Assignees: {issueDetails.assignees.map((assignee) => assignee.login).join(', ')}</p>
+            {/if}
+            {#if issueDetails.managed_block}
+              <details class="issue-body-preview">
+                <summary>Managed Studio block</summary>
+                <pre>{issueDetails.managed_block.content}</pre>
+              </details>
+            {/if}
+            {#if issueDetails.state !== 'closed'}
+              <button class="danger small" on:click={() => onCloseIssue(selectedItem)} disabled={closingIssue}>
+                {closingIssue ? 'Closing…' : 'Close issue'}
+              </button>
+            {/if}
+          {:else}
+            <p class="muted">Loading issue details…</p>
+          {/if}
+        </div>
+      {/if}
+
       <div class="stack">
         <label>
           ID
@@ -136,42 +179,6 @@
         </label>
         <button on:click={submitEdit} disabled={saving}>{saving ? "Saving..." : "Save changes"}</button>
       </div>
-
-      {#if selectedItem.issue_number && selectedItem.repo}
-        <div class="issue-details-card">
-          <div class="issue-details-header">
-            <h3>GitHub issue</h3>
-            {#if (issueDetails?.url || selectedItem.issue_url)}
-              <a href={issueDetails?.url || selectedItem.issue_url} target="_blank" rel="noreferrer">Open</a>
-            {/if}
-          </div>
-
-          {#if issueDetails?.error}
-            <p class="muted">Failed to load issue details: {issueDetails.error}</p>
-          {:else if issueDetails}
-            <strong>#{issueDetails.number} {issueDetails.title}</strong>
-            <p class="muted">{issueDetails.state}</p>
-            {#if issueDetails.labels?.length}
-              <div class="tag-list">
-                {#each issueDetails.labels as label}
-                  <span class="status-pill">{label.name}</span>
-                {/each}
-              </div>
-            {/if}
-            {#if issueDetails.assignees?.length}
-              <p class="muted">Assignees: {issueDetails.assignees.map((assignee) => assignee.login).join(', ')}</p>
-            {/if}
-            {#if issueDetails.managed_block}
-              <details class="issue-body-preview">
-                <summary>Managed Studio block</summary>
-                <pre>{issueDetails.managed_block.content}</pre>
-              </details>
-            {/if}
-          {:else}
-            <p class="muted">Loading issue details…</p>
-          {/if}
-        </div>
-      {/if}
     {:else}
       <p class="muted">Select a node in the graph to inspect and edit it.</p>
     {/if}

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -62,6 +62,14 @@ export function getGitHubIssueDetails({ repo, issue_number }) {
   return request(`/api/github/issue?${query.toString()}`);
 }
 
+export function closeGitHubIssue({ repo, issue_number }) {
+  return request("/api/github/issue/close", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify({ repo, issue_number }),
+  });
+}
+
 export function getExecutionPreview(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary
All clean. Here's a summary:

## Changes Made

### 1. Move GitHub issue details above selected node form (`Sidebar.svelte`)
- Moved the entire GitHub issue details card **above** the node edit form, so when a node with a linked issue is selected, users see the issue context first before the editable fields.

### 2. Add "Close issue" action (`Sidebar.svelte`, `App.svelte`, `api.js`, backend)
- **`web/src/lib/api.js`** — Added `closeGitHubIssue({ repo, issue_number })` API function (owned file).
- **`web/src/components/Sidebar.svelte`** — Added a "Close issue" button inside the issue details card, shown only when the issue state is not already `closed`. Accepts `onCloseIssue` and `closingIssue` props.
- **`web/src/App.svelte`** — Added `handleCloseIssue(item)` which: (1) closes the GitHub issue via API, (2) sets the graph work item state to `done`, (3) refreshes the graph.
- **`src/modules/github/github.controller.ts`** — Added `POST /api/github/issue/close` endpoint.
- **`src/modules/github/github.service.ts`** — Added `closeIssue(repo, issueNumber)` method that runs `gh issue close` then returns refreshed issue details.

### Checks Performed
- ✅ TypeScript compilation (`tsc --noEmit`) — no errors
- ✅ Vite frontend build (`npm run build`) — clean

### Scope Notes
- Files beyond `web/src/lib/api.js` were necessary to complete the feature end-to-end (backend endpoint + UI wiring). None of the forbidden files were touched.
- No broad refactors — changes are minimal and focused on the two objectives in the issue.

### No Remaining Blockers
The feature is complete and ready for review.

actual_files synced: 5 file(s).

## Context
- Work item: studio-60
- Issue: https://github.com/fusupo/escapement-studio/issues/62
- Base branch: develop
- Head branch: studio-60-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775512268745
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-60-branch
- Scope hint: Improve the details panel layout and add a close-issue action that syncs graph state to done.

## Changed files
- `src/modules/github/github.controller.ts`
- `src/modules/github/github.service.ts`
- `web/src/App.svelte`
- `web/src/components/Sidebar.svelte`
- `web/src/lib/api.js`