### PR TITLE
[#99] Studio: persist scratchpad and checklist state across refreshes and follow-up runs

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,15 +1,45 @@
-# SCRATCHPAD — studio-116
+# Scratchpad: studio-99 — Studio: persist scratchpad and checklist state across refreshes and follow-up runs
 
-## Status: COMPLETE
+## Context
+- **Repo:** fusupo/escapement-studio
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/99
+- **Branch:** studio-99-branch
+- **Base ref:** develop
+- **Scope hint:** Durably persist scratchpad, checklist, and disambiguation state for execution runs and follow-up turns.
+- **Created:** 2026-04-08T04:47:02.708Z
 
-## Changes Made
-- [x] Created `web/public/favicon.svg` — gear/escapement silhouette (dark body, light spokes, blue anchor fork)
-- [x] Added `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />` to `web/index.html`
+## File Ownership
 
-## Verification
-- [x] `vite build` succeeds — favicon copied to `web-dist/favicon.svg`, referenced in built HTML
-- [x] All 71 tests pass
-- [x] SVG is well-formed, ~1KB
+### Owned
+- (none predicted)
+
+### Shared
+- (none)
+
+### Forbidden
+- README.md
+- docs/contracts/github-sync.md
+- src/modules/git
+- src/modules/github
+- src/modules/graph
+- src/modules/planning
+- web/src/App.svelte
+- web/src/components
+- web/src/components/GraphView.svelte
+- web/src/components/PlannerChatAdapter.svelte
+- web/src/components/Sidebar.svelte
+- web/src/lib/api.js
+
+## Implementation Plan
+<!-- Fill in concrete implementation steps before starting work -->
+
+- [ ] Analyze scope and identify changes needed
+- [ ] Implement changes
+- [ ] Run tests / verify
+- [ ] Summarize results
+
+## Work Log
+<!-- Append notes and decisions as you work -->
 
 ## Blockers
-None.
+<!-- Record any issues encountered -->


### PR DESCRIPTION
## Summary
Execution run completed without a terminal summary.

actual_files synced: 1 file(s).

## Context
- Work item: studio-99
- Issue: https://github.com/fusupo/escapement-studio/issues/99
- Base branch: develop
- Head branch: studio-99-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775623622708
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-99-branch
- Scope hint: Durably persist scratchpad, checklist, and disambiguation state for execution runs and follow-up turns.

## Changed files
- `SCRATCHPAD.md`