### PR TITLE
[#92] Studio: fix status banner styling and selectability in planner chat

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -134,6 +134,17 @@ h1, h2, h3 {
 .inline-banner {
   width: 100%;
   margin: 0;
+  user-select: text;
+  cursor: text;
+}
+
+.planner-banners {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.planner-banners:not(:has(.banner)) {
+  display: none;
 }
 
 /* ── Graph ── */
@@ -232,7 +243,7 @@ h1, h2, h3 {
 /* ── Planner chat (left sidebar) ── */
 .planner-chat {
   display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto auto minmax(0, 1fr) auto;
   height: 100%;
   padding: 0.75rem;
   gap: 0.5rem;

--- a/web/src/components/PlannerChatAdapter.svelte
+++ b/web/src/components/PlannerChatAdapter.svelte
@@ -568,43 +568,45 @@
       </button>
     </div>
 
-    {#if error}<div class="banner error inline-banner">{error}</div>{/if}
+    <div class="planner-banners">
+      {#if error}<div class="banner error inline-banner">{error}</div>{/if}
 
-    {#if lastCommitResult}
-    <div class="banner {lastCommitResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
-      {#if lastCommitResult.result.status === 'applied'}
-        Applied {lastCommitResult.approved_mutation_ids.length} mutation(s) from {lastCommitResult.proposal_id}. Graph version {lastCommitResult.result.previous_graph_version} → {lastCommitResult.result.new_graph_version}.
-      {:else if lastCommitResult.result.status === 'stale'}
-        Proposal {lastCommitResult.proposal_id} is stale. Current graph version: {lastCommitResult.result.current_graph_version}.
-      {:else}
-        Commit failed for proposal {lastCommitResult.proposal_id}: {lastCommitResult.result.errors.map((item) => item.message).join('; ')}
+      {#if lastCommitResult}
+      <div class="banner {lastCommitResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+        {#if lastCommitResult.result.status === 'applied'}
+          Applied {lastCommitResult.approved_mutation_ids.length} mutation(s) from {lastCommitResult.proposal_id}. Graph version {lastCommitResult.result.previous_graph_version} → {lastCommitResult.result.new_graph_version}.
+        {:else if lastCommitResult.result.status === 'stale'}
+          Proposal {lastCommitResult.proposal_id} is stale. Current graph version: {lastCommitResult.result.current_graph_version}.
+        {:else}
+          Commit failed for proposal {lastCommitResult.proposal_id}: {lastCommitResult.result.errors.map((item) => item.message).join('; ')}
+        {/if}
+      </div>
+      {/if}
+
+      {#if lastMemoryWriteResult}
+      <div class="banner {lastMemoryWriteResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+        {#if lastMemoryWriteResult.result.status === 'applied'}
+          Applied {lastMemoryWriteResult.approved_edit_ids.length} planning memory edit(s). Memory hash {lastMemoryWriteResult.result.previous_content_hash.slice(0, 8)} → {lastMemoryWriteResult.result.new_content_hash.slice(0, 8)}.
+        {:else if lastMemoryWriteResult.result.status === 'stale'}
+          Memory change {lastMemoryWriteResult.change_id} is stale. Current memory hash: {lastMemoryWriteResult.result.current_content_hash.slice(0, 8)}.
+        {:else}
+          Memory write failed: {lastMemoryWriteResult.result.errors.map((item) => item.message).join('; ')}
+        {/if}
+      </div>
+      {/if}
+
+      {#if lastGitHubSyncResult}
+      <div class="banner {lastGitHubSyncResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
+        {#if lastGitHubSyncResult.result.status === 'applied'}
+          Applied {lastGitHubSyncResult.approved_operation_ids.length} GitHub sync operation(s). Body hash {lastGitHubSyncResult.result.previous_body_hash.slice(0, 8)} → {lastGitHubSyncResult.result.new_body_hash.slice(0, 8)}.
+        {:else if lastGitHubSyncResult.result.status === 'stale'}
+          GitHub sync {lastGitHubSyncResult.sync_id} is stale. Current body hash: {lastGitHubSyncResult.result.current_body_hash.slice(0, 8)}.
+        {:else}
+          GitHub sync failed: {lastGitHubSyncResult.result.errors.map((item) => item.message).join('; ')}
+        {/if}
+      </div>
       {/if}
     </div>
-    {/if}
-
-    {#if lastMemoryWriteResult}
-    <div class="banner {lastMemoryWriteResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
-      {#if lastMemoryWriteResult.result.status === 'applied'}
-        Applied {lastMemoryWriteResult.approved_edit_ids.length} planning memory edit(s). Memory hash {lastMemoryWriteResult.result.previous_content_hash.slice(0, 8)} → {lastMemoryWriteResult.result.new_content_hash.slice(0, 8)}.
-      {:else if lastMemoryWriteResult.result.status === 'stale'}
-        Memory change {lastMemoryWriteResult.change_id} is stale. Current memory hash: {lastMemoryWriteResult.result.current_content_hash.slice(0, 8)}.
-      {:else}
-        Memory write failed: {lastMemoryWriteResult.result.errors.map((item) => item.message).join('; ')}
-      {/if}
-    </div>
-    {/if}
-
-    {#if lastGitHubSyncResult}
-    <div class="banner {lastGitHubSyncResult.result.status === 'applied' ? 'success' : 'error'} inline-banner">
-      {#if lastGitHubSyncResult.result.status === 'applied'}
-        Applied {lastGitHubSyncResult.approved_operation_ids.length} GitHub sync operation(s). Body hash {lastGitHubSyncResult.result.previous_body_hash.slice(0, 8)} → {lastGitHubSyncResult.result.new_body_hash.slice(0, 8)}.
-      {:else if lastGitHubSyncResult.result.status === 'stale'}
-        GitHub sync {lastGitHubSyncResult.sync_id} is stale. Current body hash: {lastGitHubSyncResult.result.current_body_hash.slice(0, 8)}.
-      {:else}
-        GitHub sync failed: {lastGitHubSyncResult.result.errors.map((item) => item.message).join('; ')}
-      {/if}
-    </div>
-    {/if}
 
     {#if chatSubTab === 'transcript'}
     <div class="planner-scroll-region" bind:this={chatScrollEl}>


### PR DESCRIPTION
## Summary
## Summary

### Changes made

**`web/src/components/PlannerChatAdapter.svelte`**
- Wrapped all status banners (error, commit result, memory write result, GitHub sync result) in a single `<div class="planner-banners">` container. Previously each banner was a direct grid child, causing extra implicit grid rows that broke the `grid-template-rows: auto auto auto minmax(0,1fr) auto` layout when banners appeared.

**`web/src/app.css`**
- Updated `.planner-chat` grid from 5 rows to 6: `auto auto auto auto minmax(0,1fr) auto` to account for the banner container row.
- Added `user-select: text; cursor: text` to `.inline-banner` so banner text is selectable/copyable.
- Added `.planner-banners` styles: grid with gap for stacking multiple banners.
- Added `.planner-banners:not(:has(.banner))` to collapse the container when no banners are visible, preventing a spurious gap.

### Verification
- Vite production build succeeds (`✓ 1393 modules transformed`)
- No new warnings in build output

### Scope notes
- Both files modified (`app.css`, `PlannerChatAdapter.svelte`) were not in predicted/forbidden lists — this is expected since no files were predicted for this styling fix.
- Changes are minimal and focused on the banner layout issue only.

### No remaining blockers

actual_files synced: 0 file(s).

## Context
- Work item: studio-92
- Issue: https://github.com/fusupo/escapement-studio/issues/92
- Base branch: develop
- Head branch: studio-92-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775545479468
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-92-branch
- Scope hint: Fix planner chat status banners so success/error feedback is readable, properly styled, and selectable without breaking chat/tools layout.

## Changed files
- (not recorded)