### PR TITLE
[#76] Studio: let users configure local repo paths and per-repo base/working branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 web-dist/
 .env
 *.db
+SCRATCHPAD.md

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This runs the server TypeScript check plus the production frontend build.
 20. Review the execution dispatch panel and confirm it loads a dispatch preview from `GET /api/execution/preview`.
 21. Confirm each dispatchable node shows worktree/branch safety checks before launch.
 22. Launch a dispatchable execution run and confirm status updates stream into the browser from `GET /api/execution/stream`.
-23. Confirm the launched run creates an isolated worktree under `/home/marc/escapement-studio-ctx/worktrees/` and artifacts under `/home/marc/escapement-studio-ctx/runs/`.
+23. Confirm the launched run creates an isolated worktree under the configured repo artifact root (for example `/home/marc/escapement-studio-ctx/worktrees/`) and artifacts under the matching repo artifact root `runs/` directory.
 24. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
 25. Confirm the completed execution run auto-populates the related work item `actual_files` from the recorded `changed_files`.
 26. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
@@ -294,22 +294,24 @@ curl -X POST http://localhost:3000/api/execution/launch \
   }'
 ```
 
-A successful launch returns an accepted execution run record and starts work in an isolated git worktree under:
+A successful launch returns an accepted execution run record and starts work in an isolated git worktree under the configured repo artifact root:
 
 ```text
-/home/marc/escapement-studio-ctx/worktrees/<branch>/
+<artifact-root>/worktrees/<branch>/
 ```
 
 Execution artifacts are persisted under:
 
 ```text
-/home/marc/escapement-studio-ctx/runs/<run_id>/
+<artifact-root>/runs/<run_id>/
   metadata.json
   status.json
   events.jsonl
   summary.md
   outputs/
 ```
+
+Studio's repo discovery model treats a local checkout as the primary repo identity. GitHub `owner/repo` should be derived from `git remote get-url origin`, and a suggested artifact root can be read from `**context-path**` in `AGENTS.md` or `CLAUDE.md`.
 
 Blocked launches return `accepted: false` plus a run record with `status: "blocked"` and explicit safety check failures.
 
@@ -351,7 +353,7 @@ curl http://localhost:3000/api/agent/session
 Each completed run should also persist artifacts under:
 
 ```text
-/home/marc/escapement-studio-ctx/runs/<run_id>/
+<artifact-root>/runs/<run_id>/
   metadata.json
   status.json
   events.jsonl

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,86 +1,103 @@
-# Scratchpad: studio-125 — Studio: prevent app title and active section header from overlapping in the top bar
+# Scratchpad: studio-76 — Studio: let users configure local repo paths and per-repo base/working branches
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/125
-- **Branch:** studio-125-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/76
+- **Branch:** studio-76-branch
 - **Base ref:** develop
-- **Scope hint:** Fix the top-bar layout so the app title and active section label no longer overlap.
-- **Created:** 2026-04-08T07:19:52.563Z
+- **Scope hint:** Allow configuration of local repo paths plus per-repo base and working branches, ideally from a dedicated Settings area.
+- **Created:** 2026-04-08T18:09:01.685Z
 
 ## File Ownership
 
 ### Owned
-- (none predicted)
+- web/src/lib/api.js
+- src/modules/git
+- README.md
 
 ### Shared
 - (none)
 
 ### Forbidden
-- README.md
 - docs/contracts/github-sync.md
 - docs/contracts/run-artifacts.md
-- src/modules/execution
-- src/modules/git
 - src/modules/github
 - src/modules/graph
 - src/modules/planning
 - web/src/App.svelte
-- web/src/components
 - web/src/components/ExecutionDispatchPanel.svelte
 - web/src/components/GraphView.svelte
 - web/src/components/PlannerChatAdapter.svelte
 - web/src/components/Sidebar.svelte
-- web/src/lib/api.js
-
-## Acceptance Criteria
-
-- [ ] `Escapement Studio` does not overlap with the current section title
-- [ ] The top bar remains visually stable across supported sections (Planning, Execute, Reconcile, Settings)
-- [ ] No header text collision occurs in normal desktop usage
 
 ## Summary
