### PR TITLE
[#58] Studio: show per-run live activity log and reasoning summaries in Recent execution runs

### DIFF
--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Inject, Post, Query, Sse } from "@nestjs/common";
+import { Body, Controller, Get, Inject, Param, Post, Query, Sse } from "@nestjs/common";
 import type { MessageEvent } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { ExecutionService } from "./execution.service.js";
@@ -16,6 +16,11 @@ export class ExecutionController {
   @Get("runs")
   getRecentRuns() {
     return this.executionService.listRecentRuns();
+  }
+
+  @Get("runs/:runId/activity")
+  getRunActivity(@Param("runId") runId: string) {
+    return this.executionService.getRunActivityLog(runId);
   }
 
   @Post("launch")

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -11,6 +11,8 @@ import { GraphService } from "../graph/graph.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { WorkItemRecord } from "../graph/types.js";
 import type {
+  ActivityLogEntry,
+  ActivityLogEntryKind,
   CreateExecutionPullRequestDto,
   CreateExecutionPullRequestResult,
   ExecutionDispatchGroupPreview,
@@ -37,6 +39,7 @@ export class ExecutionService {
   private readonly worktreeRoot = join(this.artifactRoot, "worktrees");
   private readonly recentRuns: ExecutionRunRecord[] = [];
   private readonly recentRunLimit = 16;
+  private readonly activityLogLimit = 50;
   private eventCounter = 0;
 
   constructor(
@@ -157,7 +160,9 @@ export class ExecutionService {
     });
 
     this.persistRun(run);
+    this.pushActivity(run.run_id, "status_change", "Execution run queued.");
     void this.executeRun(run, node).catch((error) => {
+      this.pushActivity(run.run_id, "error", `Execution failed: ${this.getErrorMessage(error)}`);
       const failedRun = this.updateRun(run.run_id, {
         status: "error",
         completed_at: this.now(),
@@ -409,6 +414,7 @@ export class ExecutionService {
     this.appendEvent(run, { type: "run_preparing" });
 
     this.runGit(["worktree", "add", run.worktree_path, "-b", run.branch, run.base_ref]);
+    this.pushActivity(run.run_id, "status_change", `Worktree created at ${run.worktree_path}`, `Branch: ${run.branch}, Base: ${run.base_ref}`);
     this.appendEvent(run, { type: "worktree_created", worktree_path: run.worktree_path, branch: run.branch, base_ref: run.base_ref });
 
     const { session, modelFallbackMessage } = await createAgentSession({
@@ -427,6 +433,7 @@ export class ExecutionService {
       session_id: session.sessionId,
       progress_message: "Execution agent running in isolated worktree.",
     })!;
+    this.pushActivity(run.run_id, "status_change", "Agent session started.");
     this.appendEvent(run, { type: "session_started", session_id: session.sessionId });
 
     const runId = run.run_id;
@@ -442,11 +449,17 @@ export class ExecutionService {
     }
 
     const assistantText = session.getLastAssistantText()?.trim() ?? "Execution run completed without a terminal summary.";
+    // Extract a short reasoning summary from the assistant's final text
+    const reasoningSummary = this.extractReasoningSummary(assistantText);
+    if (reasoningSummary) {
+      this.pushActivity(run.run_id, "reasoning", reasoningSummary);
+    }
     const changedFiles = this.listChangedFiles(run.worktree_path);
     const actualFilesSync = this.syncActualFiles(run.work_item_id, changedFiles);
     mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
     writeFileSync(join(run.artifact_dir, "outputs", "response.json"), JSON.stringify({ assistant_text: assistantText, changed_files: changedFiles, actual_files_sync: actualFilesSync }, null, 2), "utf8");
 
+    this.pushActivity(run.run_id, "status_change", `Execution completed. ${changedFiles.length} file(s) changed.`);
     run = this.updateRun(initialRun.run_id, {
       status: "completed",
       completed_at: this.now(),
@@ -459,6 +472,11 @@ export class ExecutionService {
     this.emitRun("execution_result", run);
   }
 
+  getRunActivityLog(runId: string): ActivityLogEntry[] {
+    const run = this.getRun(runId);
+    return run?.activity_log ?? [];
+  }
+
   private handleSessionEvent(runId: string, event: AgentSessionEvent) {
     const run = this.getRun(runId);
     if (!run) {
@@ -468,12 +486,14 @@ export class ExecutionService {
     const toolName = "toolName" in event ? event.toolName ?? null : null;
     if (event.type === "tool_execution_start") {
       this.appendEvent(run, { type: event.type, tool_name: toolName });
+      this.pushActivity(runId, "tool_start", `Tool started: ${toolName ?? "unknown"}`);
       this.updateRun(runId, { progress_message: `${toolName ?? "tool"} running…` });
       return;
     }
 
     if (event.type === "tool_execution_end") {
       this.appendEvent(run, { type: event.type, tool_name: toolName });
+      this.pushActivity(runId, "tool_end", `Tool finished: ${toolName ?? "unknown"}`);
       this.updateRun(runId, { progress_message: `${toolName ?? "tool"} finished.` });
       return;
     }
@@ -485,13 +505,27 @@ export class ExecutionService {
 
     if (event.type === "agent_start" || event.type === "turn_start") {
       this.appendEvent(run, { type: event.type });
+      this.pushActivity(runId, "turn_start", "Execution turn started.");
       this.updateRun(runId, { progress_message: "Execution turn started." });
       return;
     }
 
     if (event.type === "agent_end" || event.type === "turn_end") {
       this.appendEvent(run, { type: event.type });
+      this.pushActivity(runId, "turn_end", "Execution turn completed.");
       this.updateRun(runId, { progress_message: "Execution turn completed." });
+    }
+  }
+
+  private pushActivity(runId: string, kind: ActivityLogEntryKind, message: string, detail?: string) {
+    const run = this.getRun(runId);
+    if (!run) {
+      return;
+    }
+    const entry: ActivityLogEntry = { timestamp: this.now(), kind, message, ...(detail ? { detail } : {}) };
+    run.activity_log.push(entry);
+    if (run.activity_log.length > this.activityLogLimit) {
+      run.activity_log = run.activity_log.slice(-this.activityLogLimit);
     }
   }
 
@@ -604,6 +638,7 @@ export class ExecutionService {
       prompt: input.prompt,
       progress_message: input.resultSummary ?? (input.status === "queued" ? "Execution run queued." : undefined),
       result_summary: input.resultSummary,
+      activity_log: [],
       safety_checks: input.safetyChecks,
       errors: input.errors,
     };
@@ -1008,6 +1043,19 @@ export class ExecutionService {
 
   private uniqueSorted(values: string[]): string[] {
     return [...new Set(values.map((value) => value.trim()).filter(Boolean))].sort();
+  }
+
+  private extractReasoningSummary(assistantText: string): string | null {
+    if (!assistantText || assistantText.length < 20) {
+      return null;
+    }
+    // Take the first meaningful paragraph (up to ~300 chars) as the reasoning summary
+    const lines = assistantText.split("\n").filter((l) => l.trim().length > 0);
+    const summary = lines.slice(0, 4).join(" ").trim();
+    if (summary.length <= 300) {
+      return summary;
+    }
+    return summary.slice(0, 297) + "...";
   }
 
   private getWorktreePath(branch: string): string {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -1,5 +1,13 @@
 export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "running" | "completed" | "error";
 export type ExecutionSafetyStatus = "pass" | "warn" | "fail";
+export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info";
+
+export interface ActivityLogEntry {
+  timestamp: string;
+  kind: ActivityLogEntryKind;
+  message: string;
+  detail?: string;
+}
 
 export interface ExecutionSafetyCheck {
   code: string;
@@ -83,6 +91,7 @@ export interface ExecutionRunRecord {
   prompt: string;
   progress_message?: string;
   result_summary?: string;
+  activity_log: ActivityLogEntry[];
   changed_files?: string[];
   pull_request?: ExecutionPullRequestRecord;
   safety_checks: ExecutionSafetyCheck[];

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -77,6 +77,25 @@
     return "";
   }
 
+  function activityIcon(kind) {
+    if (kind === "tool_start") return "⚙️";
+    if (kind === "tool_end") return "✅";
+    if (kind === "turn_start" || kind === "turn_end") return "🔄";
+    if (kind === "reasoning") return "💡";
+    if (kind === "error") return "❌";
+    if (kind === "status_change") return "📌";
+    return "ℹ️";
+  }
+
+  function formatActivityTime(timestamp) {
+    if (!timestamp) return "";
+    try {
+      return new Date(timestamp).toLocaleTimeString();
+    } catch {
+      return "";
+    }
+  }
+
   async function copyValue(value, message) {
     if (!value || !window?.navigator?.clipboard) {
       copiedMessage = "Clipboard unavailable in this browser.";
@@ -429,7 +448,24 @@
                   </div>
 
                   {#if run.progress_message}
-                    <p>{run.progress_message}</p>
+                    <p class="run-progress-message">{run.progress_message}</p>
+                  {/if}
+
+                  {#if run.activity_log?.length}
+                    <details class="activity-log-details" open={["running", "preparing"].includes(run.status)}>
+                      <summary>Activity log ({run.activity_log.length} event{run.activity_log.length === 1 ? '' : 's'})</summary>
+                      <div class="activity-log">
+                        {#each run.activity_log as entry}
+                          <div class="activity-entry activity-{entry.kind}">
+                            <span class="activity-icon">{activityIcon(entry.kind)}</span>
+                            <span class="activity-time">{formatActivityTime(entry.timestamp)}</span>
+                            <span class="activity-message">{entry.message}</span>
+                          </div>
+                        {/each}
+                      </div>
+                    </details>
+                  {:else if ["running", "preparing"].includes(run.status)}
+                    <div class="activity-log-placeholder muted small-text">Waiting for activity events…</div>
                   {/if}
 
                   <div class="execute-card-actions">
@@ -603,6 +639,80 @@
   .run-timestamp-grid {
     display: grid;
     gap: 0.2rem;
+  }
+
+  .run-progress-message {
+    margin: 0;
+  }
+
+  .activity-log-details {
+    border: 1px solid rgba(148, 163, 184, 0.12);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .activity-log-details summary {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    background: rgba(15, 23, 42, 0.5);
+    color: #93c5fd;
+    user-select: none;
+  }
+
+  .activity-log {
+    max-height: 240px;
+    overflow-y: auto;
+    display: grid;
+    gap: 0;
+    font-size: 0.8rem;
+  }
+
+  .activity-entry {
+    display: grid;
+    grid-template-columns: 1.4em 5.2em 1fr;
+    gap: 0.35rem;
+    align-items: baseline;
+    padding: 0.25rem 0.75rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.06);
+  }
+
+  .activity-entry:first-child {
+    border-top: none;
+  }
+
+  .activity-icon {
+    font-size: 0.75rem;
+    text-align: center;
+  }
+
+  .activity-time {
+    color: #64748b;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .activity-message {
+    color: #e2e8f0;
+    word-break: break-word;
+  }
+
+  .activity-reasoning .activity-message {
+    color: #fde68a;
+    font-style: italic;
+  }
+
+  .activity-error .activity-message {
+    color: #fca5a5;
+  }
+
+  .activity-tool_start .activity-message,
+  .activity-tool_end .activity-message {
+    color: #93c5fd;
+  }
+
+  .activity-log-placeholder {
+    padding: 0.5rem 0;
   }
 
   .ghost-link {


### PR DESCRIPTION
## Summary
## Summary

### Changes made (4 files, all within owned scope):

1. **`src/modules/execution/types.ts`** — Added `ActivityLogEntry` interface and `ActivityLogEntryKind` type. Added `activity_log: ActivityLogEntry[]` field to `ExecutionRunRecord`.

2. **`src/modules/execution/execution.service.ts`** — 
   - `pushActivity()` helper appends entries to the run's activity log (capped at 50 entries)
   - Activity events logged at: run queued, worktree created, session started, tool start/end, turn start/end, execution completed, errors
   - `extractReasoningSummary()` extracts a short summary from the agent's final response text (logged as a `reasoning` entry)
   - `getRunActivityLog()` public method for the API endpoint

3. **`src/modules/execution/execution.controller.ts`** — Added `GET /api/execution/runs/:runId/activity` endpoint.

4. **`web/src/components/ExecutionDispatchPanel.svelte`** — 
   - Expandable activity log section in each run card (auto-opens for running/preparing runs)
   - Grid layout with icon, timestamp, and message per entry
   - Color-coded by entry kind (tools=blue, reasoning=yellow, errors=red)
   - Scrollable with 240px max-height
   - Live updates via existing SSE stream (activity_log is part of the run record)

### Checks performed:
- ✅ TypeScript compilation (`tsc --noEmit`) — clean
- ✅ Vite build — clean  
- ✅ All 38 tests pass

### No blockers.

actual_files synced: 0 file(s).

## Context
- Work item: studio-58
- Issue: https://github.com/fusupo/escapement-studio/issues/58
- Base branch: develop
- Head branch: studio-58-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775512853995
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-58-branch
- Scope hint: Add a detailed per-run activity view with status, progress, tool activity, and user-visible reasoning summaries for execution runs.

## Changed files
- (not recorded)