### PR TITLE
[#64] Studio: fix multi-issue creation flow that mis-stages or bundles graph proposals incorrectly

### DIFF
--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -68,6 +68,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private turnCounter = 0;
   private currentTurnId: string | null = null;
   private activeProposalId: string | null = null;
+  private proposalCounter = 0;
   private lastCommitResult: PlanningGraphCommitResult | null = null;
   private activeMemoryChangeId: string | null = null;
   private lastMemoryWriteResult: PlanningMemoryWriteResult | null = null;
@@ -628,12 +629,13 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         });
 
         const workItemId = params.work_item_id?.trim() || `studio-${created.number}`;
+        const groupId = `issue-${created.number}`;
 
         const mutations: ProposeMutationsToolInput["mutations"] = [
           {
-            id: "m1",
             type: "create_work_item",
             entity_id: workItemId,
+            group_id: groupId,
             payload: {
               id: workItemId,
               name: created.title,
@@ -649,11 +651,10 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           },
         ];
 
-        let edgeIndex = 2;
         if (params.parent_id?.trim()) {
           mutations.push({
-            id: `m${edgeIndex++}`,
             type: "create_edge",
+            group_id: groupId,
             payload: {
               from_id: workItemId,
               rel: "is_part_of",
@@ -667,8 +668,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           for (const depId of params.depends_on_ids) {
             if (depId?.trim()) {
               mutations.push({
-                id: `m${edgeIndex++}`,
                 type: "create_edge",
+                group_id: groupId,
                 payload: {
                   from_id: workItemId,
                   rel: "depends_on",
@@ -680,10 +681,24 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           }
         }
 
-        const proposal = this.normalizeProposal({
-          summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
-          mutations,
-        });
+        // Accumulate into existing active proposal from the same turn,
+        // so multi-issue creation produces one reviewable proposal.
+        const existingProposal = this.getActiveProposalForAccumulation();
+        let proposal: PlanningMutationProposal;
+
+        if (existingProposal) {
+          proposal = this.accumulateMutations(
+            existingProposal,
+            mutations,
+            `+ GitHub issue #${created.number}: ${created.title}`,
+          );
+        } else {
+          proposal = this.normalizeProposal({
+            summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
+            mutations,
+          });
+        }
+
         this.proposals.set(proposal.proposal_id, proposal);
         this.activeProposalId = proposal.proposal_id;
         this.lastCommitResult = null;
@@ -767,7 +782,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
   private normalizeProposal(input: ProposeMutationsToolInput): PlanningMutationProposal {
     const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
-    const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}`;
+    const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}_${++this.proposalCounter}`;
     const createdAt = input.created_at?.trim() || this.now();
 
     return {
@@ -1029,6 +1044,53 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
   private getActiveProposal(): PlanningMutationProposal | null {
     return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
+  }
+
+  /**
+   * Return the active proposal only if it was created in the current turn
+   * and has not yet been committed — suitable for accumulating additional
+   * mutations from a second github_create_issue call in the same flow.
+   */
+  private getActiveProposalForAccumulation(): PlanningMutationProposal | null {
+    const proposal = this.getActiveProposal();
+    if (!proposal || !this.currentTurnId) {
+      return null;
+    }
+    // Only accumulate when the existing proposal belongs to this turn
+    if (proposal.source.turn_id !== this.currentTurnId) {
+      return null;
+    }
+    return proposal;
+  }
+
+  /**
+   * Append new mutations to an existing proposal, re-numbering their IDs
+   * to avoid collisions. Returns the updated (same-ID) proposal.
+   */
+  private accumulateMutations(
+    existing: PlanningMutationProposal,
+    newMutations: ProposeMutationsToolInput["mutations"],
+    summaryAppendix: string,
+  ): PlanningMutationProposal {
+    // Find the highest existing numeric suffix to avoid ID collisions
+    const maxExistingIndex = existing.mutations.reduce((max, mutation) => {
+      const match = mutation.id.match(/^m(\d+)$/);
+      return match ? Math.max(max, Number(match[1])) : max;
+    }, 0);
+
+    let nextIndex = maxExistingIndex + 1;
+    const normalized = newMutations.map((mutation) =>
+      this.normalizeProposalMutation(
+        { ...mutation, id: `m${nextIndex++}` },
+        0, // index param unused when id is pre-set
+      ),
+    );
+
+    return {
+      ...existing,
+      summary: `${existing.summary} ${summaryAppendix}`,
+      mutations: [...existing.mutations, ...normalized],
+    };
   }
 
   private getActiveMemoryChange(): PlanningMemoryChange | null {

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -125,9 +125,20 @@
     sessionId = event.session_id || sessionId;
 
     if (event.event_type === "mutation_proposal") {
-      activeProposal = event.payload?.proposal ?? null;
+      const nextProposal = event.payload?.proposal ?? null;
+      // When the same proposal is updated (e.g. multi-issue accumulation),
+      // preserve existing selections and auto-select only the new mutations.
+      const isSameProposal = nextProposal && activeProposal && nextProposal.proposal_id === activeProposal.proposal_id;
       lastCommitResult = null;
-      syncMutationSelection(activeProposal);
+      if (isSameProposal) {
+        const existingIds = new Set((activeProposal.mutations ?? []).map((m) => m.id));
+        const newIds = (nextProposal.mutations ?? []).filter((m) => !existingIds.has(m.id)).map((m) => m.id);
+        activeProposal = nextProposal;
+        selectedMutationIds = [...selectedMutationIds.filter((id) => nextProposal.mutations.some((m) => m.id === id)), ...newIds];
+      } else {
+        activeProposal = nextProposal;
+        syncMutationSelection(activeProposal);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
## Summary

### What changed

**`src/modules/planning/planning.service.ts`** (3 fixes):

1. **Proposal ID uniqueness** — Added a monotonic `proposalCounter` so `normalizeProposal` generates `prop_${Date.now()}_${counter}` instead of `prop_${Date.now()}`. This prevents two rapid `github_create_issue` calls from colliding on the same Map key.

2. **Mutation accumulation** — Added `getActiveProposalForAccumulation()` and `accumulateMutations()` methods. When `github_create_issue` runs and there's already a pending proposal from the same turn, new mutations are appended to it (with properly renumbered IDs and `group_id` per issue) instead of creating a separate proposal that overwrites the first.

3. **Group IDs** — Each issue's mutations now carry `group_id: "issue-N"` so they're visually and logically grouped within a combined proposal.

**`web/src/components/PlannerChatAdapter.svelte`** (1 fix):

4. **SSE selection preservation** — When a `mutation_proposal` event arrives for the *same* proposal ID (accumulation case), existing user checkbox selections are preserved and only the newly added mutations are auto-selected.

### Checks performed
- `npm run build` — TypeScript check + Vite web build: ✅
- `npm test` — 42/42 tests pass: ✅

### Remaining notes
- All changes stayed within predicted scope (planning module, github module, PlannerChatAdapter)
- No forbidden files touched
- The fix is backward-compatible: single-issue creation flows work identically (no accumulation target, so a fresh proposal is created as before)

actual_files synced: 0 file(s).

## Context
- Work item: studio-64
- Issue: https://github.com/fusupo/escapement-studio/issues/64
- Base branch: develop
- Head branch: studio-64-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775515734850
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-64-branch
- Scope hint: Fix the bug where creating multiple GitHub issues in one flow can produce confusing or incorrect graph proposal staging.

## Changed files
- (not recorded)