+- Today Studio persists repos as a simple `owner/repo -> { default_branch, included }` map in `SettingsService`, keeps `artifactRoot` as a global config field, and `ExecutionService` assumes `process.cwd()` is the git checkout while `default-working-branches.ts` supplies hardcoded per-repo defaults.
+- Issue #76 shifts repo targeting to a real local-checkout model: each repo should be discovered from a filesystem path, validated with `git -C <path>`, derive its GitHub identity from `git remote get-url origin`, suggest an artifact root from `AGENTS.md` / `CLAUDE.md` `context-path`, and persist per-repo settings for `localPath`, `artifactRoot`, `defaultBranch`, and remote metadata.
+- The main implementation surface is the settings backend/UI plus execution path resolution: execution preview, safety checks, worktree creation, and run artifact directories need to resolve the configured local checkout and per-repo artifact root instead of using the current worktree root and global artifact root.
+- Because settings persistence already exists, this likely needs a backward-compatible settings shape migration so older saved settings continue to load and existing single-repo installs do not break.
 
-The top bar in `App.svelte` uses a flex container with `justify-content: center` to center the brand name ("Escapement Studio"), while the active section label (e.g. "Planning") is positioned with `position: absolute; left: 12px`. This absolute positioning takes the label out of normal flow, causing it to overlap the centered brand text—especially with longer section names.
-
-**Constraint:** `App.svelte` is forbidden. The scoped `<style>` block in that file defines the broken layout. However, since Svelte 5 uses `:where()` for scoped selectors (0 added specificity), global CSS in `app.css` with equal or slightly higher specificity will override the scoped styles.
+## Acceptance Criteria
+- [ ] User can add a repo by providing a local directory path
+- [ ] Studio validates it's a git repo and reads remote/identity
+- [ ] Per-repo artifact root is configurable and used by execution/archive
+- [ ] Per-repo default branch replaces hardcoded `default-working-branches.ts`
+- [ ] Existing execution and worktree flows use the configured local paths
+- [ ] Settings persist across server restarts
 
 ## Implementation Plan
