### PR TITLE
[#95] Studio: create and maintain a worktree-local scratchpad before implementation begins

### DIFF
--- a/src/modules/execution/__tests__/build-scratchpad.test.ts
+++ b/src/modules/execution/__tests__/build-scratchpad.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionRunRecord, ExecutionDispatchNodePreview } from "../types.js";
+
+/**
+ * We test buildScratchpad by constructing a minimal service instance via
+ * Object.create so we can call the public method without wiring up DI.
+ */
+function callBuildScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
+  const service = Object.create(ExecutionService.prototype) as ExecutionService;
+  return service.buildScratchpad(run, node);
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_1234",
+    run_type: "execution",
+    work_item_id: "studio-42",
+    work_item_name: "Add widget support",
+    status: "preparing",
+    created_at: "2026-04-07T00:00:00.000Z",
+    updated_at: "2026-04-07T00:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/42",
+    branch: "studio-42-branch",
+    base_ref: "develop",
+    worktree_path: "/tmp/worktrees/studio-42-branch",
+    artifact_dir: "/tmp/artifacts/exec_1234",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function makeNode(overrides: Partial<ExecutionDispatchNodePreview> = {}): ExecutionDispatchNodePreview {
+  return {
+    id: "studio-42",
+    name: "Add widget support",
+    repo: "fusupo/escapement-studio",
+    branch: "studio-42-branch",
+    default_base_ref: "develop",
+    files_owned: [],
+    files_shared: [],
+    files_forbidden: [],
+    worktree_path: "/tmp/worktrees/studio-42-branch",
+    safety_checks: [],
+    can_launch: true,
+    ...overrides,
+  };
+}
+
+describe("buildScratchpad", () => {
+  it("produces a markdown document with correct heading", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode());
+    expect(md).toContain("# Scratchpad: studio-42 — Add widget support");
+  });
+
+  it("includes context fields", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode({ scope_hint: "Add widget rendering" }));
+    expect(md).toContain("**Repo:** fusupo/escapement-studio");
+    expect(md).toContain("**Issue:** https://github.com/fusupo/escapement-studio/issues/42");
+    expect(md).toContain("**Branch:** studio-42-branch");
+    expect(md).toContain("**Base ref:** develop");
+    expect(md).toContain("**Scope hint:** Add widget rendering");
+  });
+
+  it("lists owned files", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode({ files_owned: ["src/widget.ts", "src/widget.test.ts"] }));
+    expect(md).toContain("### Owned\n- src/widget.ts\n- src/widget.test.ts");
+  });
+
+  it("shows placeholder when no owned files", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode({ files_owned: [] }));
+    expect(md).toContain("### Owned\n- (none predicted)");
+  });
+
+  it("lists shared files with assessment", () => {
+    const md = callBuildScratchpad(
+      makeRun(),
+      makeNode({
+        files_shared: [{ path: "src/shared.ts", assessment: "read-only", confidence: "high", notes: "" }],
+      }),
+    );
+    expect(md).toContain("- src/shared.ts (read-only/high)");
+  });
+
+  it("lists forbidden files", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode({ files_forbidden: ["src/do-not-touch.ts"] }));
+    expect(md).toContain("### Forbidden\n- src/do-not-touch.ts");
+  });
+
+  it("includes implementation plan section with checkboxes", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode());
+    expect(md).toContain("## Implementation Plan");
+    expect(md).toContain("- [ ] Analyze scope");
+    expect(md).toContain("- [ ] Implement changes");
+    expect(md).toContain("- [ ] Run tests / verify");
+    expect(md).toContain("- [ ] Summarize results");
+  });
+
+  it("includes work log and blockers sections", () => {
+    const md = callBuildScratchpad(makeRun(), makeNode());
+    expect(md).toContain("## Work Log");
+    expect(md).toContain("## Blockers");
+  });
+
+  it("handles missing optional fields gracefully", () => {
+    const md = callBuildScratchpad(
+      makeRun({ repo: null, issue_url: null }),
+      makeNode({ scope_hint: null }),
+    );
+    expect(md).toContain("**Repo:** (not set)");
+    expect(md).toContain("**Issue:** (not linked)");
+    expect(md).toContain("**Scope hint:** (not set)");
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -448,6 +448,10 @@ export class ExecutionService {
     this.pushActivity(run.run_id, "status_change", `Worktree created at ${run.worktree_path}`, `Branch: ${run.branch}, Base: ${run.base_ref}`);
     this.appendEvent(run, { type: "worktree_created", worktree_path: run.worktree_path, branch: run.branch, base_ref: run.base_ref });
 
+    const scratchpadPath = this.writeScratchpad(run, node);
+    this.pushActivity(run.run_id, "status_change", `Scratchpad written to ${scratchpadPath}`);
+    this.appendEvent(run, { type: "scratchpad_written", path: scratchpadPath });
+
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd: run.worktree_path,
       sessionManager: SessionManager.inMemory(run.worktree_path),
@@ -776,7 +780,72 @@ export class ExecutionService {
       forbidden,
       "",
       "If you must go beyond the predicted scope, explain why in the final summary.",
+      "",
+      "A SCRATCHPAD.md file has been created in your worktree with structured context.",
+      "Update it as you work: check off progress items, add work-log notes, and record any blockers.",
+      "Do not commit SCRATCHPAD.md — it is a local working document.",
     ].join("\n");
+  }
+
+  /** Build a structured scratchpad markdown document for the execution worktree. */
+  buildScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
+    const owned = node.files_owned.length
+      ? node.files_owned.map((path) => `- ${path}`).join("\n")
+      : "- (none predicted)";
+    const shared = node.files_shared.length
+      ? node.files_shared.map((file) => `- ${file.path} (${file.assessment}/${file.confidence})`).join("\n")
+      : "- (none)";
+    const forbidden = node.files_forbidden.length
+      ? node.files_forbidden.map((path) => `- ${path}`).join("\n")
+      : "- (none)";
+
+    return [
+      `# Scratchpad: ${run.work_item_id} — ${run.work_item_name}`,
+      "",
+      "## Context",
+      `- **Repo:** ${run.repo ?? "(not set)"}`,
+      `- **Issue:** ${run.issue_url ?? "(not linked)"}`,
+      `- **Branch:** ${run.branch}`,
+      `- **Base ref:** ${run.base_ref}`,
+      `- **Scope hint:** ${node.scope_hint ?? "(not set)"}`,
+      `- **Created:** ${run.created_at}`,
+      "",
+      "## File Ownership",
+      "",
+      "### Owned",
+      owned,
+      "",
+      "### Shared",
+      shared,
+      "",
+      "### Forbidden",
+      forbidden,
+      "",
+      "## Implementation Plan",
+      "<!-- Fill in concrete implementation steps before starting work -->",
+      "",
+      "- [ ] Analyze scope and identify changes needed",
+      "- [ ] Implement changes",
+      "- [ ] Run tests / verify",
+      "- [ ] Summarize results",
+      "",
+      "## Work Log",
+      "<!-- Append notes and decisions as you work -->",
+      "",
+      "## Blockers",
+      "<!-- Record any issues encountered -->",
+      "",
+    ].join("\n");
+  }
+
+  /** Write the scratchpad to the execution worktree; returns the file path. */
+  private writeScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
+    const content = this.buildScratchpad(run, node);
+    const scratchpadPath = join(run.worktree_path, "SCRATCHPAD.md");
+    writeFileSync(scratchpadPath, content, "utf8");
+    // Also persist a copy in the artifact directory for post-run review
+    writeFileSync(join(run.artifact_dir, "scratchpad-initial.md"), content, "utf8");
+    return scratchpadPath;
   }
 
   private createRunRecord(input: {


### PR DESCRIPTION
## Summary
## Summary

### Changes Made

**`src/modules/execution/execution.service.ts`** (69 insertions):
1. **`buildScratchpad(run, node)`** — Public method that generates a structured markdown scratchpad containing:
   - Context section (repo, issue, branch, base ref, scope hint, timestamp)
   - File ownership sections (owned, shared, forbidden)
   - Implementation plan template with checkboxes
   - Work log and blockers sections with HTML comment placeholders
2. **`writeScratchpad(run, node)`** — Private method that writes the scratchpad to:
   - `SCRATCHPAD.md` in the execution worktree (for the agent to use)
   - `scratchpad-initial.md` in the artifact directory (for post-run review)
3. **Integrated into `executeRun()`** — Scratchpad is written after worktree creation but before the agent session starts, with activity log and event entries
4. **Updated `buildPrompt()`** — Added 3 lines instructing the agent about SCRATCHPAD.md: use it, update it, don't commit it

**`src/modules/execution/__tests__/build-scratchpad.test.ts`** (new, 117 lines):
- 9 test cases covering: heading, context fields, owned/shared/forbidden files, empty file lists, plan checkboxes, work log/blockers sections, and missing optional fields

### Tests/Checks
- ✅ All 9 new tests pass
- ✅ All 25 tests across all 3 execution test files pass
- ✅ TypeScript compiles cleanly (`tsc --noEmit`)

### Remaining Blockers
None. The implementation is self-contained within the execution module. No forbidden files were touched.

actual_files synced: 0 file(s).

## Context
- Work item: studio-95
- Issue: https://github.com/fusupo/escapement-studio/issues/95
- Base branch: develop
- Head branch: studio-95-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775584456250
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-95-branch
- Scope hint: Generate and maintain a structured scratchpad inside the execution worktree before implementation starts.

## Changed files
- (not recorded)