### PR TITLE
[#69] Studio: allow follow-up chat with the executing agent for active and recent runs

### DIFF
--- a/docs/contracts/run-artifacts.md
+++ b/docs/contracts/run-artifacts.md
@@ -71,6 +71,30 @@ Suggested V1 types:
 - `execution`
 - `reconciliation`
 
+## Follow-up chat
+
+Active and recently completed execution runs support follow-up messages from the Studio UI.
+
+### Delivery modes
+
+| Run status | Delivery | Behavior |
+|------------|----------|----------|
+| `running` / `preparing` | `steer` | Interrupts the current turn; message is delivered before the next LLM call. |
+| `running` / `preparing` | `followUp` (default) | Queued; delivered when the current turn finishes. |
+| `completed` | `new_turn` | A new agent session is created in the same worktree and the follow-up is sent as a fresh prompt. |
+
+### API
+
+- `POST /api/execution/follow-up` — `{ run_id, message, delivery? }`
+- `GET /api/execution/runs/:runId/chat` — returns chat history `{ run_id, messages: [{ timestamp, role, text }] }`
+
+### Artifact events
+
+Follow-up interactions append to the existing `events.jsonl`:
+
+- `follow_up_sent` — when a steer/followUp message is accepted by an active session
+- `follow_up_turn_completed` — when a new-turn follow-up finishes
+
 ## Notes
 
 - `status.json` and SSE serve different purposes: current durable snapshot vs live browser transport

--- a/src/modules/execution/__tests__/follow-up-types.test.ts
+++ b/src/modules/execution/__tests__/follow-up-types.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { FollowUpMessageDto, FollowUpMessageResult, RunChatHistory, RunChatMessage } from "../types.js";
+
+describe("follow-up types", () => {
+  it("FollowUpMessageDto accepts minimal input", () => {
+    const dto: FollowUpMessageDto = {
+      run_id: "exec_123",
+      message: "Please also add tests",
+    };
+    expect(dto.run_id).toBe("exec_123");
+    expect(dto.message).toBe("Please also add tests");
+    expect(dto.delivery).toBeUndefined();
+  });
+
+  it("FollowUpMessageDto accepts delivery mode", () => {
+    const dto: FollowUpMessageDto = {
+      run_id: "exec_123",
+      message: "Stop and fix the lint errors",
+      delivery: "steer",
+    };
+    expect(dto.delivery).toBe("steer");
+  });
+
+  it("FollowUpMessageResult represents accepted follow-up", () => {
+    const result: FollowUpMessageResult = {
+      accepted: true,
+      run_id: "exec_123",
+      delivery: "followUp",
+      message: "Please also add tests",
+    };
+    expect(result.accepted).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("FollowUpMessageResult represents rejected follow-up", () => {
+    const result: FollowUpMessageResult = {
+      accepted: false,
+      run_id: "exec_123",
+      delivery: "followUp",
+      message: "test",
+      error: "Run is in blocked status",
+    };
+    expect(result.accepted).toBe(false);
+    expect(result.error).toBe("Run is in blocked status");
+  });
+
+  it("RunChatHistory models conversation", () => {
+    const messages: RunChatMessage[] = [
+      { timestamp: "2026-04-06T10:00:00Z", role: "assistant", text: "Done implementing the feature." },
+      { timestamp: "2026-04-06T10:01:00Z", role: "user", text: "Also add unit tests please." },
+      { timestamp: "2026-04-06T10:02:00Z", role: "assistant", text: "Added 3 test cases." },
+    ];
+    const history: RunChatHistory = {
+      run_id: "exec_456",
+      messages,
+    };
+    expect(history.messages).toHaveLength(3);
+    expect(history.messages[0].role).toBe("assistant");
+    expect(history.messages[1].role).toBe("user");
+  });
+});

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Inject, Param, Post, Query, Sse } from "@nestjs/
 import type { MessageEvent } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { ExecutionService } from "./execution.service.js";
-import type { CleanupWorktreeDto, CreateExecutionPullRequestDto, LaunchExecutionRunDto, SyncMergedExecutionDto } from "./types.js";
+import type { CleanupWorktreeDto, CreateExecutionPullRequestDto, FollowUpMessageDto, LaunchExecutionRunDto, SyncMergedExecutionDto } from "./types.js";
 
 @Controller("api/execution")
 export class ExecutionController {
@@ -46,6 +46,16 @@ export class ExecutionController {
   @Post("cleanup-all")
   cleanupAllStale() {
     return this.executionService.cleanupAllStale();
+  }
+
+  @Post("follow-up")
+  sendFollowUp(@Body() body: FollowUpMessageDto) {
+    return this.executionService.sendFollowUp(body);
+  }
+
+  @Get("runs/:runId/chat")
+  getRunChat(@Param("runId") runId: string) {
+    return this.executionService.getRunChatHistory(runId);
   }
 
   @Sse("stream")

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -22,10 +22,14 @@ import type {
   ExecutionRunRecord,
   ExecutionSafetyCheck,
   ExecutionStatusEvent,
+  FollowUpMessageDto,
+  FollowUpMessageResult,
   LaunchExecutionRunDto,
   LaunchExecutionRunResult,
   CleanupWorktreeDto,
   CleanupWorktreeResult,
+  RunChatHistory,
+  RunChatMessage,
   SyncMergedExecutionDto,
   SyncMergedExecutionResult,
 } from "./types.js";
@@ -41,6 +45,10 @@ export class ExecutionService {
   private readonly recentRunLimit = 16;
   private readonly activityLogLimit = 50;
   private eventCounter = 0;
+  /** Active agent sessions keyed by run_id — kept alive while run is active */
+  private readonly activeSessions = new Map<string, import("@mariozechner/pi-coding-agent").AgentSession>();
+  /** Chat history per run (user follow-ups + assistant replies) */
+  private readonly chatHistories = new Map<string, RunChatMessage[]>();
 
   constructor(
     @Inject(GraphService) private readonly graphService: GraphService,
@@ -459,6 +467,9 @@ export class ExecutionService {
     this.pushActivity(run.run_id, "status_change", "Agent session started.");
     this.appendEvent(run, { type: "session_started", session_id: session.sessionId });
 
+    // Store session so follow-up messages can reach it while the run is active
+    this.activeSessions.set(run.run_id, session);
+
     const runId = run.run_id;
     const unsubscribe = session.subscribe((event) => {
       this.handleSessionEvent(runId, event);
@@ -468,10 +479,13 @@ export class ExecutionService {
       await session.prompt(run.prompt);
     } finally {
       unsubscribe();
+      this.activeSessions.delete(run.run_id);
       session.dispose();
     }
 
     const assistantText = session.getLastAssistantText()?.trim() ?? "Execution run completed without a terminal summary.";
+    // Record the initial run response in chat history so follow-up has context
+    this.pushChatMessage(run.run_id, { timestamp: this.now(), role: "assistant", text: assistantText });
     // Extract a short reasoning summary from the assistant's final text
     const reasoningSummary = this.extractReasoningSummary(assistantText);
     if (reasoningSummary) {
@@ -498,6 +512,140 @@ export class ExecutionService {
   getRunActivityLog(runId: string): ActivityLogEntry[] {
     const run = this.getRun(runId);
     return run?.activity_log ?? [];
+  }
+
+  getRunChatHistory(runId: string): RunChatHistory {
+    return {
+      run_id: runId,
+      messages: this.chatHistories.get(runId) ?? [],
+    };
+  }
+
+  async sendFollowUp(input: FollowUpMessageDto): Promise<FollowUpMessageResult> {
+    const runId = input.run_id?.trim();
+    if (!runId) {
+      throw new BadRequestException("run_id is required");
+    }
+    const message = input.message?.trim();
+    if (!message) {
+      throw new BadRequestException("message is required");
+    }
+
+    const run = this.getRun(runId);
+    if (!run) {
+      throw new BadRequestException(`Unknown execution run: ${runId}`);
+    }
+
+    // Record the user message in chat history
+    this.pushChatMessage(runId, { timestamp: this.now(), role: "user", text: message });
+
+    const session = this.activeSessions.get(runId);
+
+    // Active session: steer or follow-up into the live run
+    if (session && (run.status === "running" || run.status === "preparing")) {
+      const delivery = input.delivery ?? "followUp";
+      try {
+        if (delivery === "steer") {
+          await session.steer(message);
+        } else {
+          await session.followUp(message);
+        }
+        this.pushActivity(runId, "follow_up", `Follow-up (${delivery}): ${message.length > 120 ? message.slice(0, 117) + "..." : message}`);
+        this.appendEvent(run, { type: "follow_up_sent", delivery, message_length: message.length });
+        return { accepted: true, run_id: runId, delivery, message };
+      } catch (error) {
+        const errorMessage = this.getErrorMessage(error);
+        this.pushActivity(runId, "error", `Follow-up delivery failed: ${errorMessage}`);
+        return { accepted: false, run_id: runId, delivery, message, error: errorMessage };
+      }
+    }
+
+    // Completed run: spin up a new session in the worktree for a continuation turn
+    if (run.status === "completed" && existsSync(run.worktree_path)) {
+      try {
+        this.pushActivity(runId, "follow_up", `Starting follow-up turn: ${message.length > 120 ? message.slice(0, 117) + "..." : message}`);
+        const updatedRun = this.updateRun(runId, {
+          status: "running",
+          progress_message: "Follow-up turn running.",
+        });
+        if (!updatedRun) {
+          return { accepted: false, run_id: runId, delivery: "new_turn", message, error: "Failed to update run status" };
+        }
+
+        // Fire-and-forget the follow-up turn
+        void this.executeFollowUpTurn(updatedRun, message).catch((error) => {
+          this.pushActivity(runId, "error", `Follow-up turn failed: ${this.getErrorMessage(error)}`);
+          this.updateRun(runId, {
+            status: "completed",
+            progress_message: `Follow-up turn failed: ${this.getErrorMessage(error)}`,
+          });
+        });
+
+        return { accepted: true, run_id: runId, delivery: "new_turn", message };
+      } catch (error) {
+        return { accepted: false, run_id: runId, delivery: "new_turn", message, error: this.getErrorMessage(error) };
+      }
+    }
+
+    return {
+      accepted: false,
+      run_id: runId,
+      delivery: input.delivery ?? "followUp",
+      message,
+      error: `Cannot send follow-up to run in status "${run.status}". Only running or completed runs accept follow-up messages.`,
+    };
+  }
+
+  private async executeFollowUpTurn(run: ExecutionRunRecord, message: string) {
+    const { session, modelFallbackMessage } = await createAgentSession({
+      cwd: run.worktree_path,
+      sessionManager: SessionManager.inMemory(run.worktree_path),
+      tools: createCodingTools(run.worktree_path),
+    });
+
+    if (modelFallbackMessage) {
+      this.logger.warn(modelFallbackMessage);
+    }
+
+    this.activeSessions.set(run.run_id, session);
+    const unsubscribe = session.subscribe((event) => {
+      this.handleSessionEvent(run.run_id, event);
+    });
+
+    try {
+      await session.prompt(message);
+    } finally {
+      unsubscribe();
+      this.activeSessions.delete(run.run_id);
+      session.dispose();
+    }
+
+    const assistantText = session.getLastAssistantText()?.trim() ?? "Follow-up turn completed without a summary.";
+    this.pushChatMessage(run.run_id, { timestamp: this.now(), role: "assistant", text: assistantText });
+
+    const changedFiles = this.listChangedFiles(run.worktree_path);
+    const actualFilesSync = this.syncActualFiles(run.work_item_id, changedFiles);
+
+    this.pushActivity(run.run_id, "follow_up", `Follow-up turn completed. ${changedFiles.length} file(s) changed.`);
+    const nextRun = this.updateRun(run.run_id, {
+      status: "completed",
+      completed_at: this.now(),
+      progress_message: "Follow-up turn completed.",
+      result_summary: assistantText,
+      changed_files: changedFiles,
+    });
+    if (nextRun) {
+      this.writeSummary(nextRun);
+      this.appendEvent(nextRun, { type: "follow_up_turn_completed", changed_files: changedFiles, actual_files_sync: actualFilesSync });
+      this.emitRun("execution_result", nextRun);
+    }
+  }
+
+  private pushChatMessage(runId: string, message: RunChatMessage) {
+    if (!this.chatHistories.has(runId)) {
+      this.chatHistories.set(runId, []);
+    }
+    this.chatHistories.get(runId)!.push(message);
   }
 
   private handleSessionEvent(runId: string, event: AgentSessionEvent) {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -1,6 +1,6 @@
 export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "running" | "completed" | "error";
 export type ExecutionSafetyStatus = "pass" | "warn" | "fail";
-export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info";
+export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info" | "follow_up";
 
 export interface ActivityLogEntry {
   timestamp: string;
@@ -192,4 +192,30 @@ export interface SyncMergedExecutionResult {
 
 export interface ExecutionStatusEvent {
   run: ExecutionRunRecord;
+}
+
+export interface FollowUpMessageDto {
+  run_id: string;
+  message: string;
+  /** "steer" interrupts the current turn; "followUp" waits for the current turn to finish. Default: "followUp" */
+  delivery?: "steer" | "followUp";
+}
+
+export interface FollowUpMessageResult {
+  accepted: boolean;
+  run_id: string;
+  delivery: "steer" | "followUp" | "new_turn";
+  message: string;
+  error?: string;
+}
+
+export interface RunChatHistory {
+  run_id: string;
+  messages: RunChatMessage[];
+}
+
+export interface RunChatMessage {
+  timestamp: string;
+  role: "user" | "assistant";
+  text: string;
 }

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { getExecutionPreview, launchExecutionRun, listExecutionRuns, openPullRequest } from "../lib/api.js";
+  import { getExecutionPreview, getRunChatHistory, launchExecutionRun, listExecutionRuns, openPullRequest, sendFollowUpMessage } from "../lib/api.js";
 
   let preview = null;
   let runs = [];
@@ -14,6 +14,10 @@
   let launchingIds = [];
   let openingPrRunIds = [];
   let prResults = {};
+  let followUpTexts = {};
+  let sendingFollowUp = {};
+  let chatHistories = {};
+  let expandedChat = {};
 
   $: activeRuns = runs.filter((run) => ["queued", "preparing", "running"].includes(run.status));
   $: completedRuns = runs.filter((run) => run.status === "completed");
@@ -149,6 +153,67 @@
       error = prError.message;
     } finally {
       openingPrRunIds = openingPrRunIds.filter((id) => id !== run.run_id);
+    }
+  }
+
+  function canSendFollowUp(run) {
+    return ["running", "preparing", "completed"].includes(run.status);
+  }
+
+  async function handleSendFollowUp(run) {
+    const text = (followUpTexts[run.run_id] || "").trim();
+    if (!text) return;
+
+    sendingFollowUp = { ...sendingFollowUp, [run.run_id]: true };
+    error = "";
+
+    // Optimistically add to local chat history
+    const userMsg = { timestamp: new Date().toISOString(), role: "user", text };
+    chatHistories = {
+      ...chatHistories,
+      [run.run_id]: [...(chatHistories[run.run_id] || []), userMsg],
+    };
+    followUpTexts = { ...followUpTexts, [run.run_id]: "" };
+    expandedChat = { ...expandedChat, [run.run_id]: true };
+
+    try {
+      const delivery = ["running", "preparing"].includes(run.status) ? "followUp" : undefined;
+      const result = await sendFollowUpMessage({
+        run_id: run.run_id,
+        message: text,
+        ...(delivery ? { delivery } : {}),
+      });
+      if (!result.accepted) {
+        error = result.error || "Follow-up was not accepted.";
+      }
+    } catch (followUpError) {
+      error = followUpError.message;
+    } finally {
+      sendingFollowUp = { ...sendingFollowUp, [run.run_id]: false };
+    }
+  }
+
+  async function loadChatHistory(runId) {
+    try {
+      const result = await getRunChatHistory(runId);
+      chatHistories = { ...chatHistories, [runId]: result.messages || [] };
+    } catch (chatError) {
+      console.error("Failed to load chat history", chatError);
+    }
+  }
+
+  function toggleChat(runId) {
+    const next = !expandedChat[runId];
+    expandedChat = { ...expandedChat, [runId]: next };
+    if (next && !chatHistories[runId]) {
+      loadChatHistory(runId);
+    }
+  }
+
+  function handleFollowUpKeydown(event, run) {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      handleSendFollowUp(run);
     }
   }
 
@@ -474,6 +539,11 @@
                     {/if}
                     <button class="secondary small" on:click={() => copyValue(run.branch, `Copied branch ${run.branch}`)}>Copy branch</button>
                     <button class="secondary small" on:click={() => copyValue(run.worktree_path, `Copied worktree for ${run.work_item_id}`)}>Copy worktree</button>
+                    {#if canSendFollowUp(run)}
+                      <button class="secondary small" on:click={() => toggleChat(run.run_id)}>
+                        {expandedChat[run.run_id] ? 'Hide chat' : 'Follow-up chat'}
+                      </button>
+                    {/if}
                     {#if run.status === "completed"}
                       {#if run.pull_request}
                         <a class="ghost-link small" href={run.pull_request.url} target="_blank" rel="noreferrer">PR #{run.pull_request.number}</a>
@@ -487,6 +557,39 @@
                       <a class="ghost-link small" href="#reconciliation-panel">Review reconciliation</a>
                     {/if}
                   </div>
+
+                  {#if expandedChat[run.run_id] && canSendFollowUp(run)}
+                    <div class="follow-up-chat">
+                      {#if chatHistories[run.run_id]?.length}
+                        <div class="follow-up-messages">
+                          {#each chatHistories[run.run_id] as msg}
+                            <div class="follow-up-msg follow-up-{msg.role}">
+                              <span class="follow-up-role">{msg.role === 'user' ? 'You' : 'Agent'}</span>
+                              <span class="follow-up-time">{formatActivityTime(msg.timestamp)}</span>
+                              <div class="follow-up-text">{msg.text}</div>
+                            </div>
+                          {/each}
+                        </div>
+                      {/if}
+                      <div class="follow-up-input-row">
+                        <textarea
+                          class="follow-up-input"
+                          placeholder={["running", "preparing"].includes(run.status) ? "Steer or follow up on the active run…" : "Send a follow-up message to continue this run…"}
+                          bind:value={followUpTexts[run.run_id]}
+                          on:keydown={(e) => handleFollowUpKeydown(e, run)}
+                          rows="2"
+                          disabled={sendingFollowUp[run.run_id]}
+                        ></textarea>
+                        <button
+                          class="follow-up-send"
+                          on:click={() => handleSendFollowUp(run)}
+                          disabled={sendingFollowUp[run.run_id] || !(followUpTexts[run.run_id] || '').trim()}
+                        >
+                          {sendingFollowUp[run.run_id] ? 'Sending…' : 'Send'}
+                        </button>
+                      </div>
+                    </div>
+                  {/if}
 
                   {#if run.result_summary}
                     <details>
@@ -713,6 +816,93 @@
 
   .activity-log-placeholder {
     padding: 0.5rem 0;
+  }
+
+  /* Follow-up chat */
+  .follow-up-chat {
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    border-radius: 8px;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.45);
+  }
+
+  .follow-up-messages {
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 0.5rem 0.65rem;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .follow-up-msg {
+    display: grid;
+    gap: 0.15rem;
+  }
+
+  .follow-up-role {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .follow-up-user .follow-up-role {
+    color: #93c5fd;
+  }
+
+  .follow-up-assistant .follow-up-role {
+    color: #86efac;
+  }
+
+  .follow-up-time {
+    font-size: 0.7rem;
+    color: #64748b;
+  }
+
+  .follow-up-text {
+    font-size: 0.82rem;
+    color: #e2e8f0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 80px;
+    overflow-y: auto;
+  }
+
+  .follow-up-input-row {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem 0.65rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.1);
+    align-items: flex-end;
+  }
+
+  .follow-up-input {
+    flex: 1;
+    resize: vertical;
+    min-height: 2.2rem;
+    max-height: 6rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: 6px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(2, 6, 23, 0.6);
+    color: #e2e8f0;
+    font-size: 0.85rem;
+    font-family: inherit;
+    line-height: 1.4;
+  }
+
+  .follow-up-input::placeholder {
+    color: #64748b;
+  }
+
+  .follow-up-input:focus {
+    outline: none;
+    border-color: rgba(96, 165, 250, 0.5);
+  }
+
+  .follow-up-send {
+    align-self: flex-end;
+    white-space: nowrap;
   }
 
   .ghost-link {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -107,6 +107,18 @@ export function openPullRequest(payload) {
   });
 }
 
+export function sendFollowUpMessage(payload) {
+  return request("/api/execution/follow-up", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getRunChatHistory(runId) {
+  return request(`/api/execution/runs/${encodeURIComponent(runId)}/chat`);
+}
+
 export function getReconciliationReports(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary
## Summary

### What changed

| File | Change |
|------|--------|
| `src/modules/execution/types.ts` | Added `FollowUpMessageDto`, `FollowUpMessageResult`, `RunChatHistory`, `RunChatMessage` types; added `"follow_up"` to `ActivityLogEntryKind` |
| `src/modules/execution/execution.service.ts` | Stored active `AgentSession` refs in a `Map`; added `sendFollowUp()` (routes to steer/followUp for active sessions, creates new session for completed runs); added `getRunChatHistory()`, `executeFollowUpTurn()`, `pushChatMessage()`; records initial assistant response in chat history |
| `src/modules/execution/execution.controller.ts` | Added `POST /api/execution/follow-up` and `GET /api/execution/runs/:runId/chat` endpoints |
| `web/src/lib/api.js` | Added `sendFollowUpMessage()` and `getRunChatHistory()` API client functions |
| `web/src/components/ExecutionDispatchPanel.svelte` | Added follow-up chat UI: expandable chat panel per run card with message history, textarea input, Enter-to-send, and delivery-mode-aware placeholder text |
| `docs/contracts/run-artifacts.md` | Documented follow-up delivery modes (steer/followUp/new_turn), new API endpoints, and artifact event types |
| `src/modules/execution/__tests__/follow-up-types.test.ts` | New test file with 5 tests for DTO types and chat history modeling |

### How it works

- **Active runs** (`running`/`preparing`): The `AgentSession` is stored in a `Map<runId, AgentSession>`. Follow-up messages are delivered via `session.followUp()` (default) or `session.steer()` (for urgent corrections). The session ref is cleaned up when the run completes.
- **Completed runs**: A new `AgentSession` is spun up in the existing worktree, the follow-up is sent as a fresh `prompt()`, and the run transitions back to `running` → `completed`. Changed files are re-synced.
- **Chat history**: Both user follow-ups and assistant replies are tracked in-memory per run, accessible via `GET /runs/:id/chat`.

### Tests and checks

- **TypeScript**: `npx tsc --noEmit` passes cleanly
- **Vitest**: All 47 tests pass (42 existing + 5 new)
- All changes stay within the predicted file scope

### Remaining blockers

- None blocking merge. Potential follow-ups:
  - Persist chat history to disk (currently in-memory only, lost on server restart)
  - SSE push of assistant replies for follow-up turns so the chat panel updates in real-time without polling
  - Rate-limiting follow-up messages to prevent overloading active sessions

actual_files synced: 0 file(s).

## Context
- Work item: studio-69
- Issue: https://github.com/fusupo/escapement-studio/issues/69
- Base branch: develop
- Head branch: studio-69-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775517316863
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-69-branch
- Scope hint: Add a follow-up chat surface for active/recent execution runs so users can correct or steer the executing agent without restarting the workflow.

## Changed files
- (not recorded)