### PR TITLE
[#125] Studio: prevent app title and active section header from overlapping in the top bar

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,12 +1,12 @@
-# Scratchpad: studio-108 — Studio: Execute tab 3-column layout — run list, run detail, worktree sidebar
+# Scratchpad: studio-125 — Studio: prevent app title and active section header from overlapping in the top bar
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/108
-- **Branch:** studio-108-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/125
+- **Branch:** studio-125-branch
 - **Base ref:** develop
-- **Scope hint:** Restructure the Execute tab into a fixed three-column workspace with run list, selected run detail, and worktree/safety context.
-- **Created:** 2026-04-08T04:47:55.933Z
+- **Scope hint:** Fix the top-bar layout so the app title and active section label no longer overlap.
+- **Created:** 2026-04-08T07:19:52.563Z
 
 ## File Ownership
 
@@ -33,16 +33,54 @@
 - web/src/components/Sidebar.svelte
 - web/src/lib/api.js
 
-## Implementation Plan
-<!-- Fill in concrete implementation steps before starting work -->
+## Acceptance Criteria
 
-- [ ] Analyze scope and identify changes needed
-- [ ] Implement changes
-- [ ] Run tests / verify
-- [ ] Summarize results
+- [ ] `Escapement Studio` does not overlap with the current section title
+- [ ] The top bar remains visually stable across supported sections (Planning, Execute, Reconcile, Settings)
+- [ ] No header text collision occurs in normal desktop usage
+
+## Summary
+
+The top bar in `App.svelte` uses a flex container with `justify-content: center` to center the brand name ("Escapement Studio"), while the active section label (e.g. "Planning") is positioned with `position: absolute; left: 12px`. This absolute positioning takes the label out of normal flow, causing it to overlap the centered brand text—especially with longer section names.
+
+**Constraint:** `App.svelte` is forbidden. The scoped `<style>` block in that file defines the broken layout. However, since Svelte 5 uses `:where()` for scoped selectors (0 added specificity), global CSS in `app.css` with equal or slightly higher specificity will override the scoped styles.
+
+## Implementation Plan
+
+- [x] **Override title-bar layout in `web/src/app.css`** — Add global CSS rules to:
+  1. Change `.title-bar` from centered flex to a 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`. This gives the label, brand, and spacer each their own non-overlapping column.
+  2. Remove `position: absolute` and `left: 12px` from `.title-bar-label` (override to `position: static`).
+  3. Ensure `.title-bar-brand` stays visually centered in the middle column.
+  4. Use specificity like `.main-area > .title-bar` (0,2,0) to reliably override scoped styles (0,1,0 effective).
+- [x] **Verify across all tabs** — Check that all section labels (Planning, Execute, Reconcile, Settings) render without collision.
+- [x] **Run build** — `npm run build:web` to confirm no errors.
+- [x] **Run tests** — `npm test` to confirm nothing breaks.
+
+## Affected Files
+
+- **`web/src/app.css`** — Add global overrides for `.title-bar`, `.title-bar-label`, and `.title-bar-brand` to switch from absolute positioning to CSS grid layout, preventing overlap.
+
+## Quality Checks
+- [ ] TypeScript compilation passes (`npm run check`)
+- [ ] Tests pass (`npm test`)
+- [ ] Build succeeds (`npm run build:web`)
+
+## Questions / Concerns
+
+- **`App.svelte` is forbidden but contains the broken styles.** The plan uses global CSS overrides in `app.css` to fix the layout without modifying `App.svelte`. This works because Svelte 5 scoped styles use `:where()` (zero added specificity). This is the only viable approach given the file ownership constraints. If the team prefers the fix to live in `App.svelte` directly, this issue would need to be re-assigned with different file ownership.
+- **No predicted owned files** — The manifest didn't predict any files for this issue. `web/src/app.css` is not in the forbidden list, so modifying it should be acceptable.
 
 ## Work Log
-<!-- Append notes and decisions as you work -->
+
+### 2026-04-08 - Setup
+- Scratchpad created by Studio execution service
+- Branch: studio-125-branch
+
+### 2026-04-08 - Implementation
+- Added global CSS overrides in `web/src/app.css` to fix title-bar layout
+- Used `.main-area > .title-bar` selector (specificity 0,2,0) to override Svelte 5 scoped styles
+- Switched from absolute positioning to 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`
+- Build passes, pre-existing test failures in graph-writer unrelated to this change
+- Committed as `fix(web): prevent app title and section label from overlapping in top bar`
 
 ## Blockers
-<!-- Record any issues encountered -->

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1207,6 +1207,26 @@ a:hover {
   background: transparent;
 }
 
+/* ── Title-bar overlap fix (overrides scoped styles in App.svelte) ── */
+.main-area > .title-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+}
+
+.main-area > .title-bar .title-bar-label {
+  position: static;
+  text-align: left;
+}
+
+.main-area > .title-bar .title-bar-brand {
+  text-align: center;
+}
+
+.main-area > .title-bar .title-bar-spacer {
+  /* occupies right column to keep brand centered */
+}
+
 /* ── Responsive ── */
 @media (max-width: 1100px) {
   .toolbar {


### PR DESCRIPTION
## Summary
## Final Summary

### What changed
- **`web/src/app.css`** — Added global CSS overrides (20 lines) that switch the `.title-bar` from `display: flex` + `position: absolute` children to a `display: grid` with `grid-template-columns: 1fr auto 1fr`. This gives the section label (left), brand name (center), and spacer (right) each their own non-overlapping column. Used `.main-area > .title-bar` selector to reliably override Svelte 5's `:where()`-based scoped styles.

### Quality checks
- ✅ **Build** (`npm run build:web`) — passes
- ⚠️ **Tests** (`npm test`) — 1 test file fails (15 tests in `graph-writer.service.test.ts`) due to pre-existing SQLite issues, unrelated to this CSS change. 6 other test files pass.

### No blockers or follow-up items

actual_files synced: 1 file(s).

## Context
- Work item: studio-125
- Issue: https://github.com/fusupo/escapement-studio/issues/125
- Base branch: develop
- Head branch: studio-125-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775632792563
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-125-branch
- Scope hint: Fix the top-bar layout so the app title and active section label no longer overlap.

## Changed files
- `SCRATCHPAD.md`