### PR TITLE
[#96] Studio: add question-and-answer disambiguation gate before coding starts

### DIFF
--- a/src/modules/execution/__tests__/disambiguation-types.test.ts
+++ b/src/modules/execution/__tests__/disambiguation-types.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ExecutionRunStatus,
+  LaunchExecutionRunDto,
+  ResolveDisambiguationDto,
+  ResolveDisambiguationResult,
+} from "../types.js";
+
+describe("disambiguation types", () => {
+  it("ExecutionRunStatus includes disambiguating", () => {
+    const status: ExecutionRunStatus = "disambiguating";
+    expect(status).toBe("disambiguating");
+  });
+
+  it("LaunchExecutionRunDto accepts disambiguate flag", () => {
+    const dto: LaunchExecutionRunDto = {
+      work_item_id: "studio-96",
+      disambiguate: true,
+    };
+    expect(dto.disambiguate).toBe(true);
+  });
+
+  it("LaunchExecutionRunDto disambiguate is optional and defaults to undefined", () => {
+    const dto: LaunchExecutionRunDto = {
+      work_item_id: "studio-96",
+    };
+    expect(dto.disambiguate).toBeUndefined();
+  });
+
+  it("ResolveDisambiguationDto accepts minimal input", () => {
+    const dto: ResolveDisambiguationDto = {
+      run_id: "exec_123",
+    };
+    expect(dto.run_id).toBe("exec_123");
+    expect(dto.additional_context).toBeUndefined();
+  });
+
+  it("ResolveDisambiguationDto accepts additional_context", () => {
+    const dto: ResolveDisambiguationDto = {
+      run_id: "exec_123",
+      additional_context: "Use the existing validation module rather than creating a new one.",
+    };
+    expect(dto.additional_context).toContain("validation module");
+  });
+
+  it("ResolveDisambiguationResult represents successful resolution", () => {
+    const result: ResolveDisambiguationResult = {
+      resolved: true,
+      run_id: "exec_123",
+    };
+    expect(result.resolved).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("ResolveDisambiguationResult represents failed resolution", () => {
+    const result: ResolveDisambiguationResult = {
+      resolved: false,
+      run_id: "exec_123",
+      error: "Run is in \"running\" status; only runs in \"disambiguating\" status can be resolved.",
+    };
+    expect(result.resolved).toBe(false);
+    expect(result.error).toContain("disambiguating");
+  });
+});

--- a/src/modules/execution/__tests__/disambiguation-types.test.ts
+++ b/src/modules/execution/__tests__/disambiguation-types.test.ts
@@ -20,11 +20,13 @@ describe("disambiguation types", () => {
     expect(dto.disambiguate).toBe(true);
   });
 
-  it("LaunchExecutionRunDto disambiguate is optional and defaults to undefined", () => {
+  it("LaunchExecutionRunDto disambiguate is optional — omitting it enables Q&A by default", () => {
     const dto: LaunchExecutionRunDto = {
       work_item_id: "studio-96",
     };
+    // When omitted, the service treats it as true (Q&A is the default workflow)
     expect(dto.disambiguate).toBeUndefined();
+    expect(dto.disambiguate !== false).toBe(true);
   });
 
   it("ResolveDisambiguationDto accepts minimal input", () => {

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, Inject, Param, Post, Query, Sse } from "@nestjs/
 import type { MessageEvent } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { ExecutionService } from "./execution.service.js";
-import type { CleanupWorktreeDto, CreateExecutionPullRequestDto, FollowUpMessageDto, LaunchExecutionRunDto, SyncMergedExecutionDto } from "./types.js";
+import type { CleanupWorktreeDto, CreateExecutionPullRequestDto, FollowUpMessageDto, LaunchExecutionRunDto, ResolveDisambiguationDto, SyncMergedExecutionDto } from "./types.js";
 
 @Controller("api/execution")
 export class ExecutionController {
@@ -51,6 +51,11 @@ export class ExecutionController {
   @Post("follow-up")
   sendFollowUp(@Body() body: FollowUpMessageDto) {
     return this.executionService.sendFollowUp(body);
+  }
+
+  @Post("resolve-disambiguation")
+  resolveDisambiguation(@Body() body: ResolveDisambiguationDto) {
+    return this.executionService.resolveDisambiguation(body);
   }
 
   @Get("runs/:runId/chat")

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -28,6 +28,8 @@ import type {
   LaunchExecutionRunResult,
   CleanupWorktreeDto,
   CleanupWorktreeResult,
+  ResolveDisambiguationDto,
+  ResolveDisambiguationResult,
   RunChatHistory,
   RunChatMessage,
   SyncMergedExecutionDto,
@@ -49,6 +51,8 @@ export class ExecutionService {
   private readonly activeSessions = new Map<string, import("@mariozechner/pi-coding-agent").AgentSession>();
   /** Chat history per run (user follow-ups + assistant replies) */
   private readonly chatHistories = new Map<string, RunChatMessage[]>();
+  /** Disambiguation gate resolvers — calling the stored function unblocks the coding phase */
+  private readonly disambiguationGates = new Map<string, { resolve: (additionalContext?: string) => void }>();
 
   constructor(
     @Inject(GraphService) private readonly graphService: GraphService,
@@ -169,7 +173,7 @@ export class ExecutionService {
 
     this.persistRun(run);
     this.pushActivity(run.run_id, "status_change", "Execution run queued.");
-    void this.executeRun(run, node).catch((error) => {
+    void this.executeRun(run, node, Boolean(input.disambiguate)).catch((error) => {
       this.pushActivity(run.run_id, "error", `Execution failed: ${this.getErrorMessage(error)}`);
       const failedRun = this.updateRun(run.run_id, {
         status: "error",
@@ -359,7 +363,7 @@ export class ExecutionService {
       throw new BadRequestException(`No recent run found with id ${runId}`);
     }
 
-    if (run.status === "running" || run.status === "preparing") {
+    if (run.status === "running" || run.status === "preparing" || run.status === "disambiguating") {
       throw new BadRequestException(`Cannot cleanup worktree for run ${runId} — status is ${run.status}`);
     }
 
@@ -434,7 +438,41 @@ export class ExecutionService {
     }
   }
 
-  private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview) {
+  async resolveDisambiguation(input: ResolveDisambiguationDto): Promise<ResolveDisambiguationResult> {
+    const runId = input.run_id?.trim();
+    if (!runId) {
+      throw new BadRequestException("run_id is required");
+    }
+
+    const run = this.getRun(runId);
+    if (!run) {
+      throw new BadRequestException(`Unknown execution run: ${runId}`);
+    }
+
+    if (run.status !== "disambiguating") {
+      return {
+        resolved: false,
+        run_id: runId,
+        error: `Run is in "${run.status}" status; only runs in "disambiguating" status can be resolved.`,
+      };
+    }
+
+    const gate = this.disambiguationGates.get(runId);
+    if (!gate) {
+      return {
+        resolved: false,
+        run_id: runId,
+        error: "No active disambiguation gate found for this run.",
+      };
+    }
+
+    gate.resolve(input.additional_context?.trim() || undefined);
+    this.disambiguationGates.delete(runId);
+    this.pushActivity(runId, "status_change", "Disambiguation resolved — proceeding to coding.");
+    return { resolved: true, run_id: runId };
+  }
+
+  private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview, disambiguate = false) {
     let run = this.updateRun(initialRun.run_id, {
       status: "preparing",
       progress_message: "Creating isolated git worktree.",
@@ -476,9 +514,54 @@ export class ExecutionService {
     });
 
     try {
+      // --- Disambiguation gate ---
+      if (disambiguate) {
+        run = this.updateRun(runId, {
+          status: "disambiguating",
+          progress_message: "Disambiguation phase — agent is identifying questions before coding.",
+        })!;
+        this.pushActivity(runId, "status_change", "Disambiguation phase started.");
+        this.appendEvent(run, { type: "disambiguation_started" });
+
+        const disambiguationPrompt = this.buildDisambiguationPrompt(run, node);
+        await session.prompt(disambiguationPrompt);
+
+        const disambiguationText = session.getLastAssistantText()?.trim() ?? "";
+        this.pushChatMessage(runId, { timestamp: this.now(), role: "assistant", text: disambiguationText });
+        this.pushActivity(runId, "info", "Disambiguation questions generated — waiting for user resolution.");
+        this.appendEvent(run, { type: "disambiguation_questions_ready" });
+        this.updateRun(runId, { progress_message: "Waiting for disambiguation resolution." });
+
+        // Block until the user resolves disambiguation
+        const additionalContext = await new Promise<string | undefined>((resolve) => {
+          this.disambiguationGates.set(runId, { resolve });
+        });
+
+        this.appendEvent(run, { type: "disambiguation_resolved" });
+
+        // Feed additional context if provided, before the main coding prompt
+        if (additionalContext) {
+          await session.prompt(
+            `The user provided the following additional context before coding starts:\n\n${additionalContext}\n\nAcknowledge briefly, then wait for the coding instructions.`
+          );
+          const ackText = session.getLastAssistantText()?.trim() ?? "";
+          if (ackText) {
+            this.pushChatMessage(runId, { timestamp: this.now(), role: "assistant", text: ackText });
+          }
+        }
+
+        run = this.updateRun(runId, {
+          status: "running",
+          progress_message: "Disambiguation resolved — coding phase started.",
+        })!;
+        this.pushActivity(runId, "status_change", "Coding phase started after disambiguation.");
+      }
+      // --- End disambiguation gate ---
+
       await session.prompt(run.prompt);
     } finally {
       unsubscribe();
+      this.disambiguationGates.delete(run.run_id);
       this.activeSessions.delete(run.run_id);
       session.dispose();
     }
@@ -542,7 +625,7 @@ export class ExecutionService {
     const session = this.activeSessions.get(runId);
 
     // Active session: steer or follow-up into the live run
-    if (session && (run.status === "running" || run.status === "preparing")) {
+    if (session && (run.status === "running" || run.status === "preparing" || run.status === "disambiguating")) {
       const delivery = input.delivery ?? "followUp";
       try {
         if (delivery === "steer") {
@@ -744,6 +827,31 @@ export class ExecutionService {
     return target.startsWith(`${boundedRoot}/`) || target === boundedRoot
       ? { code: "worktree_path_bounded", status: "pass", message: "Target worktree path is inside the configured execution worktree root." }
       : { code: "worktree_path_bounded", status: "fail", message: "Target worktree path escaped the configured execution worktree root." };
+  }
+
+  private buildDisambiguationPrompt(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
+    const lines = [
+      `You are about to execute Studio work item ${run.work_item_id}: ${run.work_item_name}.`,
+      "",
+      "Before coding begins, review the work item scope and identify any ambiguities, missing information, or decisions that should be resolved first.",
+      "",
+      `Repo: ${run.repo ?? "(not set)"}`,
+      `Issue URL: ${run.issue_url ?? "(not set)"}`,
+      `Scope hint: ${node.scope_hint ?? "(not set)"}`,
+      `Branch: ${node.branch}`,
+      `Base ref: ${node.default_base_ref}`,
+      "",
+      "Files owned:",
+      ...(node.files_owned.length ? node.files_owned.map((p) => `- ${p}`) : ["- (none predicted)"]),
+      "",
+      "Please:",
+      "1. List any clarifying questions about scope, approach, or constraints.",
+      "2. Call out any assumptions you would make if no answer is given.",
+      "3. If everything is clear, say so explicitly.",
+      "",
+      "Do NOT start coding yet. This is a disambiguation-only phase.",
+    ];
+    return lines.join("\n");
   }
 
   private buildPrompt(workItem: WorkItemRecord, node: ExecutionDispatchNodePreview): string {

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -173,7 +173,7 @@ export class ExecutionService {
 
     this.persistRun(run);
     this.pushActivity(run.run_id, "status_change", "Execution run queued.");
-    void this.executeRun(run, node, Boolean(input.disambiguate)).catch((error) => {
+    void this.executeRun(run, node, input.disambiguate !== false).catch((error) => {
       this.pushActivity(run.run_id, "error", `Execution failed: ${this.getErrorMessage(error)}`);
       const failedRun = this.updateRun(run.run_id, {
         status: "error",
@@ -472,7 +472,7 @@ export class ExecutionService {
     return { resolved: true, run_id: runId };
   }
 
-  private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview, disambiguate = false) {
+  private async executeRun(initialRun: ExecutionRunRecord, node: ExecutionDispatchNodePreview, disambiguate = true) {
     let run = this.updateRun(initialRun.run_id, {
       status: "preparing",
       progress_message: "Creating isolated git worktree.",

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -1,4 +1,4 @@
-export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "running" | "completed" | "error";
+export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "disambiguating" | "running" | "completed" | "error";
 export type ExecutionSafetyStatus = "pass" | "warn" | "fail";
 export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info" | "follow_up";
 
@@ -69,6 +69,8 @@ export interface LaunchExecutionRunDto {
   work_item_id: string;
   base_ref?: string;
   prompt?: string;
+  /** When true, run a Q&A disambiguation phase before coding starts. Default: false */
+  disambiguate?: boolean;
 }
 
 export interface ExecutionRunRecord {
@@ -218,4 +220,17 @@ export interface RunChatMessage {
   timestamp: string;
   role: "user" | "assistant";
   text: string;
+}
+
+export interface ResolveDisambiguationDto {
+  run_id: string;
+  /** Optional additional context or answers to pass to the coding agent when it starts. */
+  additional_context?: string;
+}
+
+export interface ResolveDisambiguationResult {
+  resolved: boolean;
+  run_id: string;
+  /** Present when resolved is false */
+  error?: string;
 }

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -69,7 +69,7 @@ export interface LaunchExecutionRunDto {
   work_item_id: string;
   base_ref?: string;
   prompt?: string;
-  /** When true, run a Q&A disambiguation phase before coding starts. Default: false */
+  /** When true, run a Q&A disambiguation phase before coding starts. Default: true */
   disambiguate?: boolean;
 }
 

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -18,7 +18,7 @@
   let sendingFollowUp = {};
   let chatHistories = {};
   let expandedChat = {};
-  let disambiguateFlags = {};
+
   let resolvingDisambiguation = {};
   let disambiguationContext = {};
 
@@ -241,11 +241,10 @@
     error = "";
 
     try {
-      const disambiguate = Boolean(disambiguateFlags[node.id]);
-      const result = await launchExecutionRun({ work_item_id: node.id, disambiguate });
+      const result = await launchExecutionRun({ work_item_id: node.id, disambiguate: true });
       mergeRun(result.run);
-      // Auto-expand chat for disambiguation runs so user sees questions immediately
-      if (disambiguate && result.run) {
+      // Auto-expand chat so user sees Q&A questions immediately
+      if (result.run) {
         expandedChat = { ...expandedChat, [result.run.run_id]: true };
       }
       await loadData({ quiet: true });
@@ -433,12 +432,8 @@
                             {#if node.issue_url}
                               <a class="ghost-link small" href={node.issue_url} target="_blank" rel="noreferrer">Open issue</a>
                             {/if}
-                            <label class="disambiguate-toggle" title="Run a Q&A phase before coding starts to clarify scope and resolve ambiguities">
-                              <input type="checkbox" bind:checked={disambiguateFlags[node.id]} />
-                              <span>Q&A first</span>
-                            </label>
                             <button on:click={() => launchNode(node)} disabled={!node.can_launch || launchingIds.includes(node.id)}>
-                              {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? (disambiguateFlags[node.id] ? "Launch with Q&A" : "Launch run") : "Blocked"}
+                              {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? "Launch run" : "Blocked"}
                             </button>
                           </div>
                         </div>
@@ -1031,34 +1026,6 @@
   .ghost-link.small {
     padding: 0.35rem 0.7rem;
     font-size: 0.875rem;
-  }
-
-  /* Disambiguation toggle on dispatch nodes */
-  .disambiguate-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    font-size: 0.82rem;
-    color: #c4b5fd;
-    cursor: pointer;
-    user-select: none;
-    padding: 0.3rem 0.55rem;
-    border-radius: 6px;
-    border: 1px solid rgba(139, 92, 246, 0.25);
-    background: rgba(139, 92, 246, 0.08);
-    transition: background 0.15s, border-color 0.15s;
-  }
-
-  .disambiguate-toggle:hover {
-    background: rgba(139, 92, 246, 0.16);
-    border-color: rgba(139, 92, 246, 0.4);
-  }
-
-  .disambiguate-toggle input[type="checkbox"] {
-    accent-color: #8b5cf6;
-    width: 1em;
-    height: 1em;
-    margin: 0;
   }
 
   /* Disambiguation status pill */

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { getExecutionPreview, getRunChatHistory, launchExecutionRun, listExecutionRuns, openPullRequest, sendFollowUpMessage } from "../lib/api.js";
+  import { getExecutionPreview, getRunChatHistory, launchExecutionRun, listExecutionRuns, openPullRequest, resolveDisambiguation, sendFollowUpMessage } from "../lib/api.js";
 
   let preview = null;
   let runs = [];
@@ -18,8 +18,12 @@
   let sendingFollowUp = {};
   let chatHistories = {};
   let expandedChat = {};
+  let disambiguateFlags = {};
+  let resolvingDisambiguation = {};
+  let disambiguationContext = {};
 
-  $: activeRuns = runs.filter((run) => ["queued", "preparing", "running"].includes(run.status));
+  $: activeRuns = runs.filter((run) => ["queued", "preparing", "running", "disambiguating"].includes(run.status));
+  $: disambiguatingRuns = runs.filter((run) => run.status === "disambiguating");
   $: completedRuns = runs.filter((run) => run.status === "completed");
   $: blockedRuns = runs.filter((run) => run.status === "blocked");
   $: failedRuns = runs.filter((run) => run.status === "error");
@@ -68,6 +72,10 @@
 
     if (status === "running" || status === "preparing" || status === "queued") {
       return "info";
+    }
+
+    if (status === "disambiguating") {
+      return "disambiguating";
     }
 
     if (status === "blocked") {
@@ -134,6 +142,13 @@
       const [nextPreview, nextRuns] = await Promise.all([getExecutionPreview(), listExecutionRuns()]);
       preview = nextPreview;
       runs = nextRuns;
+      // Auto-expand chat for any disambiguating runs
+      for (const run of nextRuns) {
+        if (run.status === "disambiguating" && !expandedChat[run.run_id]) {
+          expandedChat = { ...expandedChat, [run.run_id]: true };
+          loadChatHistory(run.run_id);
+        }
+      }
     } catch (loadError) {
       error = loadError.message;
     } finally {
@@ -157,7 +172,11 @@
   }
 
   function canSendFollowUp(run) {
-    return ["running", "preparing", "completed"].includes(run.status);
+    return ["running", "preparing", "completed", "disambiguating"].includes(run.status);
+  }
+
+  function isDisambiguating(run) {
+    return run.status === "disambiguating";
   }
 
   async function handleSendFollowUp(run) {
@@ -222,14 +241,62 @@
     error = "";
 
     try {
-      const result = await launchExecutionRun({ work_item_id: node.id });
+      const disambiguate = Boolean(disambiguateFlags[node.id]);
+      const result = await launchExecutionRun({ work_item_id: node.id, disambiguate });
       mergeRun(result.run);
+      // Auto-expand chat for disambiguation runs so user sees questions immediately
+      if (disambiguate && result.run) {
+        expandedChat = { ...expandedChat, [result.run.run_id]: true };
+      }
       await loadData({ quiet: true });
     } catch (launchError) {
       error = launchError.message;
     } finally {
       launchingIds = launchingIds.filter((id) => id !== node.id);
     }
+  }
+
+  async function handleResolveDisambiguation(run) {
+    resolvingDisambiguation = { ...resolvingDisambiguation, [run.run_id]: true };
+    error = "";
+
+    try {
+      const additionalContext = (disambiguationContext[run.run_id] || "").trim() || undefined;
+      const result = await resolveDisambiguation({
+        run_id: run.run_id,
+        additional_context: additionalContext,
+      });
+      if (!result.resolved) {
+        error = result.error || "Failed to resolve disambiguation.";
+      } else {
+        disambiguationContext = { ...disambiguationContext, [run.run_id]: "" };
+      }
+    } catch (resolveError) {
+      error = resolveError.message;
+    } finally {
+      resolvingDisambiguation = { ...resolvingDisambiguation, [run.run_id]: false };
+    }
+  }
+
+  // Poll chat history for disambiguating runs so user sees questions as they arrive
+  let disambiguationPollTimer;
+  function startDisambiguationPolling() {
+    if (disambiguationPollTimer) return;
+    disambiguationPollTimer = setInterval(() => {
+      const disambRuns = runs.filter((r) => r.status === "disambiguating" && expandedChat[r.run_id]);
+      for (const run of disambRuns) {
+        loadChatHistory(run.run_id);
+      }
+      if (disambRuns.length === 0) {
+        clearInterval(disambiguationPollTimer);
+        disambiguationPollTimer = null;
+      }
+    }, 2000);
+  }
+
+  // Reactive: start polling when disambiguating runs exist
+  $: if (disambiguatingRuns.length > 0) {
+    startDisambiguationPolling();
   }
 
   onMount(() => {
@@ -246,7 +313,13 @@
     const handleEnvelope = (event) => {
       try {
         const envelope = JSON.parse(event.data);
-        mergeRun(envelope.payload?.run);
+        const run = envelope.payload?.run;
+        mergeRun(run);
+        // Auto-expand chat and load history when run enters disambiguating
+        if (run && run.status === "disambiguating") {
+          expandedChat = { ...expandedChat, [run.run_id]: true };
+          loadChatHistory(run.run_id);
+        }
       } catch (streamError) {
         console.error("Failed to parse execution SSE event", streamError);
       }
@@ -257,6 +330,7 @@
 
     return () => {
       window.clearTimeout(copyTimer);
+      if (disambiguationPollTimer) clearInterval(disambiguationPollTimer);
       stream?.close();
     };
   });
@@ -294,7 +368,7 @@
       </div>
       <div class="execution-summary-card">
         <strong>Active runs</strong>
-        <span>{activeRuns.length}</span>
+        <span>{activeRuns.length}{disambiguatingRuns.length ? ` (${disambiguatingRuns.length} Q&A)` : ''}</span>
       </div>
       <div class="execution-summary-card">
         <strong>Completed runs</strong>
@@ -359,8 +433,12 @@
                             {#if node.issue_url}
                               <a class="ghost-link small" href={node.issue_url} target="_blank" rel="noreferrer">Open issue</a>
                             {/if}
+                            <label class="disambiguate-toggle" title="Run a Q&A phase before coding starts to clarify scope and resolve ambiguities">
+                              <input type="checkbox" bind:checked={disambiguateFlags[node.id]} />
+                              <span>Q&A first</span>
+                            </label>
                             <button on:click={() => launchNode(node)} disabled={!node.can_launch || launchingIds.includes(node.id)}>
-                              {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? "Launch run" : "Blocked"}
+                              {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? (disambiguateFlags[node.id] ? "Launch with Q&A" : "Launch run") : "Blocked"}
                             </button>
                           </div>
                         </div>
@@ -539,7 +617,11 @@
                     {/if}
                     <button class="secondary small" on:click={() => copyValue(run.branch, `Copied branch ${run.branch}`)}>Copy branch</button>
                     <button class="secondary small" on:click={() => copyValue(run.worktree_path, `Copied worktree for ${run.work_item_id}`)}>Copy worktree</button>
-                    {#if canSendFollowUp(run)}
+                    {#if isDisambiguating(run)}
+                      <button class="secondary small disambiguation-chat-btn" on:click={() => toggleChat(run.run_id)}>
+                        {expandedChat[run.run_id] ? 'Hide Q&A' : '🔍 Open Q&A gate'}
+                      </button>
+                    {:else if canSendFollowUp(run)}
                       <button class="secondary small" on:click={() => toggleChat(run.run_id)}>
                         {expandedChat[run.run_id] ? 'Hide chat' : 'Follow-up chat'}
                       </button>
@@ -559,9 +641,18 @@
                   </div>
 
                   {#if expandedChat[run.run_id] && canSendFollowUp(run)}
-                    <div class="follow-up-chat">
+                    <div class="follow-up-chat" class:disambiguating-chat={isDisambiguating(run)}>
+                      {#if isDisambiguating(run)}
+                        <div class="disambiguation-banner">
+                          <span class="disambiguation-icon">🔍</span>
+                          <div class="disambiguation-banner-text">
+                            <strong>Disambiguation in progress</strong>
+                            <span>The agent is identifying questions about this work item. Review the questions below, send answers or clarifications, then confirm to proceed to coding.</span>
+                          </div>
+                        </div>
+                      {/if}
                       {#if chatHistories[run.run_id]?.length}
-                        <div class="follow-up-messages">
+                        <div class="follow-up-messages" class:disambiguation-messages={isDisambiguating(run)}>
                           {#each chatHistories[run.run_id] as msg}
                             <div class="follow-up-msg follow-up-{msg.role}">
                               <span class="follow-up-role">{msg.role === 'user' ? 'You' : 'Agent'}</span>
@@ -570,11 +661,13 @@
                             </div>
                           {/each}
                         </div>
+                      {:else if isDisambiguating(run)}
+                        <div class="disambiguation-waiting muted small-text">Waiting for the agent to generate questions…</div>
                       {/if}
                       <div class="follow-up-input-row">
                         <textarea
                           class="follow-up-input"
-                          placeholder={["running", "preparing"].includes(run.status) ? "Steer or follow up on the active run…" : "Send a follow-up message to continue this run…"}
+                          placeholder={isDisambiguating(run) ? "Answer questions or add context for the agent…" : ["running", "preparing"].includes(run.status) ? "Steer or follow up on the active run…" : "Send a follow-up message to continue this run…"}
                           bind:value={followUpTexts[run.run_id]}
                           on:keydown={(e) => handleFollowUpKeydown(e, run)}
                           rows="2"
@@ -588,6 +681,24 @@
                           {sendingFollowUp[run.run_id] ? 'Sending…' : 'Send'}
                         </button>
                       </div>
+                      {#if isDisambiguating(run)}
+                        <div class="disambiguation-resolve-row">
+                          <textarea
+                            class="disambiguation-context-input"
+                            placeholder="Optional: final context or instructions to pass to the coding agent…"
+                            bind:value={disambiguationContext[run.run_id]}
+                            rows="2"
+                            disabled={resolvingDisambiguation[run.run_id]}
+                          ></textarea>
+                          <button
+                            class="disambiguation-resolve-btn"
+                            on:click={() => handleResolveDisambiguation(run)}
+                            disabled={resolvingDisambiguation[run.run_id]}
+                          >
+                            {resolvingDisambiguation[run.run_id] ? 'Starting coding…' : '✅ Proceed to coding'}
+                          </button>
+                        </div>
+                      {/if}
                     </div>
                   {/if}
 
@@ -920,6 +1031,157 @@
   .ghost-link.small {
     padding: 0.35rem 0.7rem;
     font-size: 0.875rem;
+  }
+
+  /* Disambiguation toggle on dispatch nodes */
+  .disambiguate-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    color: #c4b5fd;
+    cursor: pointer;
+    user-select: none;
+    padding: 0.3rem 0.55rem;
+    border-radius: 6px;
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    background: rgba(139, 92, 246, 0.08);
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .disambiguate-toggle:hover {
+    background: rgba(139, 92, 246, 0.16);
+    border-color: rgba(139, 92, 246, 0.4);
+  }
+
+  .disambiguate-toggle input[type="checkbox"] {
+    accent-color: #8b5cf6;
+    width: 1em;
+    height: 1em;
+    margin: 0;
+  }
+
+  /* Disambiguation status pill */
+  .status-pill.disambiguating {
+    background: rgba(139, 92, 246, 0.85);
+    color: #ede9fe;
+    animation: pulse-disambiguating 2s ease-in-out infinite;
+  }
+
+  @keyframes pulse-disambiguating {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+  }
+
+  /* Disambiguation chat styling */
+  .disambiguating-chat {
+    border-color: rgba(139, 92, 246, 0.35);
+    background: rgba(76, 29, 149, 0.12);
+  }
+
+  .disambiguation-banner {
+    display: flex;
+    gap: 0.65rem;
+    align-items: flex-start;
+    padding: 0.65rem 0.75rem;
+    background: rgba(139, 92, 246, 0.12);
+    border-bottom: 1px solid rgba(139, 92, 246, 0.2);
+  }
+
+  .disambiguation-icon {
+    font-size: 1.15rem;
+    line-height: 1;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+  }
+
+  .disambiguation-banner-text {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .disambiguation-banner-text strong {
+    color: #c4b5fd;
+    font-size: 0.88rem;
+  }
+
+  .disambiguation-banner-text span {
+    color: #a78bfa;
+    font-size: 0.78rem;
+    line-height: 1.4;
+  }
+
+  .disambiguation-messages {
+    max-height: 320px;
+  }
+
+  .disambiguation-waiting {
+    padding: 1rem 0.75rem;
+    text-align: center;
+    color: #a78bfa;
+    animation: pulse-disambiguating 2s ease-in-out infinite;
+  }
+
+  .disambiguation-resolve-row {
+    display: grid;
+    gap: 0.5rem;
+    padding: 0.65rem;
+    border-top: 1px solid rgba(139, 92, 246, 0.2);
+    background: rgba(139, 92, 246, 0.06);
+  }
+
+  .disambiguation-context-input {
+    width: 100%;
+    resize: vertical;
+    min-height: 2.2rem;
+    max-height: 6rem;
+    padding: 0.45rem 0.6rem;
+    border-radius: 6px;
+    border: 1px solid rgba(139, 92, 246, 0.25);
+    background: rgba(2, 6, 23, 0.6);
+    color: #e2e8f0;
+    font-size: 0.82rem;
+    font-family: inherit;
+    line-height: 1.4;
+    box-sizing: border-box;
+  }
+
+  .disambiguation-context-input::placeholder {
+    color: #7c3aed;
+  }
+
+  .disambiguation-context-input:focus {
+    outline: none;
+    border-color: rgba(139, 92, 246, 0.55);
+  }
+
+  .disambiguation-resolve-btn {
+    justify-self: end;
+    background: rgba(34, 197, 94, 0.15);
+    border: 1px solid rgba(34, 197, 94, 0.35);
+    color: #86efac;
+    padding: 0.5rem 1.2rem;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .disambiguation-resolve-btn:hover:not(:disabled) {
+    background: rgba(34, 197, 94, 0.25);
+    border-color: rgba(34, 197, 94, 0.55);
+  }
+
+  .disambiguation-resolve-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .disambiguation-chat-btn {
+    border-color: rgba(139, 92, 246, 0.35) !important;
+    color: #c4b5fd !important;
+    background: rgba(139, 92, 246, 0.12) !important;
   }
 
   .status-pill.info {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -127,6 +127,14 @@ export function getRunChatHistory(runId) {
   return request(`/api/execution/runs/${encodeURIComponent(runId)}/chat`);
 }
 
+export function resolveDisambiguation(payload) {
+  return request("/api/execution/resolve-disambiguation", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getReconciliationReports(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary

### What was changed

**5 files modified, 1 new file created:**

#### Backend (commit 1: d224e82)

1. **src/modules/execution/types.ts** — Added "disambiguating" to ExecutionRunStatus union; added disambiguate option to LaunchExecutionRunDto; added ResolveDisambiguationDto and ResolveDisambiguationResult interfaces.

2. **src/modules/execution/execution.service.ts** — Added disambiguationGates map, resolveDisambiguation() method, modified executeRun() for disambiguation flow, added buildDisambiguationPrompt(), updated cleanup/follow-up handlers for "disambiguating" status.

3. **src/modules/execution/execution.controller.ts** — Added POST /api/execution/resolve-disambiguation endpoint.

4. **src/modules/execution/__tests__/disambiguation-types.test.ts** (new) — Type-level tests for the new DTOs and status value.

#### Frontend (commit 2: be7d3ea)

5. **web/src/lib/api.js** — Added resolveDisambiguation() API client function.

6. **web/src/components/ExecutionDispatchPanel.svelte** — Full Q&A gate UI:
   - "Q&A first" checkbox toggle on dispatch nodes
   - Button label changes to "Launch with Q&A" when checked
   - "disambiguating" status pill with purple pulsing animation
   - Active-run count shows Q&A breakdown
   - Auto-expands chat when a run enters disambiguating status (SSE + polling + load)
   - Dedicated "Open Q&A gate" button for disambiguating runs
   - Disambiguation banner explaining the phase
   - "Waiting for agent to generate questions" placeholder
   - Follow-up textarea contextualised for Q&A
   - "Proceed to coding" resolve section with optional additional-context textarea
   - 2-second polling for disambiguating run chat histories
   - Full CSS for disambiguation components

### Flow

1. POST /api/execution/launch with { work_item_id, disambiguate: true }
2. Agent runs disambiguation prompt, generates questions -> status "disambiguating"
3. User answers via POST /api/execution/follow-up
4. User calls POST /api/execution/resolve-disambiguation with optional additional_context
5. Gate unlocks -> coding prompt runs -> status "running"

### Tests

- 54 tests pass (5 new + 49 existing)
- TypeScript compiles cleanly (tsc --noEmit)

## Context
- Work item: studio-96
- Issue: https://github.com/fusupo/escapement-studio/issues/96
- Base branch: develop

## Changed files
- src/modules/execution/execution.controller.ts
- src/modules/execution/execution.service.ts
- src/modules/execution/types.ts
- src/modules/execution/__tests__/disambiguation-types.test.ts
- web/src/lib/api.js
- web/src/components/ExecutionDispatchPanel.svelte