### PR TITLE
[#63] Studio: align graph work item IDs with GitHub issue numbers for issue-backed items

### DIFF
--- a/src/modules/graph/__tests__/graph-writer.service.test.ts
+++ b/src/modules/graph/__tests__/graph-writer.service.test.ts
@@ -230,6 +230,68 @@ describe("GraphWriterService", () => {
     });
   });
 
+  describe("apply — ID alignment validation", () => {
+    it("rejects issue-backed work item with misaligned ID", () => {
+      const result = writer.apply({
+        mutations: [
+          {
+            mutation_id: "m1",
+            kind: "create_work_item",
+            work_item: { id: "studio-99", name: "Wrong ID", kind: "issue", issue_number: 42 },
+          },
+        ],
+      });
+
+      expect(result.status).toBe("validation_failed");
+      const failed = result as GraphMutationsValidationFailedResult;
+      expect(failed.errors).toHaveLength(1);
+      expect(failed.errors[0].code).toBe("malformed_payload");
+      expect(failed.errors[0].message).toContain("studio-42");
+    });
+
+    it("accepts issue-backed work item with aligned ID", () => {
+      const result = writer.apply({
+        mutations: [
+          {
+            mutation_id: "m1",
+            kind: "create_work_item",
+            work_item: { id: "studio-42", name: "Aligned", kind: "issue", issue_number: 42 },
+          },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+    });
+
+    it("skips alignment check for non-issue kinds", () => {
+      const result = writer.apply({
+        mutations: [
+          {
+            mutation_id: "m1",
+            kind: "create_work_item",
+            work_item: { id: "phase:core", name: "Core Phase", kind: "phase" },
+          },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+    });
+
+    it("skips alignment check for issue items without issue_number", () => {
+      const result = writer.apply({
+        mutations: [
+          {
+            mutation_id: "m1",
+            kind: "create_work_item",
+            work_item: { id: "draft-item", name: "Draft", kind: "issue" },
+          },
+        ],
+      });
+
+      expect(result.status).toBe("applied");
+    });
+  });
+
   describe("apply — version tracking", () => {
     it("increments version on each successful apply", () => {
       writer.apply({

--- a/src/modules/graph/graph-writer.service.ts
+++ b/src/modules/graph/graph-writer.service.ts
@@ -1,19 +1,20 @@
 import { BadRequestException, Inject, Injectable } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { SQLiteService } from "./sqlite.service.js";
-import type {
-  ApplyGraphMutationsDto,
-  ApplyGraphMutationsResult,
-  CreateEdgeDto,
-  CreateWorkItemDto,
-  EdgeConfidence,
-  EdgeRel,
-  GraphMutation,
-  GraphMutationError,
-  UpdateEdgeDto,
-  UpdateWorkItemDto,
-  WorkItemKind,
-  WorkItemState,
+import {
+  checkIdAlignment,
+  type ApplyGraphMutationsDto,
+  type ApplyGraphMutationsResult,
+  type CreateEdgeDto,
+  type CreateWorkItemDto,
+  type EdgeConfidence,
+  type EdgeRel,
+  type GraphMutation,
+  type GraphMutationError,
+  type UpdateEdgeDto,
+  type UpdateWorkItemDto,
+  type WorkItemKind,
+  type WorkItemState,
 } from "./types.js";
 
 interface RawWorkItemRecord {
@@ -136,6 +137,11 @@ export class GraphWriterService {
           }
           if (snapshot.workItems.has(work_item.id)) {
             errors.push(this.error(mutation, "duplicate_entity", `work item already exists: ${work_item.id}`));
+            continue;
+          }
+          const alignmentIssue = checkIdAlignment(work_item.id, work_item.kind, work_item.issue_number);
+          if (alignmentIssue) {
+            errors.push(this.error(mutation, "malformed_payload", alignmentIssue));
             continue;
           }
           snapshot.workItems.set(work_item.id, this.toRawWorkItem(work_item));

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -1,4 +1,33 @@
 export type WorkItemKind = "issue" | "capability" | "phase" | "track";
+
+/**
+ * Derive the canonical work-item ID for an issue-backed item.
+ * Convention: "studio-{issue_number}"
+ */
+export function deriveIssueWorkItemId(issueNumber: number): string {
+  return `studio-${issueNumber}`;
+}
+
+/**
+ * Check whether a work item's ID is aligned with its issue_number.
+ * Returns null if aligned or not applicable, otherwise a diagnostic string.
+ */
+export function checkIdAlignment(
+  id: string,
+  kind: WorkItemKind,
+  issueNumber: number | null | undefined,
+): string | null {
+  if (kind !== "issue" || issueNumber == null) return null;
+  const expected = deriveIssueWorkItemId(issueNumber);
+  if (id === expected) return null;
+  return `ID "${id}" does not match issue_number ${issueNumber} (expected "${expected}")`;
+}
+
+export interface MisalignedWorkItem {
+  id: string;
+  issue_number: number;
+  expected_id: string;
+}
 export type WorkItemState = "planned" | "in_progress" | "open_pr" | "done" | "deferred" | "cancelled";
 export type EdgeRel = "depends_on" | "is_part_of" | "implemented_by";
 export type EdgeConfidence = "certain" | "inferred" | "ambiguous";

--- a/src/modules/graph/work-items.controller.ts
+++ b/src/modules/graph/work-items.controller.ts
@@ -15,6 +15,11 @@ export class WorkItemsController {
     return this.workItems.list({ repo, state, kind });
   }
 
+  @Get("misaligned")
+  findMisaligned() {
+    return this.workItems.findMisaligned();
+  }
+
   @Get(":id")
   get(@Param("id") id: string) {
     return this.workItems.get(id);

--- a/src/modules/graph/work-items.service.ts
+++ b/src/modules/graph/work-items.service.ts
@@ -3,7 +3,7 @@ import type { Database as DatabaseType } from "better-sqlite3";
 import { parseJsonArray } from "../../lib/manifest-core.js";
 import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
-import type { CreateWorkItemDto, UpdateWorkItemDto, WorkItemRecord } from "./types.js";
+import { deriveIssueWorkItemId, type CreateWorkItemDto, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord } from "./types.js";
 
 interface RawWorkItemRecord {
   id: string;
@@ -92,6 +92,27 @@ export class WorkItemsService {
     }
 
     return this.get(id);
+  }
+
+  /**
+   * Find issue-backed work items whose ID does not match their issue_number.
+   */
+  findMisaligned(): MisalignedWorkItem[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, issue_number FROM work_items
+         WHERE kind = 'issue' AND issue_number IS NOT NULL`
+      )
+      .all() as Array<{ id: string; issue_number: number }>;
+
+    const misaligned: MisalignedWorkItem[] = [];
+    for (const row of rows) {
+      const expected = deriveIssueWorkItemId(row.issue_number);
+      if (row.id !== expected) {
+        misaligned.push({ id: row.id, issue_number: row.issue_number, expected_id: expected });
+      }
+    }
+    return misaligned;
   }
 
   delete(id: string): { deleted: true; id: string } {


### PR DESCRIPTION
## Summary
## Summary

### Changes Made (all in `src/modules/graph/`)

| File | Change |
|------|--------|
| `types.ts` | Added `deriveIssueWorkItemId(issueNumber)` utility, `checkIdAlignment(id, kind, issueNumber)` validator, and `MisalignedWorkItem` interface |
| `graph-writer.service.ts` | Added ID alignment validation in `create_work_item` — rejects issue-backed items where ID ≠ `studio-{issue_number}` |
| `work-items.service.ts` | Added `findMisaligned()` method that queries all issue-backed items and returns those with ID/issue_number mismatch |
| `work-items.controller.ts` | Added `GET /api/work-items/misaligned` endpoint for reconciliation detection |
| `__tests__/graph-writer.service.test.ts` | Added 4 tests: rejects misaligned ID, accepts aligned ID, skips check for non-issue kinds, skips check when no issue_number |

### Verification
- **All 42 tests pass** (including 4 new)
- **TypeScript compiles cleanly** (`tsc --noEmit` — no errors)

### Design Decisions
- Validation is a **hard reject** (not a warning) — prevents future misalignment at creation time
- Non-issue kinds (phase, track, capability) and issue items without `issue_number` are **not affected**
- The `findMisaligned()` endpoint enables detection of **pre-existing** mismatches for manual reconciliation

### No Blockers
The planning service (outside owned scope) already defaults to `studio-${created.number}` on line 630, which naturally aligns. The prompt guideline there could be updated to note the validation, but that's outside the owned file set.

actual_files synced: 0 file(s).

## Context
- Work item: studio-63
- Issue: https://github.com/fusupo/escapement-studio/issues/63
- Base branch: develop
- Head branch: studio-63-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775514420608
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-63-branch
- Scope hint: Ensure issue-backed Studio work item IDs stay aligned with their corresponding GitHub issue numbers during creation, staging, and reconciliation.

## Changed files
- (not recorded)