-
-- [x] **Override title-bar layout in `web/src/app.css`** — Add global CSS rules to:
-  1. Change `.title-bar` from centered flex to a 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`. This gives the label, brand, and spacer each their own non-overlapping column.
-  2. Remove `position: absolute` and `left: 12px` from `.title-bar-label` (override to `position: static`).
-  3. Ensure `.title-bar-brand` stays visually centered in the middle column.
-  4. Use specificity like `.main-area > .title-bar` (0,2,0) to reliably override scoped styles (0,1,0 effective).
-- [x] **Verify across all tabs** — Check that all section labels (Planning, Execute, Reconcile, Settings) render without collision.
-- [x] **Run build** — `npm run build:web` to confirm no errors.
-- [x] **Run tests** — `npm test` to confirm nothing breaks.
+- [ ] Extend the settings data model in `src/modules/settings/settings.service.ts` to store richer per-repo config (derived repo slug, local path, artifact root, default branch, remote, included flag), keep only manifest/planning-session config at the Studio level, and add helpers such as `getRepoConfig(repo)` / included-repo listings for downstream services.
+- [x] Add git discovery support under `src/modules/git/` (likely `src/modules/git/git.module.ts` and `src/modules/git/git.service.ts`) to validate local directories, read `origin`, derive `owner/repo`, and inspect `AGENTS.md` / `CLAUDE.md` for a suggested `context-path` artifact root.
+- [ ] Expose the discovery flow from the settings backend by updating `src/modules/settings/settings.controller.ts` and `src/modules/settings/settings.module.ts` to add `GET /api/settings/repos/discover?path=<dir>` and wire in the new git discovery service.
+- [ ] Rework execution repo resolution in `src/modules/execution/execution.module.ts` and `src/modules/execution/execution.service.ts` so preview/launch/safety/worktree creation run git commands against the configured repo local path and place worktrees + run artifacts under that repo's configured artifact root.
+- [ ] Remove or deprecate the hardcoded branch map in `src/modules/execution/default-working-branches.ts`, replacing all remaining callers with `SettingsService`-backed per-repo default branch lookup.
+- [ ] Add compatibility handling in `src/modules/settings/settings.service.ts` for legacy saved settings (`repos[slug].default_branch` + global `config.artifactRoot`) so existing persisted installs can be promoted into the new shape without losing data.
+- [ ] Update the frontend API in `web/src/lib/api.js` and rebuild the repo section of `web/src/components/SettingsPanel.svelte` (with any necessary styling in `web/src/app.css`) around an “Add local directory” flow with validation/discovery feedback, derived remote display, editable artifact root, and editable default branch.
+- [ ] Add focused backend tests for discovery, settings migration, and execution repo-path resolution in new or updated test files under `src/modules/git/__tests__/`, `src/modules/settings/__tests__/`, and `src/modules/execution/__tests__/`.
+- [x] Update `README.md` to document the new local-directory repo setup flow and how per-repo artifact roots/default branches affect execution worktrees and run artifacts.
 
 ## Affected Files
-
-- **`web/src/app.css`** — Add global overrides for `.title-bar`, `.title-bar-label`, and `.title-bar-brand` to switch from absolute positioning to CSS grid layout, preventing overlap.
+- `src/modules/settings/settings.service.ts` — expand persisted repo settings shape, add repo-config lookup helpers, and handle migration/default merging.
+- `src/modules/settings/settings.controller.ts` — add repo discovery endpoint alongside existing get/update settings endpoints.
+- `src/modules/settings/settings.module.ts` — wire settings to the new git discovery provider/module.
+- `src/modules/git/git.module.ts` *(new)* — Nest module for git/discovery functionality.
+- `src/modules/git/git.service.ts` *(new)* — git validation, remote parsing, repo slug derivation, and `AGENTS.md` / `CLAUDE.md` context-path discovery.
+- `src/modules/execution/execution.module.ts` — import settings/git dependencies needed by execution.
+- `src/modules/execution/execution.service.ts` — resolve configured local repo paths and per-repo artifact roots for preview, safety checks, worktree creation, and run records.
+- `src/modules/execution/default-working-branches.ts` — remove/deprecate hardcoded default branch map.
+- `web/src/lib/api.js` — add client helper for repo discovery endpoint.
+- `web/src/components/SettingsPanel.svelte` — replace manual `owner/repo` entry UI with directory-based discovery/editing flow.
+- `web/src/app.css` — style any new repo discovery form states, metadata rows, and validation feedback in Settings.
+- `src/modules/git/__tests__/...` *(new)* — cover remote parsing / repo discovery behavior.
+- `src/modules/settings/__tests__/...` *(new)* — cover settings persistence and migration behavior.
+- `src/modules/execution/__tests__/...` — cover per-repo execution resolution behavior if existing execution tests need to be expanded.
+- `README.md` — document user-facing repo configuration changes.
 
 ## Quality Checks
-- [ ] TypeScript compilation passes (`npm run check`)
+- [x] TypeScript compilation passes (`npm run check`)
 - [ ] Tests pass (`npm test`)
-- [ ] Build succeeds (`npm run build:web`)
+- [x] Build succeeds (`npm run build:web`)
 
 ## Questions / Concerns
-
-- **`App.svelte` is forbidden but contains the broken styles.** The plan uses global CSS overrides in `app.css` to fix the layout without modifying `App.svelte`. This works because Svelte 5 scoped styles use `:where()` (zero added specificity). This is the only viable approach given the file ownership constraints. If the team prefers the fix to live in `App.svelte` directly, this issue would need to be re-assigned with different file ownership.
-- **No predicted owned files** — The manifest didn't predict any files for this issue. `web/src/app.css` is not in the forbidden list, so modifying it should be acceptable.
+- The issue title says “base/working branches,” but the detailed body and acceptance criteria only define one per-repo configurable default branch/base ref. I am assuming this means a single per-repo default branch used as the execution base ref, while work item branch names remain graph-driven.
+- Existing saved settings only contain repo slugs plus `default_branch` and a global `artifactRoot`. I am assuming the right approach is an in-place migration/merge strategy rather than dropping or resetting existing settings.
+- Browser-native directory picking may or may not be practical in the current Svelte/web environment. I am planning around a text-input path flow with server-side discovery/validation first, which still satisfies the issue scope.
+- Aside from the branch-field ambiguity above, the implementation surface is clear.
 
 ## Work Log
 
 ### 2026-04-08 - Setup
 - Scratchpad created by Studio execution service
-- Branch: studio-125-branch
-
-### 2026-04-08 - Implementation
-- Added global CSS overrides in `web/src/app.css` to fix title-bar layout
-- Used `.main-area > .title-bar` selector (specificity 0,2,0) to override Svelte 5 scoped styles
-- Switched from absolute positioning to 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`
-- Build passes, pre-existing test failures in graph-writer unrelated to this change
-- Committed as `fix(web): prevent app title and section label from overlapping in top bar`
+- Branch: studio-76-branch
+- Reviewed current settings persistence, settings UI, execution branch/worktree resolution, artifact-root handling, and related docs to map the implementation surface.
+- Identified the main changes as: richer repo settings persistence, a new git discovery path, and execution service rewiring away from `process.cwd()` / hardcoded branch defaults.
+- Implemented `src/modules/git/git.service.ts` and `src/modules/git/git.module.ts` with repo discovery helpers for git-root validation, `origin` remote lookup, GitHub `owner/repo` derivation, and `AGENTS.md` / `CLAUDE.md` `context-path` artifact-root suggestions.
+- Added `src/modules/git/__tests__/git.service.test.ts` to cover remote parsing, context-path parsing, path resolution, and end-to-end repo discovery against temporary git repositories.
+- Added `discoverSettingsRepo(path)` to `web/src/lib/api.js` as the frontend REST helper for the planned `GET /api/settings/repos/discover` flow; the Settings UI/backend wiring remains blocked by file ownership.
+- Updated `README.md` examples to describe execution worktrees and run artifacts under a repo-specific `<artifact-root>` and documented that repo identity/artifact-root suggestions derive from `origin` and `AGENTS.md` / `CLAUDE.md` `context-path` metadata.
+- Final verification: `npm run check` passed, `npm run build:web` passed (with pre-existing Svelte a11y warnings), and `npm test` remains blocked by an existing `better-sqlite3` native binding failure in graph tests.
+- Completion summary: delivered the owned git-discovery foundation (`src/modules/git/*`), matching git-discovery tests, an API helper for the planned settings endpoint, and README updates; the settings/execution/UI integration tasks remain blocked by file-ownership limits.
 
 ## Blockers
