### PR TITLE
[#71] Studio: only show Close issue when the GitHub issue is open and its linked PR is merged

### DIFF
--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { getPullRequestDetails } from "../lib/api.js";
+
   const defaultWorkItem = {
     id: "",
     name: "",
@@ -28,6 +30,9 @@
   export let onCloseIssue = () => {};
   export let closingIssue = false;
 
+  let linkedPrDetails = null;
+  let loadingPr = false;
+
   let editForm = { ...defaultWorkItem };
   let createForm = { ...defaultWorkItem };
   let edgeForm = { ...defaultEdge };
@@ -48,6 +53,35 @@
       edgeForm = { ...edgeForm, from_id: selectedItem.id };
     }
   }
+
+  // Extract linked PR number from the work item (check multiple meta locations)
+  $: linkedPrNumber = selectedItem?.pull_request?.number
+    ?? selectedItem?.meta?.pull_request?.number
+    ?? selectedItem?.meta?.studio_post_merge_sync?.pull_request?.number
+    ?? null;
+
+  // Fetch live PR details when the selected item has a linked PR
+  $: void loadLinkedPrDetails(selectedItem?.repo, linkedPrNumber);
+
+  async function loadLinkedPrDetails(repo, prNumber) {
+    if (!repo || !prNumber) {
+      linkedPrDetails = null;
+      return;
+    }
+    loadingPr = true;
+    try {
+      linkedPrDetails = await getPullRequestDetails({ repo, pull_request_number: prNumber });
+    } catch {
+      linkedPrDetails = null;
+    } finally {
+      loadingPr = false;
+    }
+  }
+
+  // Close issue is allowed only when the GitHub issue is open and the linked PR is merged
+  $: canCloseIssue = issueDetails
+    && issueDetails.state?.toLowerCase() === "open"
+    && linkedPrDetails?.merged_at != null;
 
   $: if (!selectedItem && edgeForm.from_id && !graph.items.some((item) => item.id === edgeForm.from_id)) {
     edgeForm = { ...defaultEdge };
@@ -122,12 +156,23 @@
                 <pre>{issueDetails.managed_block.content}</pre>
               </details>
             {/if}
-            {#if selectedItem.meta?.pull_request?.url}
+            {#if linkedPrDetails}
+              <a href={linkedPrDetails.url} target="_blank" rel="noreferrer">
+                PR #{linkedPrDetails.number}{linkedPrDetails.is_draft ? ' (draft)' : ''}
+                {#if linkedPrDetails.merged_at}
+                  <span class="status-pill">merged</span>
+                {:else if linkedPrDetails.state === 'OPEN'}
+                  <span class="status-pill">open</span>
+                {:else}
+                  <span class="status-pill">{linkedPrDetails.state?.toLowerCase()}</span>
+                {/if}
+              </a>
+            {:else if selectedItem.meta?.pull_request?.url}
               <a href={selectedItem.meta.pull_request.url} target="_blank" rel="noreferrer">
                 PR #{selectedItem.meta.pull_request.number}{selectedItem.meta.pull_request.is_draft ? ' (draft)' : ''}
               </a>
             {/if}
-            {#if issueDetails.state?.toLowerCase() !== 'closed'}
+            {#if canCloseIssue}
               <button class="danger small" on:click={() => onCloseIssue(selectedItem)} disabled={closingIssue}>
                 {closingIssue ? 'Closing…' : 'Close issue'}
               </button>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -62,6 +62,11 @@ export function getGitHubIssueDetails({ repo, issue_number }) {
   return request(`/api/github/issue?${query.toString()}`);
 }
 
+export function getPullRequestDetails({ repo, pull_request_number }) {
+  const query = new URLSearchParams({ repo, pull_request_number: String(pull_request_number) });
+  return request(`/api/github/pull-request?${query.toString()}`);
+}
+
 export function closeGitHubIssue({ repo, issue_number }) {
   return request("/api/github/issue/close", {
     method: "POST",


### PR DESCRIPTION
## Summary
## Summary

### Changes Made

**`web/src/lib/api.js`**
- Added `getPullRequestDetails({ repo, pull_request_number })` — calls the existing `GET /api/github/pull-request` endpoint to fetch live PR details including `merged_at`.

**`web/src/components/Sidebar.svelte`**
- Added reactive PR detail fetching: when a selected work item has a linked PR (checked across `pull_request`, `meta.pull_request`, and `meta.studio_post_merge_sync.pull_request`), it fetches live PR details from the backend.
- **Gated the "Close issue" button** with a `canCloseIssue` reactive: only shows when `issueDetails.state` is `"open"` AND `linkedPrDetails.merged_at` is non-null.
- Enhanced the PR link display to show live status badges (merged/open/closed) when live details are available, with fallback to the static meta link.

### Verification
- `npm run build` passes successfully (only pre-existing a11y warnings in forbidden files).

### No Remaining Blockers
All changes stay within the predicted file scope (Sidebar.svelte + api.js). No forbidden files touched.

actual_files synced: 0 file(s).

## Context
- Work item: studio-71
- Issue: https://github.com/fusupo/escapement-studio/issues/71
- Base branch: develop
- Head branch: studio-71-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775515385435
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-71-branch
- Scope hint: Gate the Close issue action on GitHub issue open state plus linked PR merged state, hiding it unless the issue is open and the implementation PR has merged.

## Changed files
- (not recorded)