### PR TITLE
[#101] Studio: reverse graph arrow direction for depends_on and is_part_of edges

### DIFF
--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -161,7 +161,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     const color = EDGE_COLORS[link.rel] ?? "#484f58";
     const dash = EDGE_DASH[link.rel] ?? "";
     const w = link.confidence === "ambiguous" ? 1 : 1.5;
-    g.setEdge(link.target, link.source, {
+    g.setEdge(link.source, link.target, {
       style: `stroke: ${color}; stroke-width: ${w}px; fill: none; stroke-opacity: 0.6;${dash ? ` stroke-dasharray: ${dash};` : ""}`,
       arrowheadStyle: `fill: ${color}; stroke: none; opacity: 0.8;`,
       curve: d3.curveBasis,


### PR DESCRIPTION
## Summary
That's the fix. Here's what was wrong and what I changed:

**Problem:** In `web/src/lib/graph.js`, the dagre edge was created as `g.setEdge(link.target, link.source, ...)` which reversed the arrow direction. For a `depends_on` edge where A depends on B (`from_id=A, to_id=B`), the arrow was pointing at A (the dependent) instead of B (the dependency).

**Fix:** Swapped to `g.setEdge(link.source, link.target, ...)` so arrows now point from the dependent toward the dependency/parent — matching the semantic direction of `depends_on` and `is_part_of`.

Want me to commit this?

## Context
- Work item: studio-101
- Issue: https://github.com/fusupo/escapement-studio/issues/101
- Base branch: develop
- Head branch: studio-101-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775581985993
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-101-branch
- Scope hint: Fix graph rendering so depends_on and is_part_of arrows point toward dependency/parent targets rather than toward the source item.

## Changed files
- `web/src/lib/graph.js`