### PR TITLE
[#106] Studio: global CSS tightening — smaller fonts, tighter spacing, app-like density

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,0 +1,47 @@
+# Scratchpad: studio-106 — Studio: global CSS tightening — smaller fonts, tighter spacing, app-like density
+
+## Context
+- **Repo:** fusupo/escapement-studio
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/106
+- **Branch:** studio-106-branch
+- **Base ref:** develop
+- **Scope hint:** Reduce global UI density with smaller base fonts, tighter spacing, and more compact controls across the app.
+- **Created:** 2026-04-07T19:55:37.749Z
+
+## File Ownership
+
+### Owned
+- (none predicted)
+
+### Shared
+- (none)
+
+### Forbidden
+- docs/contracts/run-artifacts.md
+- src/modules/execution
+- src/modules/github
+- src/modules/graph
+- src/modules/planning
+- web/src/App.svelte
+- web/src/app.css
+- web/src/components
+- web/src/components/ExecutionDispatchPanel.svelte
+- web/src/components/GraphView.svelte
+- web/src/components/PlannerChatAdapter.svelte
+- web/src/components/Sidebar.svelte
+
+## Implementation Plan
+<!-- Fill in concrete implementation steps before starting work -->
+
+- [x] Analyze scope and identify changes needed
+- [ ] Implement changes — BLOCKED
+- [ ] Run tests / verify
+- [ ] Summarize results
+
+## Work Log
+
+- **2026-04-07:** Every CSS-containing file is forbidden. This task cannot proceed without access to at least `web/src/app.css` (global styles) and ideally the component `<style>` blocks. No owned or shared files exist for this work item.
+
+## Blockers
+
+- **HARD BLOCKER:** All CSS files are forbidden. The task requires modifying `web/src/app.css` and component styles, but these are all listed as forbidden (owned by other work items). This work item needs to be re-dispatched with file ownership over `web/src/app.css` at minimum.


### PR DESCRIPTION
## Summary
Those are good questions — let me answer them and also address the file ownership blocker.

**On the questions:**

1. Go with **(b)** — target the loosest spots. The chat bubbles, sidebar sections, and card paddings feel the most generous. Leave already-tight areas alone.

2. **Yes, component styles too** — `app.css` plus any component `<style>` blocks that have loose spacing.

3. **Yes, bring radii down** — `10px → 6px`, `8px → 5px`. Tighter radii feel more app-like.

4. **Line-height → 1.35** on the root.

**On the file ownership blocker:** You're right that the dispatch constraints are wrong here — this is a CSS-focused task and those files are its scope. Go ahead and modify `web/src/app.css` and any component files you need. The forbidden list was a dispatch artifact, not an intentional restriction for this issue. Treat all web/src CSS-containing files as owned.

actual_files synced: 1 file(s).

## Context
- Work item: studio-106
- Issue: https://github.com/fusupo/escapement-studio/issues/106
- Base branch: develop
- Head branch: studio-106-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775591737749
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-106-branch
- Scope hint: Reduce global UI density with smaller base fonts, tighter spacing, and more compact controls across the app.

## Changed files
- `SCRATCHPAD.md`