### PR TITLE
[#81] Studio: deselect the current graph node when clicking the graph background

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -226,7 +226,7 @@
           {#if loading}
             <div class="empty-state">Loading graph…</div>
           {:else}
-            <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item.id)} />
+            <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item?.id ?? null)} />
           {/if}
         </div>
 

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -354,7 +354,13 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     .attr("pointer-events", "none");
 
   // Click to select
-  node.on("click", (_, d) => onSelect(d));
+  node.on("click", (event, d) => {
+    event.stopPropagation();
+    onSelect(d);
+  });
+
+  // Click background to deselect
+  svg.on("click", () => onSelect(null));
 
   // Node hover
   node.on("mouseenter", (event, d) => {


### PR DESCRIPTION
## Summary
Clean and minimal. Let me summarize:

## Summary

### Changes Made

1. **`web/src/lib/graph.js`** (owned file):
   - Added `event.stopPropagation()` to node click handler so clicks on nodes don't bubble up to the SVG background
   - Added `svg.on("click", () => onSelect(null))` to deselect the current node when clicking the empty graph background

2. **`web/src/App.svelte`** (outside predicted scope — necessary fix):
   - Changed `onSelect={(item) => (selectedId = item.id)}` to `onSelect={(item) => (selectedId = item?.id ?? null)}` to safely handle `null` when the background click triggers deselection (without this, clicking the background would crash with `Cannot read property 'id' of null`)

### Why App.svelte was touched
The existing `onSelect` callback assumed `item` would always be a node object. Since the deselection feature passes `null`, the callback needed a null-safe guard. This is a 1-character-level change (`item?.id ?? null`).

### Verification
- Vite production build succeeds with no errors
- The diff is minimal: 2 files, ~8 lines changed

### No remaining blockers
The feature is complete and ready for review.

actual_files synced: 2 file(s).

## Context
- Work item: studio-81
- Issue: https://github.com/fusupo/escapement-studio/issues/81
- Base branch: develop
- Head branch: studio-81-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775541215174
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-81-branch
- Scope hint: Clear the current graph node selection when the user clicks the empty graph background/stage.

## Changed files
- `web/src/App.svelte`
- `web/src/lib/graph.js`