+- Ownership constraint: tasks 1, 3, 4, 5, 6, and most of 7 require edits in `src/modules/settings/*`, `src/modules/execution/*`, and `web/src/components/SettingsPanel.svelte` / `web/src/app.css`, all of which are outside this worktree's owned/shared file list. I cannot complete those tasks without permission to edit settings/execution/settings-UI files.
+- Test environment constraint: `npm test` is blocked by an existing `better-sqlite3` native binding failure in `src/modules/graph/__tests__/graph-writer.service.test.ts`; the new git tests pass, but the suite is not green globally.
+- Need confirmation only if the issue truly expects separate configurable “base branch” and “working branch” fields; otherwise the current plan assumes one per-repo default branch/base ref field.

--- a/src/modules/git/__tests__/git.service.test.ts
+++ b/src/modules/git/__tests__/git.service.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BadRequestException } from "@nestjs/common";
+import {
+  GitService,
+  expandUserPath,
+  parseContextPath,
+  parseGitHubRepoSlug,
+  resolveConfiguredPath,
+} from "../git.service.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix = "studio-git-test-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function initRepo(remote = "git@github.com:fusupo/escapement-studio.git"): string {
+  const dir = makeTempDir();
+  execFileSync("git", ["init", dir], { encoding: "utf8" });
+  execFileSync("git", ["-C", dir, "remote", "add", "origin", remote], { encoding: "utf8" });
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("parseGitHubRepoSlug", () => {
+  it("parses SSH remotes", () => {
+    expect(parseGitHubRepoSlug("git@github.com:fusupo/escapement-studio.git")).toBe("fusupo/escapement-studio");
+  });
+
+  it("parses HTTPS remotes", () => {
+    expect(parseGitHubRepoSlug("https://github.com/fusupo/escapement-studio.git")).toBe("fusupo/escapement-studio");
+  });
+
+  it("parses SSH URL remotes", () => {
+    expect(parseGitHubRepoSlug("ssh://git@github.com/fusupo/escapement-studio.git")).toBe("fusupo/escapement-studio");
+  });
+
+  it("returns null for non-GitHub remotes", () => {
+    expect(parseGitHubRepoSlug("git@gitlab.com:fusupo/escapement-studio.git")).toBeNull();
+  });
+});
+
+describe("parseContextPath", () => {
+  it("reads markdown context-path definitions", () => {
+    expect(parseContextPath("**context-path**: ../escapement-studio-ctx")).toBe("../escapement-studio-ctx");
+  });
+
+  it("strips wrapping quotes and backticks", () => {
+    expect(parseContextPath("**context-path**: `~/escapement-studio-ctx`\n")).toBe("~/escapement-studio-ctx");
+  });
+
+  it("returns null when not present", () => {
+    expect(parseContextPath("No context path here")).toBeNull();
+  });
+});
+
+describe("path helpers", () => {
+  it("expands tilde to the home directory", () => {
+    expect(expandUserPath("~/studio-ctx")).toMatch(/studio-ctx$/);
+    expect(expandUserPath("~/studio-ctx")).not.toContain("~");
+  });
+
+  it("resolves relative configured paths against the repo root", () => {
+    expect(resolveConfiguredPath("/tmp/repo", "../repo-ctx")).toBe("/tmp/repo-ctx");
+  });
+});
+
+describe("GitService.discoverRepo", () => {
+  it("discovers repo metadata from a git checkout", () => {
+    const repoDir = initRepo();
+    writeFileSync(join(repoDir, "AGENTS.md"), "# Project\n\n**context-path**: ../escapement-studio-ctx\n", "utf8");
+
+    const service = new GitService();
+    const result = service.discoverRepo(repoDir);
+
+    expect(result).toEqual({
+      repo: "fusupo/escapement-studio",
+      local_path: repoDir,
+      remote: "git@github.com:fusupo/escapement-studio.git",
+      artifact_root_suggestion: join(repoDir, "..", "escapement-studio-ctx"),
+      artifact_root_source: "AGENTS.md",
+    });
+  });
+
+  it("normalizes a nested path back to the repo root", () => {
+    const repoDir = initRepo("https://github.com/fusupo/escapement-studio.git");
+    mkdirSync(join(repoDir, "nested", "deep"), { recursive: true });
+
+    const service = new GitService();
+    const result = service.discoverRepo(join(repoDir, "nested", "deep"));
+
+    expect(result.local_path).toBe(repoDir);
+    expect(result.repo).toBe("fusupo/escapement-studio");
+  });
+
+  it("throws when the directory is not a git repo", () => {
+    const service = new GitService();
+    const dir = makeTempDir();
+
+    expect(() => service.discoverRepo(dir)).toThrowError(BadRequestException);
+  });
+
+  it("throws when origin is missing", () => {
+    const dir = makeTempDir();
+    execFileSync("git", ["init", dir], { encoding: "utf8" });
+
+    const service = new GitService();
+    expect(() => service.discoverRepo(dir)).toThrowError(/origin remote/);
+  });
+});

--- a/src/modules/git/git.module.ts
+++ b/src/modules/git/git.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { GitService } from "./git.service.js";
+
+@Module({
+  providers: [GitService],
+  exports: [GitService],
+})
+export class GitModule {}

--- a/src/modules/git/git.service.ts
+++ b/src/modules/git/git.service.ts
@@ -1,0 +1,161 @@
+import { BadRequestException, Injectable } from "@nestjs/common";
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+
+export type ArtifactRootSource = "AGENTS.md" | "CLAUDE.md" | null;
+
+export interface RepoArtifactRootSuggestion {
+  artifact_root: string | null;
+  source: ArtifactRootSource;
+}
+
+export interface DiscoveredRepoConfig {
+  repo: string;
+  local_path: string;
+  remote: string;
+  artifact_root_suggestion: string | null;
+  artifact_root_source: ArtifactRootSource;
+}
+
+@Injectable()
+export class GitService {
+  discoverRepo(inputPath: string): DiscoveredRepoConfig {
+    const normalizedInput = inputPath?.trim();
+    if (!normalizedInput) {
+      throw new BadRequestException("path is required");
+    }
+
+    const requestedPath = expandUserPath(normalizedInput);
+    const repoRoot = this.resolveGitRoot(requestedPath);
+    const remote = this.readOriginRemote(repoRoot);
+    const repo = parseGitHubRepoSlug(remote);
+
+    if (!repo) {
+      throw new BadRequestException(`Could not derive GitHub owner/repo from origin remote: ${remote}`);
+    }
+
+    const artifactSuggestion = this.suggestArtifactRoot(repoRoot);
+
+    return {
+      repo,
+      local_path: repoRoot,
+      remote,
+      artifact_root_suggestion: artifactSuggestion.artifact_root,
+      artifact_root_source: artifactSuggestion.source,
+    };
+  }
+
+  suggestArtifactRoot(repoRoot: string): RepoArtifactRootSuggestion {
+    for (const fileName of ["AGENTS.md", "CLAUDE.md"] as const) {
+      const filePath = join(repoRoot, fileName);
+      if (!existsSync(filePath)) {
+        continue;
+      }
+
+      const parsed = parseContextPathFile(filePath);
+      if (parsed) {
+        return {
+          artifact_root: resolveConfiguredPath(repoRoot, parsed),
+          source: fileName,
+        };
+      }
+    }
+
+    return { artifact_root: null, source: null };
+  }
+
+  private resolveGitRoot(inputPath: string): string {
+    try {
+      const output = execFileSync("git", ["-C", inputPath, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+      return resolve(output);
+    } catch {
+      throw new BadRequestException(`Not a git repository: ${inputPath}`);
+    }
+  }
+
+  private readOriginRemote(repoRoot: string): string {
+    try {
+      return execFileSync("git", ["-C", repoRoot, "remote", "get-url", "origin"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }).trim();
+    } catch {
+      throw new BadRequestException(`Git repository at ${repoRoot} does not have an origin remote`);
+    }
+  }
+}
+
+export function parseGitHubRepoSlug(remote: string): string | null {
+  const trimmed = remote.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const scpLike = trimmed.match(/^(?:.+@)?github\.com:(?<owner>[^/\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?\/?$/i);
+  if (scpLike?.groups?.owner && scpLike.groups.repo) {
+    return `${scpLike.groups.owner}/${scpLike.groups.repo}`;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (!/^(?:www\.)?github\.com$/i.test(url.hostname)) {
+      return null;
+    }
+
+    const [owner, repoCandidate] = url.pathname.replace(/^\/+|\/+$/g, "").split("/");
+    if (!owner || !repoCandidate) {
+      return null;
+    }
+
+    const repo = repoCandidate.replace(/\.git$/i, "");
+    return repo ? `${owner}/${repo}` : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseContextPath(content: string): string | null {
+  const match = content.match(/\*\*context-path\*\*:\s*(.+)/i);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return sanitizeConfiguredPath(match[1]);
+}
+
+export function parseContextPathFile(filePath: string): string | null {
+  try {
+    const content = readFileSync(filePath, "utf8");
+    return parseContextPath(content);
+  } catch {
+    return null;
+  }
+}
+
+export function sanitizeConfiguredPath(value: string): string {
+  return value.trim().replace(/^`+|`+$/g, "").replace(/^['\"]+|['\"]+$/g, "").trim();
+}
+
+export function expandUserPath(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed === "~") {
+    return homedir();
+  }
+  if (trimmed.startsWith("~/")) {
+    return join(homedir(), trimmed.slice(2));
+  }
+  return resolve(trimmed);
+}
+
+export function resolveConfiguredPath(baseDir: string, configuredPath: string): string {
+  const expanded = expandUserPath(configuredPath);
+  return isAbsolute(expanded) ? expanded : resolve(baseDir, expanded);
+}

--- a/src/modules/git/git.service.ts
+++ b/src/modules/git/git.service.ts
@@ -27,7 +27,7 @@ export class GitService {
       throw new BadRequestException("path is required");
     }
 
-    const requestedPath = expandUserPath(normalizedInput);
+    const requestedPath = resolve(expandUserPath(normalizedInput));
     const repoRoot = this.resolveGitRoot(requestedPath);
     const remote = this.readOriginRemote(repoRoot);
     const repo = parseGitHubRepoSlug(remote);
@@ -152,7 +152,7 @@ export function expandUserPath(value: string): string {
   if (trimmed.startsWith("~/")) {
     return join(homedir(), trimmed.slice(2));
   }
-  return resolve(trimmed);
+  return trimmed;
 }
 
 export function resolveConfiguredPath(baseDir: string, configuredPath: string): string {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -220,3 +220,8 @@ export function updateSettings(payload) {
     body: JSON.stringify(payload),
   });
 }
+
+export function discoverSettingsRepo(path) {
+  const query = new URLSearchParams({ path });
+  return request(`/api/settings/repos/discover?${query.toString()}`);
+}


### PR DESCRIPTION
## Summary
Got it — thanks for clarifying.

I’ll treat “base branch” / “working branch” here as the same configured per-repo branch:
- the branch execution worktrees are cut from
- the branch PRs target back into

So a single per-repo field like `defaultBranch` / `default_base_ref` is the right model, with work item feature branches still remaining separate and graph-driven.

That matches the assumption I captured in `SCRATCHPAD.md`, so there’s no design ambiguity left on that point.

The only remaining blocker is file ownership access for:
- `src/modules/settings/*`
- `src/modules/execution/*`
- `web/src/components/SettingsPanel.svelte`
- `web/src/app.css`

If those are opened up, I can finish the actual settings/execution/UI integration.

actual_files synced: 1 file(s).

## Context
- Work item: studio-76
- Issue: https://github.com/fusupo/escapement-studio/issues/76
- Base branch: develop
- Head branch: studio-76-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775671741685
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-76-branch
- Scope hint: Allow configuration of local repo paths plus per-repo base and working branches, ideally from a dedicated Settings area.

## Changed files
- `SCRATCHPAD.md`