### PR TITLE
[#90] Studio: auto-staged graph proposals can use stale placeholder work item IDs after GitHub assigns final issue numbers

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,12 +1,17 @@
-# Scratchpad: studio-125 — Studio: prevent app title and active section header from overlapping in the top bar
+# Scratchpad: studio-90 — Studio: auto-staged graph proposals can use stale placeholder work item IDs after GitHub assigns final issue numbers
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/125
-- **Branch:** studio-125-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/90
+- **Branch:** studio-90-branch
 - **Base ref:** develop
-- **Scope hint:** Fix the top-bar layout so the app title and active section label no longer overlap.
-- **Created:** 2026-04-08T07:19:52.563Z
+- **Scope hint:** Fix auto-staged graph proposals so issue-backed IDs are rewritten to the actual GitHub issue number returned by GitHub before proposal staging and child references are generated.
+- **Created:** 2026-04-08T20:29:59.289Z
+
+## Summary
+- The failing path is `github_create_issue` in `src/modules/planning/planning.service.ts`: it creates the GitHub issue first, but then still trusts the caller-supplied `work_item_id` when staging the `create_work_item` mutation. If the caller guessed `studio-82` and GitHub returned `#83`, the proposal ends up with a misaligned issue-backed ID and fails graph validation.
+- That same auto-staging flow also builds `create_edge` mutations from `parent_id` / `depends_on_ids`, so grouped epic + child creation in one turn can accumulate edges that still point at placeholder IDs instead of the final canonical `studio-{issue_number}` ID.
+- The fix should canonicalize issue-backed IDs from the actual GitHub issue number before staging the proposal, then rewrite related parent/dependency references so all staged mutations consistently reference the final aligned ID.
 
 ## File Ownership
 
@@ -17,70 +22,56 @@
 - (none)
 
 ### Forbidden
-- README.md
 - docs/contracts/github-sync.md
 - docs/contracts/run-artifacts.md
 - src/modules/execution
-- src/modules/git
-- src/modules/github
-- src/modules/graph
-- src/modules/planning
+- src/modules/settings
 - web/src/App.svelte
 - web/src/components
 - web/src/components/ExecutionDispatchPanel.svelte
 - web/src/components/GraphView.svelte
-- web/src/components/PlannerChatAdapter.svelte
+- web/src/components/SettingsPanel.svelte
 - web/src/components/Sidebar.svelte
 - web/src/lib/api.js
 
 ## Acceptance Criteria
-
-- [ ] `Escapement Studio` does not overlap with the current section title
-- [ ] The top bar remains visually stable across supported sections (Planning, Execute, Reconcile, Settings)
-- [ ] No header text collision occurs in normal desktop usage
-
-## Summary
-
-The top bar in `App.svelte` uses a flex container with `justify-content: center` to center the brand name ("Escapement Studio"), while the active section label (e.g. "Planning") is positioned with `position: absolute; left: 12px`. This absolute positioning takes the label out of normal flow, causing it to overlap the centered brand text—especially with longer section names.
-
-**Constraint:** `App.svelte` is forbidden. The scoped `<style>` block in that file defines the broken layout. However, since Svelte 5 uses `:where()` for scoped selectors (0 added specificity), global CSS in `app.css` with equal or slightly higher specificity will override the scoped styles.
+- [x] After GitHub creates an issue, the staged graph proposal uses the actual assigned GitHub issue number to derive the issue-backed work item ID.
+- [x] For issue-backed items created through auto-staging, `entity_id` / graph work item ID always aligns with `issue_number`.
+- [x] Epic/child and dependency relationships created during grouped issue flows reference the final aligned parent ID, not a pre-creation placeholder ID.
+- [x] Multi-issue auto-staged proposals do not accumulate invalid child/dependency references when placeholder IDs differ from the final GitHub issue number.
+- [x] Regression coverage exists for epic + child issue creation flows that previously produced misaligned IDs or missing-parent validation failures.
 
 ## Implementation Plan
-
-- [x] **Override title-bar layout in `web/src/app.css`** — Add global CSS rules to:
-  1. Change `.title-bar` from centered flex to a 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`. This gives the label, brand, and spacer each their own non-overlapping column.
-  2. Remove `position: absolute` and `left: 12px` from `.title-bar-label` (override to `position: static`).
-  3. Ensure `.title-bar-brand` stays visually centered in the middle column.
-  4. Use specificity like `.main-area > .title-bar` (0,2,0) to reliably override scoped styles (0,1,0 effective).
-- [x] **Verify across all tabs** — Check that all section labels (Planning, Execute, Reconcile, Settings) render without collision.
-- [x] **Run build** — `npm run build:web` to confirm no errors.
-- [x] **Run tests** — `npm test` to confirm nothing breaks.
+- [x] Update `src/modules/planning/planning.service.ts` so `github_create_issue` always derives the staged issue-backed work item ID from `created.number` (reusing the graph ID convention helper), rewrites the `create_work_item` mutation's `entity_id` and `payload.id`, and never stages the pre-creation placeholder ID after GitHub responds.
+- [x] Extend `src/modules/planning/planning.service.ts` with same-turn placeholder-to-final ID resolution for accumulated multi-issue proposals so `parent_id` and `depends_on_ids` are rewritten to the final aligned IDs before `create_edge` mutations are staged.
+- [x] Add focused regression tests in `src/modules/planning/__tests__/planning.service.test.ts` for: (1) single issue creation where requested `work_item_id` and returned issue number differ, (2) epic + child creation where the child references the parent's placeholder ID, and (3) dependency references in grouped proposals use the rewritten final ID.
+- [x] Verify with `npm run check` and targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` (plus full `npm test` if the worktree environment allows it), then record any environment-related test limitations in this scratchpad.
 
 ## Affected Files
-
-- **`web/src/app.css`** — Add global overrides for `.title-bar`, `.title-bar-label`, and `.title-bar-brand` to switch from absolute positioning to CSS grid layout, preventing overlap.
+- `src/modules/planning/planning.service.ts` — canonicalize issue-backed IDs after GitHub issue creation, track placeholder-to-final aliases during proposal accumulation, and ensure staged edges reference final aligned IDs.
+- `src/modules/planning/__tests__/planning.service.test.ts` — add regression coverage for placeholder-ID rewriting and grouped epic/child creation flows.
 
 ## Quality Checks
-- [ ] TypeScript compilation passes (`npm run check`)
-- [ ] Tests pass (`npm test`)
-- [ ] Build succeeds (`npm run build:web`)
+- [x] TypeScript compilation passes (`npm run check`)
+- [ ] Tests pass (`npm test`) — targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` passed, but full `npm test` is blocked by missing `better-sqlite3` native bindings in existing graph tests in this worktree.
+- [x] Build succeeds (`npm run build:web`)
 
 ## Questions / Concerns
-
-- **`App.svelte` is forbidden but contains the broken styles.** The plan uses global CSS overrides in `app.css` to fix the layout without modifying `App.svelte`. This works because Svelte 5 scoped styles use `:where()` (zero added specificity). This is the only viable approach given the file ownership constraints. If the team prefers the fix to live in `App.svelte` directly, this issue would need to be re-assigned with different file ownership.
-- **No predicted owned files** — The manifest didn't predict any files for this issue. `web/src/app.css` is not in the forbidden list, so modifying it should be acceptable.
+- Assumption: for `github_create_issue`, any caller-supplied `work_item_id` is only a pre-creation hint and may be silently canonicalized to `studio-${created.number}` once GitHub returns the real issue number. That matches the issue scope and existing graph validation rules.
+- No other blockers found from the current code surface.
+- Everything else is clear.
 
 ## Work Log
 
 ### 2026-04-08 - Setup
 - Scratchpad created by Studio execution service
-- Branch: studio-125-branch
-
-### 2026-04-08 - Implementation
-- Added global CSS overrides in `web/src/app.css` to fix title-bar layout
-- Used `.main-area > .title-bar` selector (specificity 0,2,0) to override Svelte 5 scoped styles
-- Switched from absolute positioning to 3-column CSS grid: `grid-template-columns: 1fr auto 1fr`
-- Build passes, pre-existing test failures in graph-writer unrelated to this change
-- Committed as `fix(web): prevent app title and section label from overlapping in top bar`
+- Branch: studio-90-branch
+- Reviewed the `github_create_issue` auto-staging path in `src/modules/planning/planning.service.ts` plus graph ID-alignment validation in `src/modules/graph/types.ts` / `src/modules/graph/graph-writer.service.ts` to scope the fix and test surface.
+- Implemented the first fix in `src/modules/planning/planning.service.ts`: auto-staged issue-backed work items now derive their staged ID from `deriveIssueWorkItemId(created.number)` instead of trusting a stale pre-creation `work_item_id` hint.
+- Extended `src/modules/planning/planning.service.ts` with turn-scoped placeholder→final ID alias tracking so grouped `github_create_issue` flows rewrite `parent_id`, `depends_on_ids`, and previously accumulated proposal references to the final canonical issue-backed IDs.
+- Added `src/modules/planning/__tests__/planning.service.test.ts` with regression coverage for mismatched placeholder IDs, epic/child parent rewrites, dependency rewrites, and the case where a later issue creation retroactively fixes an earlier accumulated child reference.
+- Verified the change with `npm run check` ✅, `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` ✅, and `npm run build:web` ✅. Full `npm test` still fails in pre-existing graph tests because this worktree is missing `better-sqlite3` native bindings.
+- Completion summary: `github_create_issue` now stages issue-backed work items with canonical IDs derived from the actual GitHub issue number, grouped proposal edges resolve placeholder parent/dependency IDs to the final canonical IDs, and regression coverage now protects the previously failing multi-issue proposal paths.
 
 ## Blockers
+- Full `npm test` is blocked by missing `better-sqlite3` native bindings in this worktree (`Could not locate the bindings file` from existing `src/modules/graph/__tests__/graph-writer.service.test.ts`).

--- a/src/modules/planning/__tests__/planning.service.test.ts
+++ b/src/modules/planning/__tests__/planning.service.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../graph/graph.service.js", () => ({
+  GraphService: class {},
+}));
+
+vi.mock("../../graph/graph-writer.service.js", () => ({
+  GraphWriterService: class {},
+}));
+
+vi.mock("../../github/github.service.js", () => ({
+  GitHubService: class {},
+}));
+
+vi.mock("../context.service.js", () => ({
+  ContextService: class {},
+}));
+
+vi.mock("../memory.service.js", () => ({
+  MemoryService: class {},
+}));
+
+vi.mock("../sub-agent.service.js", () => ({
+  SubAgentService: class {},
+}));
+
+vi.mock("../../reconciliation/reconciliation.service.js", () => ({
+  ReconciliationService: class {},
+}));
+
+import { PlanningService } from "../planning.service.js";
+import type { PlanningMutationProposal } from "../types.js";
+
+type CreatedIssue = {
+  repo: string;
+  number: number;
+  url: string;
+  title: string;
+};
+
+function makePlanningService(createdIssues: CreatedIssue[]) {
+  const createIssue = vi.fn<(input: { repo: string; title: string; body?: string; labels?: string[] }) => Promise<CreatedIssue>>();
+  for (const issue of createdIssues) {
+    createIssue.mockResolvedValueOnce(issue);
+  }
+
+  const service = new PlanningService(
+    {} as never,
+    { getGraph: () => ({ graph_version: "7" }) } as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    { createIssue } as never,
+    {} as never,
+  );
+
+  (service as any).currentTurnId = "turn_0001";
+
+  return {
+    service,
+    createIssue,
+    tool: (service as any).createGitHubCreateIssueTool(),
+  };
+}
+
+async function executeCreateIssue(
+  tool: any,
+  params: Record<string, unknown>,
+): Promise<PlanningMutationProposal> {
+  const result = await tool.execute("tool_call_1", params, undefined, undefined, {} as never);
+  return result.details.proposal as PlanningMutationProposal;
+}
+
+function getCreateWorkItemIds(proposal: PlanningMutationProposal): string[] {
+  return proposal.mutations
+    .filter((mutation) => mutation.type === "create_work_item")
+    .map((mutation) => mutation.entity_id ?? "");
+}
+
+function getEdge(
+  proposal: PlanningMutationProposal,
+  rel: "is_part_of" | "depends_on",
+): { from_id: string; to_id: string } {
+  const mutation = proposal.mutations.find((candidate) => candidate.type === "create_edge" && candidate.payload?.rel === rel);
+  expect(mutation).toBeDefined();
+  return {
+    from_id: String(mutation?.payload?.from_id),
+    to_id: String(mutation?.payload?.to_id),
+  };
+}
+
+describe("PlanningService github_create_issue staging", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("canonicalizes staged issue-backed IDs to the actual GitHub issue number", async () => {
+    const { tool } = makePlanningService([
+      {
+        repo: "fusupo/escapement-studio",
+        number: 83,
+        url: "https://github.com/fusupo/escapement-studio/issues/83",
+        title: "Epic",
+      },
+    ]);
+
+    const proposal = await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Epic",
+      work_item_id: "studio-82",
+    });
+
+    expect(getCreateWorkItemIds(proposal)).toEqual(["studio-83"]);
+    expect(proposal.mutations[0].payload?.id).toBe("studio-83");
+    expect(proposal.mutations[0].payload?.issue_number).toBe(83);
+    expect(JSON.stringify(proposal)).not.toContain("studio-82");
+  });
+
+  it("rewrites epic-child parent references from placeholder IDs to the final canonical parent ID", async () => {
+    const { tool } = makePlanningService([
+      {
+        repo: "fusupo/escapement-studio",
+        number: 83,
+        url: "https://github.com/fusupo/escapement-studio/issues/83",
+        title: "Epic",
+      },
+      {
+        repo: "fusupo/escapement-studio",
+        number: 84,
+        url: "https://github.com/fusupo/escapement-studio/issues/84",
+        title: "Child",
+      },
+    ]);
+
+    await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Epic",
+      work_item_id: "studio-82",
+    });
+
+    const proposal = await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Child",
+      work_item_id: "studio-83",
+      parent_id: "studio-82",
+    });
+
+    expect(getCreateWorkItemIds(proposal)).toEqual(["studio-83", "studio-84"]);
+    expect(getEdge(proposal, "is_part_of")).toEqual({
+      from_id: "studio-84",
+      to_id: "studio-83",
+    });
+    expect(JSON.stringify(proposal)).not.toContain('"studio-82"');
+  });
+
+  it("rewrites depends_on references to the final canonical ID in grouped issue flows", async () => {
+    const { tool } = makePlanningService([
+      {
+        repo: "fusupo/escapement-studio",
+        number: 91,
+        url: "https://github.com/fusupo/escapement-studio/issues/91",
+        title: "Dependency",
+      },
+      {
+        repo: "fusupo/escapement-studio",
+        number: 92,
+        url: "https://github.com/fusupo/escapement-studio/issues/92",
+        title: "Blocked issue",
+      },
+    ]);
+
+    await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Dependency",
+      work_item_id: "studio-90",
+    });
+
+    const proposal = await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Blocked issue",
+      work_item_id: "studio-91",
+      depends_on_ids: ["studio-90"],
+    });
+
+    expect(getEdge(proposal, "depends_on")).toEqual({
+      from_id: "studio-92",
+      to_id: "studio-91",
+    });
+    expect(JSON.stringify(proposal)).not.toContain('"studio-90"');
+  });
+
+  it("rewrites previously accumulated child references when a later issue creation resolves the placeholder parent ID", async () => {
+    const { tool } = makePlanningService([
+      {
+        repo: "fusupo/escapement-studio",
+        number: 84,
+        url: "https://github.com/fusupo/escapement-studio/issues/84",
+        title: "Child",
+      },
+      {
+        repo: "fusupo/escapement-studio",
+        number: 83,
+        url: "https://github.com/fusupo/escapement-studio/issues/83",
+        title: "Epic",
+      },
+    ]);
+
+    await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Child",
+      work_item_id: "studio-83",
+      parent_id: "studio-82",
+    });
+
+    const proposal = await executeCreateIssue(tool, {
+      repo: "fusupo/escapement-studio",
+      title: "Epic",
+      work_item_id: "studio-82",
+    });
+
+    expect(getCreateWorkItemIds(proposal)).toEqual(["studio-84", "studio-83"]);
+    expect(getEdge(proposal, "is_part_of")).toEqual({
+      from_id: "studio-84",
+      to_id: "studio-83",
+    });
+    expect(JSON.stringify(proposal)).not.toContain('"studio-82"');
+  });
+});

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -61,6 +61,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private readonly proposals = new Map<string, PlanningMutationProposal>();
   private readonly memoryChanges = new Map<string, PlanningMemoryChange>();
   private readonly githubSyncs = new Map<string, GitHubSyncProposal>();
+  private readonly issueIdAliases = new Map<string, string>();
 
   private session?: AgentSession;
   private sessionPromise?: Promise<AgentSession>;
@@ -323,6 +324,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private handleSessionEvent(event: AgentSessionEvent) {
     if (event.type === "turn_start") {
       this.currentTurnId = `turn_${String(++this.turnCounter).padStart(4, "0")}`;
+      this.issueIdAliases.clear();
     }
 
     if (!this.isStreamableEvent(event.type)) {
@@ -347,6 +349,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
     if (event.type === "turn_end") {
       this.currentTurnId = null;
+      this.issueIdAliases.clear();
     }
   }
 
@@ -629,8 +632,15 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           labels: params.labels,
         });
 
+        const requestedWorkItemId = params.work_item_id?.trim();
         const workItemId = deriveIssueWorkItemId(created.number);
+        this.rememberIssueIdAlias(requestedWorkItemId, workItemId);
+
         const groupId = `issue-${created.number}`;
+        const parentId = this.resolveIssueIdAlias(params.parent_id);
+        const dependsOnIds = params.depends_on_ids
+          ?.map((depId) => this.resolveIssueIdAlias(depId))
+          .filter((depId): depId is string => Boolean(depId));
 
         const mutations: ProposeMutationsToolInput["mutations"] = [
           {
@@ -652,33 +662,31 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           },
         ];
 
-        if (params.parent_id?.trim()) {
+        if (parentId) {
           mutations.push({
             type: "create_edge",
             group_id: groupId,
             payload: {
               from_id: workItemId,
               rel: "is_part_of",
-              to_id: params.parent_id.trim(),
+              to_id: parentId,
             },
-            rationale: `Attach ${workItemId} under parent ${params.parent_id.trim()}.`,
+            rationale: `Attach ${workItemId} under parent ${parentId}.`,
           });
         }
 
-        if (params.depends_on_ids) {
-          for (const depId of params.depends_on_ids) {
-            if (depId?.trim()) {
-              mutations.push({
-                type: "create_edge",
-                group_id: groupId,
-                payload: {
-                  from_id: workItemId,
-                  rel: "depends_on",
-                  to_id: depId.trim(),
-                },
-                rationale: `${workItemId} depends on ${depId.trim()}.`,
-              });
-            }
+        if (dependsOnIds) {
+          for (const depId of dependsOnIds) {
+            mutations.push({
+              type: "create_edge",
+              group_id: groupId,
+              payload: {
+                from_id: workItemId,
+                rel: "depends_on",
+                to_id: depId,
+              },
+              rationale: `${workItemId} depends on ${depId}.`,
+            });
           }
         }
 
@@ -699,6 +707,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
             mutations,
           });
         }
+
+        proposal = this.rewriteProposalIssueAliases(proposal);
 
         this.proposals.set(proposal.proposal_id, proposal);
         this.activeProposalId = proposal.proposal_id;
@@ -1112,6 +1122,73 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       ...existing,
       summary: `${existing.summary} ${summaryAppendix}`,
       mutations: [...existing.mutations, ...normalized],
+    };
+  }
+
+  private rememberIssueIdAlias(requestedId: string | null | undefined, finalId: string) {
+    const placeholderId = requestedId?.trim();
+    if (!placeholderId || placeholderId === finalId) {
+      return;
+    }
+    this.issueIdAliases.set(placeholderId, this.resolveIssueIdAlias(finalId));
+  }
+
+  private resolveIssueIdAlias(id: string | null | undefined): string {
+    const trimmed = id?.trim();
+    if (!trimmed) {
+      return "";
+    }
+
+    let resolved = trimmed;
+    const seen = new Set<string>();
+
+    while (this.issueIdAliases.has(resolved) && !seen.has(resolved)) {
+      seen.add(resolved);
+      resolved = this.issueIdAliases.get(resolved) ?? resolved;
+    }
+
+    return resolved;
+  }
+
+  private rewriteProposalIssueAliases(proposal: PlanningMutationProposal): PlanningMutationProposal {
+    return {
+      ...proposal,
+      mutations: proposal.mutations.map((mutation) => this.rewriteProposalMutationIssueAliases(mutation)),
+    };
+  }
+
+  private rewriteProposalMutationIssueAliases(
+    mutation: PlanningMutationProposalMutation,
+  ): PlanningMutationProposalMutation {
+    const payload = mutation.payload && typeof mutation.payload === "object"
+      ? { ...mutation.payload }
+      : undefined;
+
+    const entityId = mutation.entity_id ? this.resolveIssueIdAlias(mutation.entity_id) : mutation.entity_id;
+
+    if (mutation.type === "create_work_item" || mutation.type === "update_work_item") {
+      if (typeof payload?.id === "string") {
+        payload.id = this.resolveIssueIdAlias(payload.id);
+      }
+    }
+
+    if (mutation.type === "create_edge") {
+      if (typeof payload?.from_id === "string") {
+        payload.from_id = this.resolveIssueIdAlias(payload.from_id);
+      }
+      if (typeof payload?.to_id === "string") {
+        payload.to_id = this.resolveIssueIdAlias(payload.to_id);
+      }
+    }
+
+    const rewrittenEntityId = mutation.type === "create_edge" && payload?.from_id && payload?.rel && payload?.to_id
+      ? `${String(payload.from_id)}:${String(payload.rel)}:${String(payload.to_id)}`
+      : entityId;
+
+    return {
+      ...mutation,
+      entity_id: rewrittenEntityId,
+      payload,
     };
   }
 

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -632,14 +632,16 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           labels: params.labels,
         });
 
+        const existingProposal = this.getActiveProposalForAccumulation();
+        const stagedWorkItemIds = this.getStagedWorkItemIds(existingProposal);
         const requestedWorkItemId = params.work_item_id?.trim();
         const workItemId = deriveIssueWorkItemId(created.number);
         this.rememberIssueIdAlias(requestedWorkItemId, workItemId);
 
         const groupId = `issue-${created.number}`;
-        const parentId = this.resolveIssueIdAlias(params.parent_id);
+        const parentId = this.resolveIssueIdAlias(params.parent_id, stagedWorkItemIds);
         const dependsOnIds = params.depends_on_ids
-          ?.map((depId) => this.resolveIssueIdAlias(depId))
+          ?.map((depId) => this.resolveIssueIdAlias(depId, stagedWorkItemIds))
           .filter((depId): depId is string => Boolean(depId));
 
         const mutations: ProposeMutationsToolInput["mutations"] = [
@@ -692,7 +694,6 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
         // Accumulate into existing active proposal from the same turn,
         // so multi-issue creation produces one reviewable proposal.
-        const existingProposal = this.getActiveProposalForAccumulation();
         let proposal: PlanningMutationProposal;
 
         if (existingProposal) {
@@ -1130,13 +1131,16 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     if (!placeholderId || placeholderId === finalId) {
       return;
     }
-    this.issueIdAliases.set(placeholderId, this.resolveIssueIdAlias(finalId));
+    this.issueIdAliases.set(placeholderId, finalId);
   }
 
-  private resolveIssueIdAlias(id: string | null | undefined): string {
+  private resolveIssueIdAlias(id: string | null | undefined, stopIds: ReadonlySet<string> = new Set()): string {
     const trimmed = id?.trim();
     if (!trimmed) {
       return "";
+    }
+    if (stopIds.has(trimmed)) {
+      return trimmed;
     }
 
     let resolved = trimmed;
@@ -1144,40 +1148,67 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
     while (this.issueIdAliases.has(resolved) && !seen.has(resolved)) {
       seen.add(resolved);
-      resolved = this.issueIdAliases.get(resolved) ?? resolved;
+      const next = this.issueIdAliases.get(resolved) ?? resolved;
+      resolved = next;
+      if (stopIds.has(resolved)) {
+        break;
+      }
     }
 
     return resolved;
   }
 
+  private getStagedWorkItemIds(proposal: PlanningMutationProposal | null | undefined): Set<string> {
+    const ids = new Set<string>();
+    if (!proposal) {
+      return ids;
+    }
+
+    for (const mutation of proposal.mutations) {
+      if (mutation.type !== "create_work_item") {
+        continue;
+      }
+      if (mutation.entity_id) {
+        ids.add(mutation.entity_id);
+      }
+      if (typeof mutation.payload?.id === "string") {
+        ids.add(mutation.payload.id);
+      }
+    }
+
+    return ids;
+  }
+
   private rewriteProposalIssueAliases(proposal: PlanningMutationProposal): PlanningMutationProposal {
+    const stagedWorkItemIds = this.getStagedWorkItemIds(proposal);
     return {
       ...proposal,
-      mutations: proposal.mutations.map((mutation) => this.rewriteProposalMutationIssueAliases(mutation)),
+      mutations: proposal.mutations.map((mutation) => this.rewriteProposalMutationIssueAliases(mutation, stagedWorkItemIds)),
     };
   }
 
   private rewriteProposalMutationIssueAliases(
     mutation: PlanningMutationProposalMutation,
+    stagedWorkItemIds: ReadonlySet<string>,
   ): PlanningMutationProposalMutation {
     const payload = mutation.payload && typeof mutation.payload === "object"
       ? { ...mutation.payload }
       : undefined;
 
-    const entityId = mutation.entity_id ? this.resolveIssueIdAlias(mutation.entity_id) : mutation.entity_id;
+    const entityId = mutation.entity_id ? this.resolveIssueIdAlias(mutation.entity_id, stagedWorkItemIds) : mutation.entity_id;
 
     if (mutation.type === "create_work_item" || mutation.type === "update_work_item") {
       if (typeof payload?.id === "string") {
-        payload.id = this.resolveIssueIdAlias(payload.id);
+        payload.id = this.resolveIssueIdAlias(payload.id, stagedWorkItemIds);
       }
     }
 
     if (mutation.type === "create_edge") {
       if (typeof payload?.from_id === "string") {
-        payload.from_id = this.resolveIssueIdAlias(payload.from_id);
+        payload.from_id = this.resolveIssueIdAlias(payload.from_id, stagedWorkItemIds);
       }
       if (typeof payload?.to_id === "string") {
-        payload.to_id = this.resolveIssueIdAlias(payload.to_id);
+        payload.to_id = this.resolveIssueIdAlias(payload.to_id, stagedWorkItemIds);
       }
     }
 

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -8,14 +8,15 @@ import { getConfig } from "../../config.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { GraphWriterService } from "../graph/graph-writer.service.js";
-import type {
-  CreateEdgeDto,
-  CreateWorkItemDto,
-  DeleteEdgeMutation,
-  DeleteWorkItemMutation,
-  EdgeRel,
-  GraphMutation,
-  UpdateWorkItemDto,
+import {
+  deriveIssueWorkItemId,
+  type CreateEdgeDto,
+  type CreateWorkItemDto,
+  type DeleteEdgeMutation,
+  type DeleteWorkItemMutation,
+  type EdgeRel,
+  type GraphMutation,
+  type UpdateWorkItemDto,
 } from "../graph/types.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
@@ -628,7 +629,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           labels: params.labels,
         });
 
-        const workItemId = params.work_item_id?.trim() || `studio-${created.number}`;
+        const workItemId = deriveIssueWorkItemId(created.number);
         const groupId = `issue-${created.number}`;
 
         const mutations: ProposeMutationsToolInput["mutations"] = [


### PR DESCRIPTION
## Summary
Done.

### What I changed

#### `src/modules/planning/planning.service.ts`
- `github_create_issue` now always derives the staged issue-backed work item ID from the actual GitHub issue number via `deriveIssueWorkItemId(created.number)`.
- Added turn-scoped placeholder → final ID alias handling for grouped `github_create_issue` flows.
- Rewrites `parent_id` and `depends_on_ids` to final canonical IDs before staging edges.
- Rewrites accumulated proposal references so earlier staged child/dependency edges get corrected once a later issue creation resolves a placeholder parent ID.
- Made alias resolution stop at already staged work item IDs so real parent/dependency IDs are not accidentally rewritten into later child IDs.

#### `src/modules/planning/__tests__/planning.service.test.ts`
Added regression coverage for:
- mismatched requested `work_item_id` vs returned GitHub issue number
- epic/child flows where the child references the parent placeholder ID
- grouped dependency flows using placeholder dependency IDs
- retroactive rewrite of an earlier accumulated child reference once the parent’s final ID becomes known

### Commits created
- `ec51944` — `fix(planning): canonicalize staged github issue ids`
- `9add7d4` — `fix(planning): rewrite grouped issue references`
- `9e1ebff` — `fix(planning): preserve staged ids during alias rewrites`

### Tests / checks run

#### Passed
- `npm run check`
- `npx vitest run src/modules/planning/__tests__/planning.service.test.ts`
- `npm run build:web`

#### Blocked / not fully passing
- `npm test`
  - Fails in pre-existing graph tests because this worktree is missing `better-sqlite3` native bindings:
  - `Could not locate the bindings file`
  - failure originates from existing `src/modules/graph/__tests__/graph-writer.service.test.ts`

### Remaining blockers / follow-up
- Only blocker is the environment-level `better-sqlite3` binding issue preventing the full test suite from passing in this worktree.
- No code follow-up items identified for this issue’s scope.

actual_files synced: 1 file(s).

## Context
- Work item: studio-90
- Issue: https://github.com/fusupo/escapement-studio/issues/90
- Base branch: develop
- Head branch: studio-90-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775680199289
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-90-branch
- Scope hint: Fix auto-staged graph proposals so issue-backed IDs are rewritten to the actual GitHub issue number returned by GitHub before proposal staging and child references are generated.

## Changed files
- `SCRATCHPAD.md`