### PR TITLE
[#116] Studio: add a recognizable favicon for browser tab identification

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,68 +1,15 @@
-# Scratchpad: studio-75 — Studio: add a Settings area for repo and execution configuration
+# SCRATCHPAD — studio-116
 
-## Context
-- **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/75
-- **Branch:** studio-75-branch
-- **Base ref:** develop
-- **Scope hint:** Add a Settings area to the Studio UI to hold repo targeting and execution configuration that currently lacks a clear home.
-- **Created:** 2026-04-07T23:19:34.064Z
+## Status: COMPLETE
 
-## File Ownership
+## Changes Made
+- [x] Created `web/public/favicon.svg` — gear/escapement silhouette (dark body, light spokes, blue anchor fork)
+- [x] Added `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` to `web/index.html`
 
-### Owned
-- web/src/components
-- web/src/app.css
-
-### Shared
-- (none)
-
-### Forbidden
-- docs/contracts/run-artifacts.md
-- src/modules/execution
-- src/modules/github
-- src/modules/graph
-- src/modules/planning
-- web/src/components/ExecutionDispatchPanel.svelte
-- web/src/components/GraphView.svelte
-- web/src/components/PlannerChatAdapter.svelte
-- web/src/components/Sidebar.svelte
-
-## Implementation Plan
-
-- [x] Analyze scope and identify changes needed
-- [x] Create `web/src/components/SettingsPanel.svelte` with settings UI
-- [x] Add settings panel CSS to `web/src/app.css`
-- [x] Wire settings tab into `App.svelte` (out of owned scope but necessary for the feature to work)
-- [x] Run build / verify — build succeeds, 71 tests pass
-- [x] Summarize results
-
-### Final pass
-- [x] Settings as 4th activity tab with gear icon
-- [x] Server-side persistence via new `src/modules/settings/` NestJS module
-- [x] Editable repos with include/exclude toggle + default branch
-- [x] Editable AppConfig (manifestPath, planningSessionDir, artifactRoot)
-- [x] API: GET/PUT /api/settings
-- [x] Build passes, 71 tests pass
-
-## Design Decisions
-
-1. Settings is a new activity bar tab with a gear icon (bottom of rail)
-2. Settings sections:
-   - **Server config** (read-only): DB path, manifest path, artifact root — from `/health` response
-   - **Repo targeting**: default working branches per repo (localStorage, editable)
-   - **Execution defaults**: base ref override, worktree root display
-3. Persistence: localStorage for user-editable settings (no new server API needed)
-4. Must touch `App.svelte` to wire the tab — noting this as a necessary scope extension
-
-## Work Log
-
-- Analyzed existing patterns: activity bar tabs, panel layout, CSS conventions
-- Health endpoint returns db path but not full config — will show what's available
-- `default-working-branches.ts` is hardcoded server-side; UI will allow local overrides
-- Created server-side settings module with SQLite persistence in studio_metadata table
-- SettingsService exposes getDefaultBranch() and listIncludedRepos() for consumption by execution module
+## Verification
+- [x] `vite build` succeeds — favicon copied to `web-dist/favicon.svg`, referenced in built HTML
+- [x] All 71 tests pass
+- [x] SVG is well-formed, ~1KB
 
 ## Blockers
-
-- None yet
+None.

--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Escapement Studio</title>
   </head>
   <body>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <!-- Gear body -->
+  <circle cx="32" cy="32" r="20" stroke="#e0e0e0" stroke-width="4" fill="#1a1a2e"/>
+  <!-- Gear teeth (8 teeth) -->
+  <g stroke="#e0e0e0" stroke-width="3" stroke-linecap="round">
+    <line x1="32" y1="2" x2="32" y2="10"/>
+    <line x1="32" y1="54" x2="32" y2="62"/>
+    <line x1="2" y1="32" x2="10" y2="32"/>
+    <line x1="54" y1="32" x2="62" y2="32"/>
+    <line x1="10.8" y1="10.8" x2="16.4" y2="16.4"/>
+    <line x1="47.6" y1="47.6" x2="53.2" y2="53.2"/>
+    <line x1="53.2" y1="10.8" x2="47.6" y2="16.4"/>
+    <line x1="16.4" y1="47.6" x2="10.8" y2="53.2"/>
+  </g>
+  <!-- Escapement anchor (Y-shaped fork) -->
+  <g stroke="#60a5fa" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="32" y1="32" x2="32" y2="46"/>
+    <line x1="32" y1="32" x2="24" y2="22"/>
+    <line x1="32" y1="32" x2="40" y2="22"/>
+  </g>
+  <!-- Center hub -->
+  <circle cx="32" cy="32" r="4" fill="#60a5fa"/>
+</svg>


### PR DESCRIPTION
## Summary
---

## Summary

**Changes made (2 files):**
- **`web/public/favicon.svg`** (new) — A simple gear silhouette with an escapement anchor fork in the center. Dark background (`#1a1a2e`), light gear outline (`#e0e0e0`), blue accent anchor/hub (`#60a5fa`). ~1KB.
- **`web/index.html`** — Added `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` in `<head>`.

**Verification:**
- ✅ Vite build succeeds — favicon is copied to `web-dist/` and referenced in the built HTML
- ✅ All 71 existing tests pass
- ✅ No forbidden files touched

**Scope notes:** Both files were outside the predicted file list (which was empty), but they're the minimal and expected files for this task. No forbidden files were modified.

**Remaining blockers:** None.

actual_files synced: 3 file(s).

## Context
- Work item: studio-116
- Issue: https://github.com/fusupo/escapement-studio/issues/116
- Base branch: develop
- Head branch: studio-116-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775622282840
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-116-branch
- Scope hint: Add a simple recognizable favicon asset and wire it into the web app entrypoint so the Studio browser tab is easy to identify.

## Changed files
- `SCRATCHPAD.md`
- `web/index.html`
- `web/public/`