### PR TITLE
feat: execution panel three-column layout with unified event stream

### DIFF
--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -47,12 +47,11 @@ export class ExecutionService {
   private readonly worktreeRoot = join(this.artifactRoot, "worktrees");
   private readonly recentRuns: ExecutionRunRecord[] = [];
   private readonly recentRunLimit = 16;
-  private readonly activityLogLimit = 50;
+  // No cap on activity log — full history preserved in status.json
   private eventCounter = 0;
   /** Active agent sessions keyed by run_id — kept alive while run is active */
   private readonly activeSessions = new Map<string, import("@mariozechner/pi-coding-agent").AgentSession>();
-  /** Chat history per run (user follow-ups + assistant replies) */
-  private readonly chatHistories = new Map<string, RunChatMessage[]>();
+  // Chat history derived from activity_log (agent_message + user_message entries)
   /** Disambiguation gate resolvers — calling the stored function unblocks the coding phase */
   private readonly disambiguationGates = new Map<string, { resolve: (additionalContext?: string) => void }>();
   /** Last-emitted checklist snapshots per run — used for dedup */
@@ -678,10 +677,15 @@ export class ExecutionService {
   }
 
   getRunChatHistory(runId: string): RunChatHistory {
-    return {
-      run_id: runId,
-      messages: this.chatHistories.get(runId) ?? [],
-    };
+    const run = this.getRun(runId);
+    const messages: RunChatMessage[] = (run?.activity_log ?? [])
+      .filter((e) => e.kind === "agent_message" || e.kind === "user_message")
+      .map((e) => ({
+        timestamp: e.timestamp,
+        role: e.kind === "agent_message" ? "assistant" as const : "user" as const,
+        text: e.message,
+      }));
+    return { run_id: runId, messages };
   }
 
   getRunChecklist(runId: string): ExecutionChecklistSnapshot {
@@ -734,8 +738,8 @@ export class ExecutionService {
       throw new BadRequestException(`Unknown execution run: ${runId}`);
     }
 
-    // Record the user message in chat history
-    this.pushChatMessage(runId, { timestamp: this.now(), role: "user", text: message });
+    // Record the user message in the unified activity log
+    this.pushActivity(runId, "user_message", message);
 
     const session = this.activeSessions.get(runId);
 
@@ -748,7 +752,6 @@ export class ExecutionService {
         } else {
           await session.followUp(message);
         }
-        this.pushActivity(runId, "follow_up", `Follow-up (${delivery}): ${message.length > 120 ? message.slice(0, 117) + "..." : message}`);
         this.appendEvent(run, { type: "follow_up_sent", delivery, message_length: message.length });
         return { accepted: true, run_id: runId, delivery, message };
       } catch (error) {
@@ -819,7 +822,7 @@ export class ExecutionService {
     }
 
     const assistantText = session.getLastAssistantText()?.trim() ?? "Follow-up turn completed without a summary.";
-    this.pushChatMessage(run.run_id, { timestamp: this.now(), role: "assistant", text: assistantText });
+    this.pushActivity(run.run_id, "agent_message", assistantText);
 
     const changedFiles = this.listChangedFiles(run.worktree_path);
     const actualFilesSync = this.syncActualFiles(run.work_item_id, changedFiles);
@@ -839,12 +842,7 @@ export class ExecutionService {
     }
   }
 
-  private pushChatMessage(runId: string, message: RunChatMessage) {
-    if (!this.chatHistories.has(runId)) {
-      this.chatHistories.set(runId, []);
-    }
-    this.chatHistories.get(runId)!.push(message);
-  }
+  // Chat messages are now stored as agent_message/user_message entries in the activity_log
 
   private handleSessionEvent(runId: string, event: AgentSessionEvent) {
     const run = this.getRun(runId);
@@ -873,8 +871,7 @@ export class ExecutionService {
       const text = this.extractTextFromMessage(message);
       this.appendEvent(run, { type: event.type, text: text?.slice(0, 2000) ?? null });
       if (text) {
-        this.pushChatMessage(runId, { timestamp: this.now(), role: "assistant", text });
-        this.pushActivity(runId, "info", text.length > 200 ? text.slice(0, 200) + "…" : text);
+        this.pushActivity(runId, "agent_message", text);
         this.emitRun("execution_status", run);
       }
       return;
@@ -972,9 +969,6 @@ export class ExecutionService {
     }
     const entry: ActivityLogEntry = { timestamp: this.now(), kind, message, ...(detail ? { detail } : {}) };
     run.activity_log.push(entry);
-    if (run.activity_log.length > this.activityLogLimit) {
-      run.activity_log = run.activity_log.slice(-this.activityLogLimit);
-    }
   }
 
   private evaluateSafety(branch: string, worktreePath: string, baseRef = getDefaultWorkingBranch(null)): ExecutionSafetyCheck[] {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -1,6 +1,6 @@
 export type ExecutionRunStatus = "queued" | "blocked" | "preparing" | "disambiguating" | "running" | "completed" | "error";
 export type ExecutionSafetyStatus = "pass" | "warn" | "fail";
-export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info" | "follow_up";
+export type ActivityLogEntryKind = "status_change" | "tool_start" | "tool_end" | "turn_start" | "turn_end" | "reasoning" | "error" | "info" | "follow_up" | "agent_message" | "user_message";
 
 export interface ActivityLogEntry {
   timestamp: string;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -160,6 +160,30 @@ a:hover {
   color: var(--green);
 }
 
+.status-pill.info {
+  background: rgba(37, 99, 235, 0.14);
+  border-color: rgba(37, 99, 235, 0.32);
+  color: #93c5fd;
+}
+
+.status-pill.warn {
+  background: rgba(210, 153, 34, 0.12);
+  border-color: rgba(210, 153, 34, 0.3);
+  color: #fbbf24;
+}
+
+.status-pill.danger {
+  background: rgba(248, 81, 73, 0.12);
+  border-color: rgba(248, 81, 73, 0.32);
+  color: #fca5a5;
+}
+
+.status-pill.disambiguating {
+  background: rgba(163, 113, 247, 0.14);
+  border-color: rgba(163, 113, 247, 0.32);
+  color: #d8b4fe;
+}
+
 /* ── Filter toolbar ── */
 .toolbar {
   display: grid;
@@ -844,11 +868,12 @@ a:hover {
 
 /* ── Execution panel ── */
 .execution-panel {
-  display: grid;
-  gap: 10px;
-  padding: 8px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 6px 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .execution-header {

--- a/web/src/components/ExecutionContextSidebar.svelte
+++ b/web/src/components/ExecutionContextSidebar.svelte
@@ -1,0 +1,218 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let kind = null;
+  export let run = null;
+  export let dispatchNode = null;
+  export let pullRequest = null;
+  export let openingPr = false;
+
+  const dispatch = createEventDispatcher();
+
+  function formatSafetySummary(checks = []) {
+    const failed = checks.filter((check) => check.status === "fail").length;
+    const warned = checks.filter((check) => check.status === "warn").length;
+    if (failed > 0) return `${failed} blocking`;
+    if (warned > 0) return `${warned} warning${warned === 1 ? "" : "s"}`;
+    return "All checks passed";
+  }
+
+  function statusTone(status) {
+    if (status === "completed") return "healthy";
+    if (["running", "preparing", "queued"].includes(status)) return "info";
+    if (status === "disambiguating") return "disambiguating";
+    if (status === "blocked") return "warn";
+    if (status === "error") return "danger";
+    return "";
+  }
+</script>
+
+<aside class="context-sidebar">
+  {#if kind === "run" && run}
+    <div class="sidebar-section">
+      <div class="sidebar-section-hdr">
+        <h3>CONTEXT</h3>
+        <span class="status-pill {statusTone(run.status)}">{run.status}</span>
+      </div>
+
+      <div class="sidebar-kv-list">
+        <div class="sidebar-kv"><span class="muted">Branch</span><code>{run.branch}</code></div>
+        <div class="sidebar-kv"><span class="muted">Base</span><code>{run.base_ref}</code></div>
+        <div class="sidebar-kv"><span class="muted">Worktree</span><code>{run.worktree_path}</code></div>
+        <div class="sidebar-kv"><span class="muted">Artifacts</span><code>{run.artifact_dir}</code></div>
+      </div>
+
+      <div class="sidebar-actions">
+        {#if run.issue_url}
+          <a class="sidebar-link" href={run.issue_url} target="_blank" rel="noreferrer">Issue</a>
+        {/if}
+        <button class="secondary small" on:click={() => dispatch("copybranch")}>Copy branch</button>
+        <button class="secondary small" on:click={() => dispatch("copyworktree")}>Copy worktree</button>
+      </div>
+    </div>
+
+    <div class="sidebar-section">
+      <div class="sidebar-section-hdr"><h3>PR</h3></div>
+      {#if pullRequest}
+        <a class="sidebar-link" href={pullRequest.url} target="_blank" rel="noreferrer">PR #{pullRequest.number}</a>
+      {:else if run.status === "completed"}
+        <button on:click={() => dispatch("openpr")} disabled={openingPr}>
+          {openingPr ? "Opening..." : "Open PR"}
+        </button>
+      {:else}
+        <p class="muted">Available after completion.</p>
+      {/if}
+
+      {#if run.changed_files?.length}
+        <div class="sidebar-file-list">
+          <div class="muted">Changed files</div>
+          <ul>{#each run.changed_files as path}<li>{path}</li>{/each}</ul>
+        </div>
+      {/if}
+    </div>
+
+    <div class="sidebar-section">
+      <div class="sidebar-section-hdr"><h3>CHECKS</h3></div>
+      <p class="muted">{formatSafetySummary(run.safety_checks || [])}</p>
+      {#if run.errors?.length}
+        <ul class="sidebar-error-list">
+          {#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}
+        </ul>
+      {:else}
+        <p class="muted">No errors.</p>
+      {/if}
+    </div>
+
+  {:else if kind === "dispatch" && dispatchNode}
+    <div class="sidebar-section">
+      <div class="sidebar-section-hdr">
+        <h3>CONTEXT</h3>
+        <span class="status-pill {dispatchNode.can_launch ? 'healthy' : 'warn'}">{dispatchNode.can_launch ? 'ready' : 'blocked'}</span>
+      </div>
+
+      <div class="sidebar-kv-list">
+        <div class="sidebar-kv"><span class="muted">Branch</span><code>{dispatchNode.branch}</code></div>
+        <div class="sidebar-kv"><span class="muted">Base</span><code>{dispatchNode.default_base_ref}</code></div>
+        <div class="sidebar-kv"><span class="muted">Worktree</span><code>{dispatchNode.worktree_path}</code></div>
+      </div>
+
+      <div class="sidebar-actions">
+        {#if dispatchNode.issue_url}
+          <a class="sidebar-link" href={dispatchNode.issue_url} target="_blank" rel="noreferrer">Issue</a>
+        {/if}
+        <button class="secondary small" on:click={() => dispatch("copybranch")}>Copy branch</button>
+        <button class="secondary small" on:click={() => dispatch("copyworktree")}>Copy worktree</button>
+        <button on:click={() => dispatch("launch")} disabled={!dispatchNode.can_launch}>
+          {dispatchNode.can_launch ? 'Launch' : 'Blocked'}
+        </button>
+      </div>
+    </div>
+
+    <div class="sidebar-section">
+      <div class="sidebar-section-hdr"><h3>SAFETY</h3></div>
+      <p class="muted">{formatSafetySummary(dispatchNode.safety_checks)}</p>
+      {#if dispatchNode.safety_checks?.length}
+        <ul class="sidebar-check-list">
+          {#each dispatchNode.safety_checks as check}
+            <li><strong>{check.code}</strong>: {check.message}</li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {:else}
+    <div class="sidebar-section sidebar-empty">
+      <p class="muted">Select a run or dispatch candidate.</p>
+    </div>
+  {/if}
+</aside>
+
+<style>
+  .context-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    align-content: start;
+    min-width: 0;
+    padding: 6px;
+  }
+
+  .sidebar-section {
+    display: grid;
+    gap: 6px;
+    padding: 8px;
+    background: var(--bg-surface, #13171f);
+    border-radius: var(--radius-sm, 3px);
+    font-size: 12px;
+  }
+
+  .sidebar-section-hdr {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .sidebar-section-hdr h3 {
+    margin: 0;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--text-secondary, #8b95a5);
+    letter-spacing: 0.08em;
+  }
+
+  .sidebar-kv-list {
+    display: grid;
+    gap: 4px;
+  }
+
+  .sidebar-kv {
+    display: grid;
+    gap: 1px;
+    font-size: 11px;
+  }
+
+  .sidebar-kv code {
+    overflow-wrap: anywhere;
+    font-size: 10.5px;
+  }
+
+  .sidebar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .sidebar-link {
+    font-size: 11px;
+    color: #58a6ff;
+    text-decoration: none;
+  }
+
+  .sidebar-link:hover { text-decoration: underline; }
+
+  .sidebar-file-list {
+    display: grid;
+    gap: 2px;
+    font-size: 11px;
+  }
+
+  .sidebar-file-list ul {
+    margin: 0;
+    padding-left: 14px;
+    font-size: 11px;
+  }
+
+  .sidebar-error-list,
+  .sidebar-check-list {
+    margin: 0;
+    padding-left: 14px;
+    font-size: 11px;
+  }
+
+  .sidebar-empty {
+    min-height: 6rem;
+    place-items: center;
+    display: grid;
+  }
+</style>

--- a/web/src/components/ExecutionDetailPane.svelte
+++ b/web/src/components/ExecutionDetailPane.svelte
@@ -1,0 +1,259 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let kind = null;
+  export let run = null;
+  export let dispatchNode = null;
+  export let pullRequest = null;
+  export let openingPr = false;
+  export let assumptions = [];
+  export let validationPolicy = null;
+
+  const dispatch = createEventDispatcher();
+
+  function statusTone(status) {
+    if (status === "completed") return "healthy";
+    if (["running", "preparing", "queued"].includes(status)) return "info";
+    if (status === "disambiguating") return "disambiguating";
+    if (status === "blocked") return "warn";
+    if (status === "error") return "danger";
+    return "";
+  }
+
+  function formatTimestamp(value) {
+    if (!value) return "";
+    try { return new Date(value).toLocaleString(); } catch { return ""; }
+  }
+
+  function formatSafetySummary(checks = []) {
+    const failed = checks.filter((c) => c.status === "fail").length;
+    const warned = checks.filter((c) => c.status === "warn").length;
+    if (failed > 0) return `${failed} blocking`;
+    if (warned > 0) return `${warned} warning${warned === 1 ? "" : "s"}`;
+    return "All passed";
+  }
+</script>
+
+<div class="detail-col">
+  {#if kind === "run" && run}
+    <!-- Context -->
+    <div class="detail-card">
+      <div class="detail-card-hdr">
+        <h3>CONTEXT</h3>
+        <span class="status-pill {statusTone(run.status)}">{run.status}</span>
+      </div>
+      <div class="detail-kv-list">
+        <div class="detail-kv"><span class="muted">Branch</span><code>{run.branch}</code></div>
+        <div class="detail-kv"><span class="muted">Base</span><code>{run.base_ref}</code></div>
+        <div class="detail-kv"><span class="muted">Worktree</span><code>{run.worktree_path}</code></div>
+        <div class="detail-kv"><span class="muted">Artifacts</span><code>{run.artifact_dir}</code></div>
+      </div>
+      <div class="detail-actions">
+        {#if run.issue_url}
+          <a class="detail-link" href={run.issue_url} target="_blank" rel="noreferrer">Issue</a>
+        {/if}
+        <button class="secondary small" on:click={() => dispatch("copybranch")}>Copy branch</button>
+        <button class="secondary small" on:click={() => dispatch("copyworktree")}>Copy worktree</button>
+      </div>
+    </div>
+
+    <!-- Timestamps -->
+    <div class="detail-card">
+      <div class="detail-card-hdr"><h3>TIMELINE</h3></div>
+      <div class="detail-kv-list">
+        <div class="detail-kv"><span class="muted">Created</span><span>{formatTimestamp(run.created_at)}</span></div>
+        <div class="detail-kv"><span class="muted">Updated</span><span>{formatTimestamp(run.updated_at)}</span></div>
+        {#if run.started_at}<div class="detail-kv"><span class="muted">Started</span><span>{formatTimestamp(run.started_at)}</span></div>{/if}
+        {#if run.completed_at}<div class="detail-kv"><span class="muted">Completed</span><span>{formatTimestamp(run.completed_at)}</span></div>{/if}
+      </div>
+    </div>
+
+    <!-- PR -->
+    <div class="detail-card">
+      <div class="detail-card-hdr"><h3>PR</h3></div>
+      {#if pullRequest}
+        <a class="detail-link" href={pullRequest.url} target="_blank" rel="noreferrer">PR #{pullRequest.number}</a>
+      {:else if run.status === "completed"}
+        <button on:click={() => dispatch("openpr")} disabled={openingPr}>
+          {openingPr ? "Opening..." : "Open PR"}
+        </button>
+      {:else}
+        <p class="muted">Available after completion.</p>
+      {/if}
+    </div>
+
+    <!-- Safety -->
+    <div class="detail-card">
+      <div class="detail-card-hdr"><h3>CHECKS</h3></div>
+      <p class="muted">{formatSafetySummary(run.safety_checks || [])}</p>
+      {#if run.errors?.length}
+        <ul class="detail-list">
+          {#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}
+        </ul>
+      {/if}
+    </div>
+
+  {:else if kind === "dispatch" && dispatchNode}
+    <!-- Context -->
+    <div class="detail-card">
+      <div class="detail-card-hdr">
+        <h3>CONTEXT</h3>
+        <span class="status-pill {dispatchNode.can_launch ? 'healthy' : 'warn'}">{dispatchNode.can_launch ? 'ready' : 'blocked'}</span>
+      </div>
+      <div class="detail-kv-list">
+        <div class="detail-kv"><span class="muted">Repo</span><span>{dispatchNode.repo}</span></div>
+        <div class="detail-kv"><span class="muted">Group</span><span>{dispatchNode.group_id}</span></div>
+        <div class="detail-kv"><span class="muted">Branch</span><code>{dispatchNode.branch}</code></div>
+        <div class="detail-kv"><span class="muted">Base</span><code>{dispatchNode.default_base_ref}</code></div>
+        <div class="detail-kv"><span class="muted">Worktree</span><code>{dispatchNode.worktree_path}</code></div>
+      </div>
+      <div class="detail-actions">
+        {#if dispatchNode.issue_url}
+          <a class="detail-link" href={dispatchNode.issue_url} target="_blank" rel="noreferrer">Issue</a>
+        {/if}
+        <button class="secondary small" on:click={() => dispatch("copybranch")}>Copy branch</button>
+        <button class="secondary small" on:click={() => dispatch("copyworktree")}>Copy worktree</button>
+        <button on:click={() => dispatch("launch")} disabled={!dispatchNode.can_launch}>
+          {dispatchNode.can_launch ? 'Launch' : 'Blocked'}
+        </button>
+      </div>
+    </div>
+
+    <!-- Scope -->
+    {#if dispatchNode.scope_hint}
+      <div class="detail-card">
+        <div class="detail-card-hdr"><h3>SCOPE</h3></div>
+        <p>{dispatchNode.scope_hint}</p>
+        <div class="scope-lists">
+          <div>
+            <span class="muted">Owned</span>
+            <ul class="detail-list">{#each dispatchNode.files_owned as p}<li>{p}</li>{:else}<li class="muted">(none)</li>{/each}</ul>
+          </div>
+          <div>
+            <span class="muted">Shared</span>
+            <ul class="detail-list">{#each dispatchNode.files_shared as s}<li><code>{s.path}</code> {s.assessment}</li>{:else}<li class="muted">(none)</li>{/each}</ul>
+          </div>
+          <div>
+            <span class="muted">Forbidden</span>
+            <ul class="detail-list">{#each dispatchNode.files_forbidden as p}<li>{p}</li>{:else}<li class="muted">(none)</li>{/each}</ul>
+          </div>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Safety -->
+    <div class="detail-card">
+      <div class="detail-card-hdr"><h3>SAFETY</h3></div>
+      {#each dispatchNode.safety_checks as check}
+        <div class="check-row {check.status}">
+          <strong>{check.code}</strong>: {check.message}
+        </div>
+      {/each}
+    </div>
+
+    <!-- Assumptions -->
+    {#if assumptions?.length}
+      <div class="detail-card">
+        <div class="detail-card-hdr"><h3>ASSUMPTIONS</h3></div>
+        <ul class="detail-list">{#each assumptions as a}<li>{a}</li>{/each}</ul>
+        {#if validationPolicy?.max_concurrent_node_heavy_tasks}
+          <p class="muted">Concurrency cap: {validationPolicy.max_concurrent_node_heavy_tasks}</p>
+        {/if}
+      </div>
+    {/if}
+
+  {:else}
+    <div class="detail-empty muted">Select a run or dispatch candidate.</div>
+  {/if}
+</div>
+
+<style>
+  .detail-col {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 6px;
+  }
+
+  .detail-card {
+    display: grid;
+    gap: 6px;
+    padding: 8px;
+    background: var(--bg-surface, #13171f);
+    border-radius: var(--radius-sm, 3px);
+    font-size: 12px;
+  }
+
+  .detail-card-hdr {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .detail-card-hdr h3 {
+    margin: 0;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--text-secondary, #8b95a5);
+    letter-spacing: 0.08em;
+  }
+
+  .detail-kv-list { display: grid; gap: 4px; }
+
+  .detail-kv {
+    display: grid;
+    gap: 1px;
+    font-size: 11px;
+  }
+
+  .detail-kv code {
+    overflow-wrap: anywhere;
+    font-size: 10.5px;
+  }
+
+  .detail-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .detail-link {
+    font-size: 11px;
+    color: #58a6ff;
+    text-decoration: none;
+  }
+
+  .detail-link:hover { text-decoration: underline; }
+
+  .detail-list {
+    margin: 0;
+    padding-left: 14px;
+    font-size: 11px;
+  }
+
+  .scope-lists {
+    display: grid;
+    gap: 6px;
+    font-size: 11px;
+  }
+
+  .scope-lists code { overflow-wrap: anywhere; font-size: 10.5px; }
+
+  .check-row {
+    font-size: 11px;
+    padding: 2px 0;
+  }
+
+  .check-row.fail strong { color: var(--red, #f85149); }
+  .check-row.warn strong { color: var(--yellow, #d29922); }
+  .check-row.pass strong { color: var(--green, #3fb950); }
+
+  .detail-empty {
+    padding: 16px 8px;
+    display: grid;
+    place-items: center;
+    min-height: 6rem;
+  }
+</style>

--- a/web/src/components/ExecutionDetailPane.svelte
+++ b/web/src/components/ExecutionDetailPane.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher } from "svelte";
+  import { renderMarkdown } from "../lib/markdown.js";
 
   export let kind = null;
   export let run = null;
@@ -8,6 +9,8 @@
   export let openingPr = false;
   export let assumptions = [];
   export let validationPolicy = null;
+  export let scratchpadContent = undefined;
+  export let scratchpadLoading = false;
 
   const dispatch = createEventDispatcher();
 
@@ -80,6 +83,24 @@
       {:else}
         <p class="muted">Available after completion.</p>
       {/if}
+    </div>
+
+    <!-- Scratchpad -->
+    <div class="detail-card">
+      <details class="detail-inline-expandable" on:toggle={(e) => e.currentTarget.open && dispatch("scratchpadtoggle")}>
+        <summary><h3>SCRATCHPAD</h3></summary>
+        <div class="scratchpad-body">
+          {#if scratchpadLoading}
+            <p class="muted">Loading...</p>
+          {:else if scratchpadContent}
+            <div class="scratchpad-rendered">{@html renderMarkdown(scratchpadContent)}</div>
+          {:else if scratchpadContent === null}
+            <p class="muted">No scratchpad available.</p>
+          {:else}
+            <p class="muted">Open to load.</p>
+          {/if}
+        </div>
+      </details>
     </div>
 
     <!-- Safety -->
@@ -249,6 +270,35 @@
   .check-row.fail strong { color: var(--red, #f85149); }
   .check-row.warn strong { color: var(--yellow, #d29922); }
   .check-row.pass strong { color: var(--green, #3fb950); }
+
+  .detail-inline-expandable summary {
+    cursor: pointer;
+    list-style: disclosure-closed;
+  }
+
+  .detail-inline-expandable[open] summary {
+    list-style: disclosure-open;
+  }
+
+  .detail-inline-expandable summary h3 {
+    display: inline;
+    margin: 0;
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--text-secondary, #8b95a5);
+    letter-spacing: 0.08em;
+  }
+
+  .scratchpad-body { margin-top: 6px; font-size: 12px; }
+
+  .scratchpad-rendered :global(h1),
+  .scratchpad-rendered :global(h2),
+  .scratchpad-rendered :global(h3) { margin: 6px 0 3px; }
+
+  .scratchpad-rendered :global(ul),
+  .scratchpad-rendered :global(ol) { padding-left: 16px; }
+
+  .scratchpad-rendered :global(code) { overflow-wrap: anywhere; }
 
   .detail-empty {
     padding: 16px 8px;

--- a/web/src/components/ExecutionDispatchList.svelte
+++ b/web/src/components/ExecutionDispatchList.svelte
@@ -1,0 +1,93 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import ExecutionDispatchListItem from "./ExecutionDispatchListItem.svelte";
+
+  export let groups = [];
+  export let selectedDispatchId = null;
+  export let launchingIds = [];
+
+  const dispatch = createEventDispatcher();
+</script>
+
+<section class="dispatch-list-section">
+  <div class="nav-section-header">
+    <h3>DISPATCH</h3>
+    <span class="nav-count">{groups.reduce((sum, group) => sum + group.nodes.length, 0)}</span>
+  </div>
+
+  {#if groups.length === 0}
+    <div class="nav-empty muted">No dispatchable groups.</div>
+  {:else}
+    {#each groups as group}
+      <div class="dispatch-group">
+        <div class="dispatch-group-label">
+          <strong>{group.group_id}</strong>
+          <span class="muted">{group.repo} · {group.nodes.length}</span>
+        </div>
+        <div class="dispatch-group-items">
+          {#each group.nodes as node}
+            <ExecutionDispatchListItem
+              {node}
+              selected={node.id === selectedDispatchId}
+              launching={launchingIds.includes(node.id)}
+              on:select={(event) => dispatch("select", event.detail)}
+              on:launch={(event) => dispatch("launch", event.detail)}
+            />
+          {/each}
+        </div>
+      </div>
+    {/each}
+  {/if}
+</section>
+
+<style>
+  .dispatch-list-section {
+    display: grid;
+    gap: 4px;
+    align-content: start;
+  }
+
+  .nav-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 2px;
+  }
+
+  .nav-section-header h3 {
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--text-secondary, #8b95a5);
+    letter-spacing: 0.08em;
+    margin: 0;
+  }
+
+  .nav-count {
+    font-size: 10.5px;
+    color: var(--text-muted, #566070);
+  }
+
+  .dispatch-group {
+    display: grid;
+    gap: 2px;
+  }
+
+  .dispatch-group-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 6px;
+    font-size: 11px;
+  }
+
+  .dispatch-group-items {
+    display: grid;
+    gap: 2px;
+  }
+
+  .nav-empty {
+    padding: 8px;
+    font-size: 11px;
+  }
+</style>

--- a/web/src/components/ExecutionDispatchListItem.svelte
+++ b/web/src/components/ExecutionDispatchListItem.svelte
@@ -1,0 +1,115 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let node;
+  export let selected = false;
+  export let launching = false;
+
+  const dispatch = createEventDispatcher();
+
+  function safetySummary(checks = []) {
+    const failed = checks.filter((check) => check.status === "fail").length;
+    const warned = checks.filter((check) => check.status === "warn").length;
+    if (failed > 0) return `${failed} blocking`;
+    if (warned > 0) return `${warned} warn`;
+    return "ready";
+  }
+</script>
+
+<div
+  class:selected
+  class="dispatch-item"
+  on:click={() => dispatch("select", { id: node.id })}
+  on:keydown={(event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      dispatch("select", { id: node.id });
+    }
+  }}
+  role="button"
+  tabindex="0"
+>
+  <div class="dispatch-item-top">
+    <strong class="dispatch-item-id">{node.id}</strong>
+    <span class="status-pill {node.can_launch ? 'healthy' : 'warn'}">{node.can_launch ? 'ready' : 'blocked'}</span>
+  </div>
+  <span class="dispatch-item-name muted">{node.name}</span>
+  <div class="dispatch-item-meta">
+    <code>{node.branch}</code>
+    <span>{safetySummary(node.safety_checks)}</span>
+  </div>
+  <div class="dispatch-item-actions">
+    <button
+      class="small"
+      on:click|stopPropagation={() => dispatch("launch", { id: node.id })}
+      disabled={!node.can_launch || launching}
+    >
+      {launching ? 'Launching...' : node.can_launch ? 'Launch' : 'Blocked'}
+    </button>
+  </div>
+</div>
+
+<style>
+  .dispatch-item {
+    display: grid;
+    gap: 2px;
+    padding: 5px 6px;
+    border-radius: var(--radius-sm, 3px);
+    border: 1px solid transparent;
+    background: transparent;
+    cursor: pointer;
+    font-size: 12px;
+  }
+
+  .dispatch-item:hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: var(--border, #2b3245);
+  }
+
+  .dispatch-item.selected {
+    background: var(--accent-muted, rgba(37, 99, 235, 0.25));
+    border-color: rgba(37, 99, 235, 0.5);
+  }
+
+  .dispatch-item-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .dispatch-item-id {
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dispatch-item-name {
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .dispatch-item-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    font-size: 10.5px;
+    color: var(--text-muted, #566070);
+  }
+
+  .dispatch-item-meta code {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 10.5px;
+  }
+
+  .dispatch-item-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 2px;
+  }
+</style>

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -273,10 +273,44 @@
     return "var(--text-muted, #566070)";
   }
 
-  // The activity_log IS the unified feed — agent_message/user_message are chat,
-  // everything else is activity. No merging needed.
-  function isActivityEvent(kind) {
-    return kind !== "agent_message" && kind !== "user_message";
+  // Group activity_log entries by turn for color-banded rendering
+  const turnColors = [
+    "rgba(37, 99, 235, 0.04)",
+    "rgba(63, 185, 80, 0.04)",
+    "rgba(163, 113, 247, 0.04)",
+    "rgba(210, 153, 34, 0.04)",
+  ];
+
+  function groupByTurn(activityLog) {
+    if (!activityLog?.length) return [];
+    const groups = [];
+    let current = { turnIndex: 0, entries: [] };
+    for (const entry of activityLog) {
+      if (entry.kind === "turn_start" && current.entries.length > 0) {
+        groups.push(current);
+        current = { turnIndex: current.turnIndex + 1, entries: [] };
+      }
+      current.entries.push(entry);
+    }
+    if (current.entries.length > 0) groups.push(current);
+    return groups;
+  }
+
+  $: selectedRunTurnGroups = selectedRun ? groupByTurn(selectedRun.activity_log) : [];
+
+  const COLLAPSE_LINE_THRESHOLD = 6;
+  let expandedMessages = {};
+
+  function toggleMessageExpand(idx) {
+    expandedMessages = { ...expandedMessages, [idx]: !expandedMessages[idx] };
+  }
+
+  function shouldCollapse(text) {
+    return text ? text.split("\n").length > COLLAPSE_LINE_THRESHOLD : false;
+  }
+
+  function truncateText(text) {
+    return text.split("\n").slice(0, COLLAPSE_LINE_THRESHOLD).join("\n");
   }
 
   function handleFollowUpKeydown(event, run) {
@@ -387,6 +421,9 @@
           }}
           on:openpr={() => selectedRun && handleOpenPR(selectedRun)}
           on:launch={() => selectedDispatch && launchNode(selectedDispatch)}
+          scratchpadContent={selectedRun ? scratchpadContent[selectedRun.run_id] : undefined}
+          scratchpadLoading={selectedRun ? !!scratchpadLoading[selectedRun.run_id] : false}
+          on:scratchpadtoggle={() => selectedRun && loadScratchpad(selectedRun.run_id)}
         />
       </div>
 
@@ -433,43 +470,11 @@
               <div class="workspace-progress">{run.progress_message}</div>
             {/if}
 
-            <!-- Scratchpad -->
-            <details class="workspace-expandable" on:toggle={(e) => e.currentTarget.open && loadScratchpad(run.run_id)}>
-              <summary>Scratchpad</summary>
-              <div class="scratchpad-body">
-                {#if scratchpadLoading[run.run_id]}
-                  <p class="muted">Loading...</p>
-                {:else if scratchpadContent[run.run_id]}
-                  <div class="scratchpad-rendered">{@html renderMarkdown(scratchpadContent[run.run_id])}</div>
-                {:else if scratchpadContent[run.run_id] === null}
-                  <p class="muted">No scratchpad available.</p>
-                {:else}
-                  <p class="muted">Open to load.</p>
-                {/if}
-              </div>
-            </details>
-
-            <!-- Checklist -->
+            <!-- Checklist (collapsible, open by default) -->
             {#if checklist?.items?.length}
-              <section class="workspace-section">
-                <div class="workspace-section-hdr"><h4>Checklist</h4></div>
-                <ExecutionChecklist items={checklist.items} />
-              </section>
-            {/if}
-
-            <!-- Result summary -->
-            {#if run.result_summary}
               <details class="workspace-expandable" open>
-                <summary>Result summary</summary>
-                <pre>{run.result_summary}</pre>
-              </details>
-            {/if}
-
-            <!-- Changed files -->
-            {#if run.changed_files?.length}
-              <details class="workspace-expandable">
-                <summary>Changed files ({run.changed_files.length})</summary>
-                <ul>{#each run.changed_files as path}<li>{path}</li>{/each}</ul>
+                <summary>Checklist ({checklist.items.filter(i => i.checked).length}/{checklist.items.length})</summary>
+                <ExecutionChecklist items={checklist.items} />
               </details>
             {/if}
 
@@ -484,43 +489,73 @@
 
           <!-- Scrollable feed -->
           <div class="workspace-feed-scroll" bind:this={feedScrollEl}>
-            {#if run.activity_log?.length > 0}
+            {#if selectedRunTurnGroups.length > 0}
               <div class="unified-feed">
-                {#each run.activity_log as entry}
-                  {#if entry.kind === "agent_message"}
-                    <div class="feed-chat feed-chat-assistant">
-                      <div class="feed-chat-hdr">
-                        <span class="feed-chat-role">Agent</span>
-                        <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
-                      </div>
-                      <div class="feed-chat-body">{entry.message}</div>
-                    </div>
-                  {:else if entry.kind === "user_message"}
-                    <div class="feed-chat feed-chat-user">
-                      <div class="feed-chat-hdr">
-                        <span class="feed-chat-role">You</span>
-                        <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
-                      </div>
-                      <div class="feed-chat-body">{entry.message}</div>
-                    </div>
-                  {:else}
-                    <div class="feed-activity" style="--activity-color: {activityKindColor(entry.kind)}">
-                      <span class="feed-activity-kind">{activityIcon(entry.kind)}</span>
-                      <span class="feed-activity-ts">{formatActivityTime(entry.timestamp)}</span>
-                      <span class="feed-activity-msg">{entry.message}</span>
-                    </div>
-                  {/if}
+                {#each selectedRunTurnGroups as group, gi}
+                  <div class="turn-band" style="background: {turnColors[group.turnIndex % turnColors.length]}">
+                    {#each group.entries as entry, ei}
+                      {@const globalIdx = `${gi}-${ei}`}
+                      {#if entry.kind === "agent_message"}
+                        <div class="feed-chat feed-chat-assistant">
+                          <div class="feed-chat-hdr">
+                            <span class="feed-chat-role">Agent</span>
+                            <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
+                            {#if shouldCollapse(entry.message)}
+                              <button class="feed-expand-btn" on:click={() => toggleMessageExpand(globalIdx)}>
+                                {expandedMessages[globalIdx] ? "collapse" : "expand"}
+                              </button>
+                            {/if}
+                          </div>
+                          <div class="feed-chat-body" class:feed-chat-collapsed={shouldCollapse(entry.message) && !expandedMessages[globalIdx]}>
+                            {expandedMessages[globalIdx] || !shouldCollapse(entry.message) ? entry.message : truncateText(entry.message)}
+                          </div>
+                          {#if shouldCollapse(entry.message) && !expandedMessages[globalIdx]}
+                            <button class="feed-expand-inline" on:click={() => toggleMessageExpand(globalIdx)}>Show full message ({entry.message.split("\n").length} lines)</button>
+                          {/if}
+                        </div>
+                      {:else if entry.kind === "user_message"}
+                        <div class="feed-chat feed-chat-user">
+                          <div class="feed-chat-hdr">
+                            <span class="feed-chat-role">You</span>
+                            <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
+                          </div>
+                          <div class="feed-chat-body">{entry.message}</div>
+                        </div>
+                      {:else if entry.kind === "turn_start" || entry.kind === "turn_end"}
+                        <!-- Absorbed into band color -->
+                      {:else}
+                        <div class="feed-activity" style="--activity-color: {activityKindColor(entry.kind)}">
+                          <span class="feed-activity-kind">{activityIcon(entry.kind)}</span>
+                          <span class="feed-activity-ts">{formatActivityTime(entry.timestamp)}</span>
+                          <span class="feed-activity-msg">{entry.message}</span>
+                        </div>
+                      {/if}
+                    {/each}
+                  </div>
                 {/each}
+
+                <!-- Pinned summary cards at end of feed -->
+                {#if run.result_summary}
+                  <div class="feed-pinned-card">
+                    <div class="feed-pinned-hdr">Result summary</div>
+                    <pre class="feed-pinned-pre">{run.result_summary}</pre>
+                  </div>
+                {/if}
+                {#if run.changed_files?.length}
+                  <div class="feed-pinned-card">
+                    <div class="feed-pinned-hdr">Changed files ({run.changed_files.length})</div>
+                    <ul class="feed-pinned-list">{#each run.changed_files as path}<li>{path}</li>{/each}</ul>
+                  </div>
+                {/if}
+                {#if run.errors?.length}
+                  <div class="feed-pinned-card feed-pinned-error">
+                    <div class="feed-pinned-hdr">Errors ({run.errors.length})</div>
+                    <ul class="feed-pinned-list">{#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}</ul>
+                  </div>
+                {/if}
               </div>
             {:else if ["running", "preparing", "disambiguating"].includes(run.status)}
               <div class="workspace-empty muted">Waiting for agent activity...</div>
-            {/if}
-
-            {#if run.errors?.length}
-              <details class="workspace-expandable">
-                <summary>Errors ({run.errors.length})</summary>
-                <ul>{#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}</ul>
-              </details>
             {/if}
           </div>
 
@@ -778,7 +813,15 @@
   /* Unified feed */
   .unified-feed {
     display: grid;
+    gap: 0;
+  }
+
+  .turn-band {
+    display: grid;
     gap: 2px;
+    padding: 4px 6px;
+    border-radius: var(--radius-sm, 3px);
+    margin-bottom: 2px;
   }
 
   /* Chat entries — prominent */
@@ -891,16 +934,70 @@
     font-size: 11px;
   }
 
-  .scratchpad-body { margin-top: 4px; }
+  /* Collapsed agent messages */
+  .feed-chat-collapsed {
+    mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+  }
 
-  .scratchpad-rendered :global(h1),
-  .scratchpad-rendered :global(h2),
-  .scratchpad-rendered :global(h3) { margin: 6px 0 3px; }
+  .feed-expand-btn {
+    padding: 0 4px;
+    background: transparent;
+    color: var(--text-muted, #566070);
+    font-size: 10px;
+    border: none;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 
-  .scratchpad-rendered :global(ul),
-  .scratchpad-rendered :global(ol) { padding-left: 16px; }
+  .feed-expand-btn:hover { color: var(--text-secondary, #8b95a5); }
 
-  .scratchpad-rendered :global(code) { overflow-wrap: anywhere; }
+  .feed-expand-inline {
+    padding: 2px 0;
+    background: transparent;
+    color: var(--accent, #2563eb);
+    font-size: 10.5px;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .feed-expand-inline:hover { text-decoration: underline; }
+
+  /* Pinned summary cards */
+  .feed-pinned-card {
+    padding: 6px 8px;
+    border-radius: var(--radius-sm, 3px);
+    border: 1px solid var(--border, #2b3245);
+    background: var(--bg-surface, #13171f);
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
+  .feed-pinned-error { border-color: rgba(248, 81, 73, 0.3); }
+
+  .feed-pinned-hdr {
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary, #8b95a5);
+    margin-bottom: 4px;
+  }
+
+  .feed-pinned-pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 11px;
+    line-height: 1.45;
+  }
+
+  .feed-pinned-list {
+    margin: 0;
+    padding-left: 14px;
+    font-size: 11px;
+  }
 
   /* Responsive */
   @media (max-width: 1100px) {

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,6 +1,17 @@
 <script>
-  import { onMount } from "svelte";
-  import { getExecutionPreview, getRunChecklist, getRunChatHistory, getRunScratchpad, launchExecutionRun, listExecutionRuns, openPullRequest, resolveDisambiguation, sendFollowUpMessage } from "../lib/api.js";
+  import { onMount, afterUpdate } from "svelte";
+  import {
+    getExecutionPreview,
+    getRunChecklist,
+    getRunScratchpad,
+    launchExecutionRun,
+    listExecutionRuns,
+    openPullRequest,
+    resolveDisambiguation,
+    sendFollowUpMessage,
+  } from "../lib/api.js";
+  import ExecutionDispatchList from "./ExecutionDispatchList.svelte";
+  import ExecutionDetailPane from "./ExecutionDetailPane.svelte";
   import ExecutionChecklist from "./ExecutionChecklist.svelte";
   import { renderMarkdown } from "../lib/markdown.js";
 
@@ -18,16 +29,30 @@
   let prResults = {};
   let followUpTexts = {};
   let sendingFollowUp = {};
-  let chatHistories = {};
-  let expandedChat = {};
-
   let resolvingDisambiguation = {};
   let disambiguationContext = {};
-
   let scratchpadContent = {};
   let scratchpadLoading = {};
-
   let checklistData = {};
+
+  // Feed scroll + auto-scroll
+  let feedScrollEl;
+  let prevActivityCount = 0;
+
+  afterUpdate(() => {
+    if (!feedScrollEl || !selectedRun) return;
+    const count = selectedRun.activity_log?.length ?? 0;
+    if (count > prevActivityCount) {
+      prevActivityCount = count;
+      feedScrollEl.scrollTop = feedScrollEl.scrollHeight;
+    }
+  });
+
+  // Selection state
+  let selectedRunId = null;
+  let selectedDispatchId = null;
+  // Which column is active: "run" or "dispatch"
+  let activeSelection = "run";
 
   $: activeRuns = runs.filter((run) => ["queued", "preparing", "running", "disambiguating"].includes(run.status));
   $: disambiguatingRuns = runs.filter((run) => run.status === "disambiguating");
@@ -35,135 +60,80 @@
   $: blockedRuns = runs.filter((run) => run.status === "blocked");
   $: failedRuns = runs.filter((run) => run.status === "error");
 
+  $: dispatchNodes = preview?.groups?.flatMap((group) =>
+    group.nodes.map((node) => ({
+      ...node,
+      group_id: group.group_id,
+      repo: group.repo,
+      merge_order: group.merge_order || [],
+    }))
+  ) || [];
+
+  $: selectedRun = selectedRunId ? runs.find((r) => r.run_id === selectedRunId) ?? null : null;
+  $: selectedDispatch = selectedDispatchId ? dispatchNodes.find((n) => n.id === selectedDispatchId) ?? null : null;
+  $: selectedPullRequest = selectedRun ? selectedRun.pull_request || prResults[selectedRun.run_id] || null : null;
+
+  // Auto-select first run or dispatch if nothing selected
+  $: {
+    if (!selectedRunId && runs.length) {
+      const preferred = runs.find((r) => ["disambiguating", "running", "preparing", "queued"].includes(r.status)) || runs[0];
+      selectedRunId = preferred.run_id;
+      activeSelection = "run";
+    }
+    if (!selectedDispatchId && dispatchNodes.length) {
+      selectedDispatchId = dispatchNodes[0].id;
+    }
+  }
+
+  function selectRun(runId) {
+    selectedRunId = runId;
+    activeSelection = "run";
+  }
+
+  function selectDispatch(id) {
+    selectedDispatchId = id;
+    activeSelection = "dispatch";
+  }
+
   function mergeRun(run) {
-    if (!run) {
-      return;
-    }
-
-    const existingIndex = runs.findIndex((item) => item.run_id === run.run_id);
-    if (existingIndex >= 0) {
-      runs = runs.map((item, index) => (index === existingIndex ? run : item));
-      return;
-    }
-
-    runs = [run, ...runs].slice(0, 16);
-  }
-
-  function formatTimestamp(value) {
-    if (!value) {
-      return "—";
-    }
-
-    return new Date(value).toLocaleString();
-  }
-
-  function formatSafetySummary(checks = []) {
-    const failed = checks.filter((check) => check.status === "fail").length;
-    const warned = checks.filter((check) => check.status === "warn").length;
-
-    if (failed > 0) {
-      return `${failed} blocking check${failed === 1 ? "" : "s"}`;
-    }
-
-    if (warned > 0) {
-      return `${warned} warning${warned === 1 ? "" : "s"}`;
-    }
-
-    return "All safety checks passed";
-  }
-
-  function runStatusTone(status) {
-    if (status === "completed") {
-      return "healthy";
-    }
-
-    if (status === "running" || status === "preparing" || status === "queued") {
-      return "info";
-    }
-
-    if (status === "disambiguating") {
-      return "disambiguating";
-    }
-
-    if (status === "blocked") {
-      return "warn";
-    }
-
-    if (status === "error") {
-      return "danger";
-    }
-
-    return "";
-  }
-
-  function activityIcon(kind) {
-    if (kind === "tool_start") return "⚙️";
-    if (kind === "tool_end") return "✅";
-    if (kind === "turn_start" || kind === "turn_end") return "🔄";
-    if (kind === "reasoning") return "💡";
-    if (kind === "error") return "❌";
-    if (kind === "status_change") return "📌";
-    return "ℹ️";
-  }
-
-  function formatActivityTime(timestamp) {
-    if (!timestamp) return "";
-    try {
-      return new Date(timestamp).toLocaleTimeString();
-    } catch {
-      return "";
+    if (!run) return;
+    const idx = runs.findIndex((item) => item.run_id === run.run_id);
+    if (idx >= 0) {
+      runs = runs.map((item, i) => (i === idx ? run : item));
+    } else {
+      runs = [run, ...runs].slice(0, 16);
     }
   }
 
   async function copyValue(value, message) {
     if (!value || !window?.navigator?.clipboard) {
-      copiedMessage = "Clipboard unavailable in this browser.";
+      copiedMessage = "Clipboard unavailable.";
       return;
     }
-
     try {
       await window.navigator.clipboard.writeText(value);
       copiedMessage = message;
       window.clearTimeout(copyTimer);
-      copyTimer = window.setTimeout(() => {
-        copiedMessage = "";
-      }, 2000);
-    } catch (copyError) {
-      copiedMessage = copyError.message;
+      copyTimer = window.setTimeout(() => { copiedMessage = ""; }, 2000);
+    } catch (e) {
+      copiedMessage = e.message;
     }
-  }
-
-  function buildPrCommand(run) {
-    return `gh pr create --base ${run.base_ref} --head ${run.branch}`;
   }
 
   async function loadData({ quiet = false } = {}) {
-    if (quiet) {
-      refreshing = true;
-    } else {
-      loading = true;
-    }
+    if (quiet) { refreshing = true; } else { loading = true; }
     error = "";
-
     try {
       const [nextPreview, nextRuns] = await Promise.all([getExecutionPreview(), listExecutionRuns()]);
       preview = nextPreview;
       runs = nextRuns;
-      // Auto-expand chat for any disambiguating runs
       for (const run of nextRuns) {
-        if ((run.status === "disambiguating" || run.status === "running") && !expandedChat[run.run_id]) {
-          expandedChat = { ...expandedChat, [run.run_id]: true };
-          loadChatHistory(run.run_id);
-        }
-      }
-      // Load initial checklist for active runs
-      for (const run of nextRuns) {
-        if (["queued", "preparing", "running", "completed"].includes(run.status) && !checklistData[run.run_id]) {
+        if (["queued", "preparing", "running", "completed", "disambiguating"].includes(run.status) && !checklistData[run.run_id]) {
           loadChecklist(run.run_id);
         }
       }
-    } catch (loadError) {
-      error = loadError.message;
+    } catch (e) {
+      error = e.message;
     } finally {
       loading = false;
       refreshing = false;
@@ -177,8 +147,8 @@
       const result = await openPullRequest({ run_id: run.run_id, auto_commit: true });
       mergeRun(result.run);
       prResults = { ...prResults, [run.run_id]: result.pull_request };
-    } catch (prError) {
-      error = prError.message;
+    } catch (e) {
+      error = e.message;
     } finally {
       openingPrRunIds = openingPrRunIds.filter((id) => id !== run.run_id);
     }
@@ -188,66 +158,31 @@
     return ["running", "preparing", "completed", "disambiguating"].includes(run.status);
   }
 
-  function isDisambiguating(run) {
-    return run.status === "disambiguating";
-  }
-
   async function handleSendFollowUp(run) {
     const text = (followUpTexts[run.run_id] || "").trim();
     if (!text) return;
-
     sendingFollowUp = { ...sendingFollowUp, [run.run_id]: true };
     error = "";
-
-    // Optimistically add to local chat history
-    const userMsg = { timestamp: new Date().toISOString(), role: "user", text };
-    chatHistories = {
-      ...chatHistories,
-      [run.run_id]: [...(chatHistories[run.run_id] || []), userMsg],
-    };
     followUpTexts = { ...followUpTexts, [run.run_id]: "" };
-    expandedChat = { ...expandedChat, [run.run_id]: true };
-
     try {
       const delivery = ["running", "preparing"].includes(run.status) ? "followUp" : undefined;
-      const result = await sendFollowUpMessage({
-        run_id: run.run_id,
-        message: text,
-        ...(delivery ? { delivery } : {}),
-      });
-      if (!result.accepted) {
-        error = result.error || "Follow-up was not accepted.";
-      }
-    } catch (followUpError) {
-      error = followUpError.message;
+      const result = await sendFollowUpMessage({ run_id: run.run_id, message: text, ...(delivery ? { delivery } : {}) });
+      if (!result.accepted) error = result.error || "Follow-up was not accepted.";
+    } catch (e) {
+      error = e.message;
     } finally {
       sendingFollowUp = { ...sendingFollowUp, [run.run_id]: false };
     }
   }
 
-  async function loadChatHistory(runId) {
-    try {
-      const result = await getRunChatHistory(runId);
-      chatHistories = { ...chatHistories, [runId]: result.messages || [] };
-    } catch (chatError) {
-      console.error("Failed to load chat history", chatError);
-    }
-  }
-
-  function toggleChat(runId) {
-    const next = !expandedChat[runId];
-    expandedChat = { ...expandedChat, [runId]: next };
-    if (next && !chatHistories[runId]) {
-      loadChatHistory(runId);
-    }
-  }
+  // Chat history is now derived from run.activity_log (agent_message + user_message entries)
 
   async function loadChecklist(runId) {
     try {
       const result = await getRunChecklist(runId);
       checklistData = { ...checklistData, [runId]: result };
-    } catch (err) {
-      console.debug("Failed to load checklist", err);
+    } catch (e) {
+      console.debug("Failed to load checklist", e);
     }
   }
 
@@ -257,116 +192,116 @@
     try {
       const result = await getRunScratchpad(runId);
       scratchpadContent = { ...scratchpadContent, [runId]: result.content };
-    } catch (scratchpadError) {
+    } catch (e) {
       scratchpadContent = { ...scratchpadContent, [runId]: null };
-      console.error("Failed to load scratchpad", scratchpadError);
     } finally {
       scratchpadLoading = { ...scratchpadLoading, [runId]: false };
-    }
-  }
-
-  function handleScratchpadToggle(event, runId) {
-    if (event.target.open) {
-      loadScratchpad(runId);
-    }
-  }
-
-  function handleFollowUpKeydown(event, run) {
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      handleSendFollowUp(run);
     }
   }
 
   async function launchNode(node) {
     launchingIds = [...launchingIds, node.id];
     error = "";
-
     try {
       const result = await launchExecutionRun({ work_item_id: node.id, disambiguate: true });
       mergeRun(result.run);
-      // Auto-expand chat so user sees Q&A questions immediately
       if (result.run) {
-        expandedChat = { ...expandedChat, [result.run.run_id]: true };
+        selectedRunId = result.run.run_id;
+        activeSelection = "run";
       }
       await loadData({ quiet: true });
-    } catch (launchError) {
-      error = launchError.message;
+    } catch (e) {
+      error = e.message;
     } finally {
       launchingIds = launchingIds.filter((id) => id !== node.id);
     }
   }
 
+  function launchNodeById(id) {
+    const node = dispatchNodes.find((n) => n.id === id);
+    if (node) launchNode(node);
+  }
+
   async function handleResolveDisambiguation(run) {
     resolvingDisambiguation = { ...resolvingDisambiguation, [run.run_id]: true };
     error = "";
-
     try {
-      const additionalContext = (disambiguationContext[run.run_id] || "").trim() || undefined;
-      const result = await resolveDisambiguation({
-        run_id: run.run_id,
-        additional_context: additionalContext,
-      });
-      if (!result.resolved) {
-        error = result.error || "Failed to resolve disambiguation.";
-      } else {
-        disambiguationContext = { ...disambiguationContext, [run.run_id]: "" };
-      }
-    } catch (resolveError) {
-      error = resolveError.message;
+      const ctx = (disambiguationContext[run.run_id] || "").trim() || undefined;
+      const result = await resolveDisambiguation({ run_id: run.run_id, additional_context: ctx });
+      if (!result.resolved) error = result.error || "Failed to resolve.";
+      else disambiguationContext = { ...disambiguationContext, [run.run_id]: "" };
+    } catch (e) {
+      error = e.message;
     } finally {
       resolvingDisambiguation = { ...resolvingDisambiguation, [run.run_id]: false };
     }
   }
 
-  // Poll chat history for disambiguating runs so user sees questions as they arrive
-  let disambiguationPollTimer;
-  function startDisambiguationPolling() {
-    if (disambiguationPollTimer) return;
-    disambiguationPollTimer = setInterval(() => {
-      const disambRuns = runs.filter((r) => (r.status === "disambiguating" || r.status === "running") && expandedChat[r.run_id]);
-      for (const run of disambRuns) {
-        loadChatHistory(run.run_id);
-      }
-      if (disambRuns.length === 0) {
-        clearInterval(disambiguationPollTimer);
-        disambiguationPollTimer = null;
-      }
-    }, 2000);
+  // Activity log delivered via SSE — no polling needed
+
+  function runStatusTone(status) {
+    if (status === "completed") return "healthy";
+    if (["running", "preparing", "queued"].includes(status)) return "info";
+    if (status === "disambiguating") return "disambiguating";
+    if (status === "blocked") return "warn";
+    if (status === "error") return "danger";
+    return "";
   }
 
-  // Reactive: start polling when disambiguating or running runs exist
-  $: if (disambiguatingRuns.length > 0 || activeRuns.length > 0) {
-    startDisambiguationPolling();
+  function formatActivityTime(value) {
+    if (!value) return "";
+    try { return new Date(value).toLocaleTimeString(); } catch { return ""; }
+  }
+
+  function activityIcon(kind) {
+    if (kind === "tool_start") return "gear";
+    if (kind === "tool_end") return "check";
+    if (kind === "turn_start" || kind === "turn_end") return "loop";
+    if (kind === "reasoning") return "idea";
+    if (kind === "error") return "err";
+    if (kind === "status_change") return "pin";
+    return "info";
+  }
+
+  function activityKindColor(kind) {
+    if (kind === "error") return "var(--red, #f85149)";
+    if (kind === "tool_start" || kind === "tool_end") return "var(--accent, #2563eb)";
+    if (kind === "status_change") return "var(--green, #3fb950)";
+    if (kind === "reasoning") return "var(--yellow, #d29922)";
+    if (kind === "turn_start" || kind === "turn_end") return "var(--purple, #a371f7)";
+    if (kind === "follow_up") return "#58a6ff";
+    return "var(--text-muted, #566070)";
+  }
+
+  // The activity_log IS the unified feed — agent_message/user_message are chat,
+  // everything else is activity. No merging needed.
+  function isActivityEvent(kind) {
+    return kind !== "agent_message" && kind !== "user_message";
+  }
+
+  function handleFollowUpKeydown(event, run) {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      if (canSendFollowUp(run)) handleSendFollowUp(run);
+    }
   }
 
   onMount(() => {
     loadData();
-
     stream = new EventSource("/api/execution/stream");
-    stream.addEventListener("open", () => {
-      connected = true;
-    });
-    stream.addEventListener("error", () => {
-      connected = false;
-    });
+    stream.addEventListener("open", () => { connected = true; });
+    stream.addEventListener("error", () => { connected = false; });
 
     const handleEnvelope = (event) => {
       try {
         const envelope = JSON.parse(event.data);
         const run = envelope.payload?.run;
         mergeRun(run);
-        // Auto-expand chat and load history when run enters disambiguating
-        if (run && run.status === "disambiguating") {
-          expandedChat = { ...expandedChat, [run.run_id]: true };
-          loadChatHistory(run.run_id);
-        }
-        // Load initial checklist when run starts running (if not already populated by SSE)
-        if (run && run.status === "running" && !checklistData[run.run_id]) {
+        if (run && ["running", "disambiguating"].includes(run.status) && !checklistData[run.run_id]) {
           loadChecklist(run.run_id);
         }
-      } catch (streamError) {
-        console.error("Failed to parse execution SSE event", streamError);
+      } catch (e) {
+        console.error("Failed to parse execution SSE event", e);
       }
     };
 
@@ -374,11 +309,9 @@
       try {
         const envelope = JSON.parse(event.data);
         const snapshot = envelope.payload;
-        if (snapshot?.run_id) {
-          checklistData = { ...checklistData, [snapshot.run_id]: snapshot };
-        }
-      } catch (err) {
-        console.error("Failed to parse checklist SSE event", err);
+        if (snapshot?.run_id) checklistData = { ...checklistData, [snapshot.run_id]: snapshot };
+      } catch (e) {
+        console.error("Failed to parse checklist SSE event", e);
       }
     };
 
@@ -388,1006 +321,607 @@
 
     return () => {
       window.clearTimeout(copyTimer);
-      if (disambiguationPollTimer) clearInterval(disambiguationPollTimer);
       stream?.close();
     };
   });
 </script>
 
 <section class="execution-panel">
-  <div class="panel-header execution-header">
-    <div>
-      <h2>Dispatch execution work</h2>
-      <p class="muted">Launch dispatchable work, track live runs, inspect worktree and branch context, and prep PR or sync follow-up without leaving the Execute tab.</p>
+  <!-- Top bar: status + summary -->
+  <div class="exec-topbar">
+    <div class="exec-topbar-left">
+      <span class:healthy={connected} class="status-pill">{connected ? "stream connected" : "reconnecting"}</span>
+      {#if preview}
+        <span class="exec-stat">{preview.summary.dispatchable_now} dispatchable</span>
+        <span class="exec-stat">{activeRuns.length} active</span>
+        <span class="exec-stat">{completedRuns.length} done</span>
+        {#if blockedRuns.length + failedRuns.length > 0}
+          <span class="exec-stat warn">{blockedRuns.length + failedRuns.length} failed</span>
+        {/if}
+      {/if}
     </div>
-    <div class="status-cluster execution-toolbar">
-      <span class:healthy={connected} class="status-pill">{connected ? "Execution stream connected" : "Execution stream reconnecting"}</span>
-      <button class="secondary" on:click={() => loadData({ quiet: true })} disabled={refreshing || loading}>{refreshing ? "Refreshing..." : "Refresh execute view"}</button>
-    </div>
+    <button class="secondary small" on:click={() => loadData({ quiet: true })} disabled={refreshing || loading}>{refreshing ? "Refreshing..." : "Refresh"}</button>
   </div>
 
   {#if copiedMessage}
     <div class="banner success inline-banner" aria-live="polite">{copiedMessage}</div>
   {/if}
-
   {#if error}
     <div class="banner error inline-banner">{error}</div>
   {/if}
 
   {#if loading}
-    <div class="empty-state">Loading execution dispatch preview…</div>
+    <div class="empty-state">Loading execution workspace...</div>
   {:else if !preview}
     <div class="empty-state">Execution preview unavailable.</div>
   {:else}
-    <div class="execution-summary-grid execute-summary-grid">
-      <div class="execution-summary-card">
-        <strong>Dispatchable now</strong>
-        <span>{preview.summary.dispatchable_now}</span>
+    <div class="exec-columns">
+      <!-- Left: Dispatch queue -->
+      <div class="exec-col-dispatch">
+        <ExecutionDispatchList
+          groups={preview.groups}
+          selectedDispatchId={activeSelection === "dispatch" ? selectedDispatchId : null}
+          {launchingIds}
+          on:select={(e) => selectDispatch(e.detail.id)}
+          on:launch={(e) => launchNodeById(e.detail.id)}
+        />
       </div>
-      <div class="execution-summary-card">
-        <strong>Active runs</strong>
-        <span>{activeRuns.length}{disambiguatingRuns.length ? ` (${disambiguatingRuns.length} Q&A)` : ''}</span>
-      </div>
-      <div class="execution-summary-card">
-        <strong>Completed runs</strong>
-        <span>{completedRuns.length}</span>
-      </div>
-      <div class="execution-summary-card">
-        <strong>Blocked / failed</strong>
-        <span>{blockedRuns.length + failedRuns.length}</span>
-      </div>
-    </div>
 
-    <div class="execute-layout">
-      <div class="execute-primary-column">
-        {#if preview.assumptions?.length}
-          <details class="execution-assumptions dispatch-group-card">
-            <summary>Dispatch assumptions and limits</summary>
-            <ul>
-              {#each preview.assumptions as assumption}
-                <li>{assumption}</li>
-              {/each}
-            </ul>
-            <p class="muted small-text execution-policy-note">
-              Heavy task concurrency cap: {preview.validation_policy.max_concurrent_node_heavy_tasks}
-            </p>
-          </details>
+      <!-- Middle: Details/context for selected item -->
+      <div class="exec-col-details">
+        <ExecutionDetailPane
+          kind={activeSelection}
+          run={activeSelection === "run" ? selectedRun : null}
+          dispatchNode={activeSelection === "dispatch" ? selectedDispatch : null}
+          pullRequest={selectedPullRequest}
+          openingPr={selectedRun ? openingPrRunIds.includes(selectedRun.run_id) : false}
+          assumptions={preview.assumptions || []}
+          validationPolicy={preview.validation_policy}
+          on:copybranch={() => {
+            if (activeSelection === "run" && selectedRun) copyValue(selectedRun.branch, `Copied branch ${selectedRun.branch}`);
+            else if (activeSelection === "dispatch" && selectedDispatch) copyValue(selectedDispatch.branch, `Copied branch ${selectedDispatch.branch}`);
+          }}
+          on:copyworktree={() => {
+            if (activeSelection === "run" && selectedRun) copyValue(selectedRun.worktree_path, `Copied worktree`);
+            else if (activeSelection === "dispatch" && selectedDispatch) copyValue(selectedDispatch.worktree_path, `Copied worktree`);
+          }}
+          on:openpr={() => selectedRun && handleOpenPR(selectedRun)}
+          on:launch={() => selectedDispatch && launchNode(selectedDispatch)}
+        />
+      </div>
+
+      <!-- Right: Workspace (run pills + active run content) -->
+      <div class="exec-col-workspace">
+        <!-- Run pill strip -->
+        {#if runs.length > 0}
+          <div class="run-pill-strip">
+            {#each runs as run}
+              <button
+                class="run-pill"
+                class:active={selectedRunId === run.run_id && activeSelection === "run"}
+                on:click={() => selectRun(run.run_id)}
+                title="{run.work_item_id} — {run.status}"
+              >
+                <span class="run-pill-dot {runStatusTone(run.status)}"></span>
+                <span class="run-pill-label">{run.work_item_id}</span>
+              </button>
+            {/each}
+          </div>
         {/if}
 
-        <section class="dispatch-group-card">
-          <div class="dispatch-group-header">
-            <div>
-              <h3>Dispatch queue</h3>
-              <p class="muted">Review launchable work, owned scope, and worktree safety before starting a run.</p>
+        <!-- Workspace content for selected run -->
+        {#if activeSelection === "run" && selectedRun}
+          {@const run = selectedRun}
+          {@const checklist = checklistData[run.run_id]}
+          {@const followUp = followUpTexts[run.run_id] || ""}
+          {@const isSending = !!sendingFollowUp[run.run_id]}
+          {@const isDisambiguating = run.status === "disambiguating"}
+          {@const disambigCtx = disambiguationContext[run.run_id] || ""}
+          {@const isResolving = !!resolvingDisambiguation[run.run_id]}
+
+          <!-- Fixed header -->
+          <div class="workspace-top">
+            <div class="workspace-header">
+              <div>
+                <h3>{run.work_item_id}</h3>
+                <span class="muted">{run.work_item_name}</span>
+              </div>
+              <span class="status-pill {runStatusTone(run.status)}">{run.status}</span>
             </div>
-            <span class="proposal-type">{preview.groups.length} group(s)</span>
+
+            {#if run.progress_message}
+              <div class="workspace-progress">{run.progress_message}</div>
+            {/if}
+
+            <!-- Scratchpad -->
+            <details class="workspace-expandable" on:toggle={(e) => e.currentTarget.open && loadScratchpad(run.run_id)}>
+              <summary>Scratchpad</summary>
+              <div class="scratchpad-body">
+                {#if scratchpadLoading[run.run_id]}
+                  <p class="muted">Loading...</p>
+                {:else if scratchpadContent[run.run_id]}
+                  <div class="scratchpad-rendered">{@html renderMarkdown(scratchpadContent[run.run_id])}</div>
+                {:else if scratchpadContent[run.run_id] === null}
+                  <p class="muted">No scratchpad available.</p>
+                {:else}
+                  <p class="muted">Open to load.</p>
+                {/if}
+              </div>
+            </details>
+
+            <!-- Checklist -->
+            {#if checklist?.items?.length}
+              <section class="workspace-section">
+                <div class="workspace-section-hdr"><h4>Checklist</h4></div>
+                <ExecutionChecklist items={checklist.items} />
+              </section>
+            {/if}
+
+            <!-- Result summary -->
+            {#if run.result_summary}
+              <details class="workspace-expandable" open>
+                <summary>Result summary</summary>
+                <pre>{run.result_summary}</pre>
+              </details>
+            {/if}
+
+            <!-- Changed files -->
+            {#if run.changed_files?.length}
+              <details class="workspace-expandable">
+                <summary>Changed files ({run.changed_files.length})</summary>
+                <ul>{#each run.changed_files as path}<li>{path}</li>{/each}</ul>
+              </details>
+            {/if}
+
+            <!-- Disambiguation banner -->
+            {#if isDisambiguating}
+              <div class="disambig-banner">
+                <strong>Setup phase</strong>
+                <span class="muted">Review the plan, answer questions, then approve to start coding.</span>
+              </div>
+            {/if}
           </div>
 
-          {#if preview.groups.length === 0}
-            <p class="muted">No dispatchable execution groups yet.</p>
-          {:else}
-            <div class="execution-groups">
-              {#each preview.groups as group}
-                <section class="dispatch-group-card dispatch-subgroup">
-                  <div class="dispatch-group-header">
-                    <div>
-                      <h3>{group.group_id}</h3>
-                      <p class="muted">Repo: {group.repo} · {group.nodes.length} launchable node(s)</p>
+          <!-- Scrollable feed -->
+          <div class="workspace-feed-scroll" bind:this={feedScrollEl}>
+            {#if run.activity_log?.length > 0}
+              <div class="unified-feed">
+                {#each run.activity_log as entry}
+                  {#if entry.kind === "agent_message"}
+                    <div class="feed-chat feed-chat-assistant">
+                      <div class="feed-chat-hdr">
+                        <span class="feed-chat-role">Agent</span>
+                        <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
+                      </div>
+                      <div class="feed-chat-body">{entry.message}</div>
                     </div>
-                    {#if group.merge_order?.length}
-                      <span class="proposal-type">Merge order: {group.merge_order.join(" → ")}</span>
-                    {/if}
-                  </div>
+                  {:else if entry.kind === "user_message"}
+                    <div class="feed-chat feed-chat-user">
+                      <div class="feed-chat-hdr">
+                        <span class="feed-chat-role">You</span>
+                        <span class="feed-chat-ts">{formatActivityTime(entry.timestamp)}</span>
+                      </div>
+                      <div class="feed-chat-body">{entry.message}</div>
+                    </div>
+                  {:else}
+                    <div class="feed-activity" style="--activity-color: {activityKindColor(entry.kind)}">
+                      <span class="feed-activity-kind">{activityIcon(entry.kind)}</span>
+                      <span class="feed-activity-ts">{formatActivityTime(entry.timestamp)}</span>
+                      <span class="feed-activity-msg">{entry.message}</span>
+                    </div>
+                  {/if}
+                {/each}
+              </div>
+            {:else if ["running", "preparing", "disambiguating"].includes(run.status)}
+              <div class="workspace-empty muted">Waiting for agent activity...</div>
+            {/if}
 
-                  <div class="dispatch-node-list">
-                    {#each group.nodes as node}
-                      <article class="dispatch-node-card execute-node-card">
-                        <div class="dispatch-node-header">
-                          <div>
-                            <strong>{node.id}</strong>
-                            <div>{node.name}</div>
-                          </div>
-                          <div class="node-action-cluster">
-                            {#if node.issue_url}
-                              <a class="ghost-link small" href={node.issue_url} target="_blank" rel="noreferrer">Open issue</a>
-                            {/if}
-                            <button on:click={() => launchNode(node)} disabled={!node.can_launch || launchingIds.includes(node.id)}>
-                              {launchingIds.includes(node.id) ? "Launching..." : node.can_launch ? "Launch run" : "Blocked"}
-                            </button>
-                          </div>
-                        </div>
+            {#if run.errors?.length}
+              <details class="workspace-expandable">
+                <summary>Errors ({run.errors.length})</summary>
+                <ul>{#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}</ul>
+              </details>
+            {/if}
+          </div>
 
-                        <div class="execution-context-row">
-                          <span class="context-chip"><span class="context-label">Branch</span><code>{node.branch}</code></span>
-                          <span class="context-chip"><span class="context-label">Base</span><code>{node.default_base_ref}</code></span>
-                          <span class="context-chip context-path"><span class="context-label">Worktree</span><code>{node.worktree_path}</code></span>
-                        </div>
+          <!-- Pinned input at bottom -->
+          {#if canSendFollowUp(run)}
+            <div class="workspace-input-pinned">
+              <div class="chat-input-row">
+                <textarea
+                  placeholder={isDisambiguating ? "Answer questions or add context..." : ["running", "preparing"].includes(run.status) ? "Steer or follow up..." : "Send a follow-up..."}
+                  value={followUp}
+                  on:input={(e) => followUpTexts = { ...followUpTexts, [run.run_id]: e.currentTarget.value }}
+                  on:keydown={(e) => handleFollowUpKeydown(e, run)}
+                  rows="2"
+                  disabled={isSending}
+                ></textarea>
+                <button on:click={() => handleSendFollowUp(run)} disabled={isSending || !followUp.trim()}>
+                  {isSending ? "..." : "Send"}
+                </button>
+              </div>
 
-                        <div class="execute-card-actions">
-                          <button class="secondary small" on:click={() => copyValue(node.branch, `Copied branch ${node.branch}`)}>Copy branch</button>
-                          <button class="secondary small" on:click={() => copyValue(node.worktree_path, `Copied worktree for ${node.id}`)}>Copy worktree</button>
-                        </div>
-
-                        <div class="safety-summary-row">
-                          <span class="status-pill {node.can_launch ? 'healthy' : 'warn'}">{node.can_launch ? 'Launchable' : 'Blocked by safety checks'}</span>
-                          <span class="muted small-text">{formatSafetySummary(node.safety_checks)}</span>
-                        </div>
-
-                        {#if node.scope_hint}
-                          <p>{node.scope_hint}</p>
-                        {/if}
-
-                        <details>
-                          <summary>Scope, sharing, and safety</summary>
-                          <div class="dispatch-scope-grid execute-scope-grid">
-                            <div>
-                              <div class="muted">Owned files</div>
-                              <ul>
-                                {#if node.files_owned.length}
-                                  {#each node.files_owned as path}<li>{path}</li>{/each}
-                                {:else}
-                                  <li>(none predicted)</li>
-                                {/if}
-                              </ul>
-                            </div>
-                            <div>
-                              <div class="muted">Shared files</div>
-                              <ul>
-                                {#if node.files_shared.length}
-                                  {#each node.files_shared as shared}<li><code>{shared.path}</code> — {shared.assessment}</li>{/each}
-                                {:else}
-                                  <li>(none)</li>
-                                {/if}
-                              </ul>
-                            </div>
-                            <div>
-                              <div class="muted">Forbidden files</div>
-                              <ul>
-                                {#if node.files_forbidden.length}
-                                  {#each node.files_forbidden as path}<li>{path}</li>{/each}
-                                {:else}
-                                  <li>(none)</li>
-                                {/if}
-                              </ul>
-                            </div>
-                          </div>
-                          <div class="execution-check-list">
-                            {#each node.safety_checks as check}
-                              <div class="execution-check {check.status}">
-                                <strong>{check.code}</strong>
-                                <span>{check.message}</span>
-                              </div>
-                            {/each}
-                          </div>
-                        </details>
-                      </article>
-                    {/each}
-                  </div>
-                </section>
-              {/each}
+              {#if isDisambiguating}
+                <div class="chat-input-row">
+                  <textarea
+                    placeholder="Optional: final context for the coding agent..."
+                    value={disambigCtx}
+                    on:input={(e) => disambiguationContext = { ...disambiguationContext, [run.run_id]: e.currentTarget.value }}
+                    rows="2"
+                    disabled={isResolving}
+                  ></textarea>
+                  <button on:click={() => handleResolveDisambiguation(run)} disabled={isResolving}>
+                    {isResolving ? "Starting..." : "Proceed to coding"}
+                  </button>
+                </div>
+              {/if}
             </div>
           {/if}
-        </section>
+
+        {:else if activeSelection === "dispatch" && selectedDispatch}
+          <div class="workspace-feed-scroll">
+            <div class="workspace-empty large muted">
+              Dispatch candidate selected. See details in the middle column, or launch to create a run.
+            </div>
+          </div>
+        {:else}
+          <div class="workspace-feed-scroll">
+            <div class="workspace-empty large muted">No runs yet. Launch a dispatch candidate to get started.</div>
+          </div>
+        {/if}
       </div>
-
-      <aside class="execute-sidebar-column">
-        <section class="dispatch-group-card execute-sidebar-card">
-          <div class="dispatch-group-header">
-            <div>
-              <h3>Run status</h3>
-              <p class="muted">Live execution state and handoff actions for recent runs.</p>
-            </div>
-            <span class="status-pill {connected ? 'healthy' : 'warn'}">{connected ? 'Live' : 'Retrying stream'}</span>
-          </div>
-
-          <div class="run-stat-grid">
-            <div class="execution-summary-card compact-stat">
-              <strong>Queued / active</strong>
-              <span>{activeRuns.length}</span>
-            </div>
-            <div class="execution-summary-card compact-stat">
-              <strong>Completed</strong>
-              <span>{completedRuns.length}</span>
-            </div>
-            <div class="execution-summary-card compact-stat">
-              <strong>Blocked</strong>
-              <span>{blockedRuns.length}</span>
-            </div>
-            <div class="execution-summary-card compact-stat">
-              <strong>Errors</strong>
-              <span>{failedRuns.length}</span>
-            </div>
-          </div>
-        </section>
-
-        <section class="dispatch-group-card execute-sidebar-card">
-          <div class="dispatch-group-header">
-            <div>
-              <h3>Recent execution runs</h3>
-              <p class="muted">Use branch, worktree, and artifact context to review work before PR or sync follow-up.</p>
-            </div>
-          </div>
-
-          {#if runs.length === 0}
-            <p class="muted">No execution runs launched yet.</p>
-          {:else}
-            <div class="dispatch-node-list run-list">
-              {#each runs as run}
-                <article class="dispatch-node-card execution-run-card">
-                  <div class="dispatch-node-header">
-                    <div>
-                      <strong>{run.work_item_id}</strong>
-                      <div>{run.work_item_name}</div>
-                    </div>
-                    <span class="status-pill {runStatusTone(run.status)}">{run.status}</span>
-                  </div>
-
-                  <div class="execution-context-row run-context-row">
-                    <span class="context-chip"><span class="context-label">Branch</span><code>{run.branch}</code></span>
-                    <span class="context-chip"><span class="context-label">Base</span><code>{run.base_ref}</code></span>
-                  </div>
-                  <div class="execution-context-row run-context-row">
-                    <span class="context-chip context-path"><span class="context-label">Worktree</span><code>{run.worktree_path}</code></span>
-                  </div>
-                  <div class="execution-context-row run-context-row">
-                    <span class="context-chip context-path"><span class="context-label">Artifacts</span><code>{run.artifact_dir}</code></span>
-                  </div>
-
-                  <div class="run-timestamp-grid small-text muted">
-                    <span>Created: {formatTimestamp(run.created_at)}</span>
-                    <span>Updated: {formatTimestamp(run.updated_at)}</span>
-                    {#if run.started_at}<span>Started: {formatTimestamp(run.started_at)}</span>{/if}
-                    {#if run.completed_at}<span>Completed: {formatTimestamp(run.completed_at)}</span>{/if}
-                  </div>
-
-                  <div class="safety-summary-row">
-                    <span class="muted small-text">{formatSafetySummary(run.safety_checks)}</span>
-                  </div>
-
-                  {#if run.progress_message}
-                    <p class="run-progress-message">{run.progress_message}</p>
-                  {/if}
-
-                  {#if run.activity_log?.length}
-                    <details class="activity-log-details" open={["running", "preparing"].includes(run.status)}>
-                      <summary>Activity log ({run.activity_log.length} event{run.activity_log.length === 1 ? '' : 's'})</summary>
-                      <div class="activity-log">
-                        {#each run.activity_log as entry}
-                          <div class="activity-entry activity-{entry.kind}">
-                            <span class="activity-icon">{activityIcon(entry.kind)}</span>
-                            <span class="activity-time">{formatActivityTime(entry.timestamp)}</span>
-                            <span class="activity-message">{entry.message}</span>
-                          </div>
-                        {/each}
-                      </div>
-                    </details>
-                  {:else if ["running", "preparing"].includes(run.status)}
-                    <div class="activity-log-placeholder muted small-text">Waiting for activity events…</div>
-                  {/if}
-
-                  <div class="execute-card-actions">
-                    {#if run.issue_url}
-                      <a class="ghost-link small" href={run.issue_url} target="_blank" rel="noreferrer">Open issue</a>
-                    {/if}
-                    <button class="secondary small" on:click={() => copyValue(run.branch, `Copied branch ${run.branch}`)}>Copy branch</button>
-                    <button class="secondary small" on:click={() => copyValue(run.worktree_path, `Copied worktree for ${run.work_item_id}`)}>Copy worktree</button>
-                    {#if isDisambiguating(run)}
-                      <button class="secondary small disambiguation-chat-btn" on:click={() => toggleChat(run.run_id)}>
-                        {expandedChat[run.run_id] ? 'Hide plan review' : '📋 Review plan'}
-                      </button>
-                    {:else if canSendFollowUp(run)}
-                      <button class="secondary small" on:click={() => toggleChat(run.run_id)}>
-                        {expandedChat[run.run_id] ? 'Hide chat' : 'Follow-up chat'}
-                      </button>
-                    {/if}
-                    {#if run.status === "completed"}
-                      {#if run.pull_request}
-                        <a class="ghost-link small" href={run.pull_request.url} target="_blank" rel="noreferrer">PR #{run.pull_request.number}</a>
-                      {:else if prResults[run.run_id]}
-                        <a class="ghost-link small" href={prResults[run.run_id].url} target="_blank" rel="noreferrer">PR #{prResults[run.run_id].number}</a>
-                      {:else}
-                        <button on:click={() => handleOpenPR(run)} disabled={openingPrRunIds.includes(run.run_id)}>
-                          {openingPrRunIds.includes(run.run_id) ? 'Opening PR…' : 'Open PR'}
-                        </button>
-                      {/if}
-
-                    {/if}
-                  </div>
-
-                  {#if isDisambiguating(run)}
-                    {#if expandedChat[run.run_id]}
-                      <div class="follow-up-chat disambiguating-chat">
-                        <div class="disambiguation-banner">
-                          <span class="disambiguation-icon">📋</span>
-                          <div class="disambiguation-banner-text">
-                            <strong>Setup phase — Review implementation plan</strong>
-                            <span>The agent has analyzed the issue and codebase. Review the plan and checklist below, answer any questions, then approve to start coding.</span>
-                          </div>
-                        </div>
-                        {#if chatHistories[run.run_id]?.length}
-                          <div class="follow-up-messages disambiguation-messages">
-                            {#each chatHistories[run.run_id] as msg}
-                              <div class="follow-up-msg follow-up-{msg.role}">
-                                <span class="follow-up-role">{msg.role === 'user' ? 'You' : 'Agent'}</span>
-                                <span class="follow-up-time">{formatActivityTime(msg.timestamp)}</span>
-                                <div class="follow-up-text">{msg.text}</div>
-                              </div>
-                            {/each}
-                          </div>
-                        {:else}
-                          <div class="disambiguation-waiting muted small-text">Waiting for the agent to generate questions…</div>
-                        {/if}
-                        <div class="follow-up-input-row">
-                          <textarea
-                            class="follow-up-input"
-                            placeholder="Answer questions or add context for the agent…"
-                            bind:value={followUpTexts[run.run_id]}
-                            on:keydown={(e) => handleFollowUpKeydown(e, run)}
-                            rows="2"
-                            disabled={sendingFollowUp[run.run_id]}
-                          ></textarea>
-                          <button
-                            class="follow-up-send"
-                            on:click={() => handleSendFollowUp(run)}
-                            disabled={sendingFollowUp[run.run_id] || !(followUpTexts[run.run_id] || '').trim()}
-                          >
-                            {sendingFollowUp[run.run_id] ? 'Sending…' : 'Send'}
-                          </button>
-                        </div>
-                        <div class="disambiguation-resolve-row">
-                          <textarea
-                            class="disambiguation-context-input"
-                            placeholder="Optional: final context or instructions to pass to the coding agent…"
-                            bind:value={disambiguationContext[run.run_id]}
-                            rows="2"
-                            disabled={resolvingDisambiguation[run.run_id]}
-                          ></textarea>
-                          <button
-                            class="disambiguation-resolve-btn"
-                            on:click={() => handleResolveDisambiguation(run)}
-                            disabled={resolvingDisambiguation[run.run_id]}
-                          >
-                            {resolvingDisambiguation[run.run_id] ? 'Starting coding…' : '✅ Proceed to coding'}
-                          </button>
-                        </div>
-                      </div>
-                    {/if}
-                  {/if}
-                  {#if checklistData[run.run_id]?.items?.length}
-                    <ExecutionChecklist items={checklistData[run.run_id].items} />
-                  {/if}
-
-                  {#if !isDisambiguating(run) && expandedChat[run.run_id] && canSendFollowUp(run)}
-                    <div class="follow-up-chat">
-                      {#if chatHistories[run.run_id]?.length}
-                        <div class="follow-up-messages">
-                          {#each chatHistories[run.run_id] as msg}
-                            <div class="follow-up-msg follow-up-{msg.role}">
-                              <span class="follow-up-role">{msg.role === 'user' ? 'You' : 'Agent'}</span>
-                              <span class="follow-up-time">{formatActivityTime(msg.timestamp)}</span>
-                              <div class="follow-up-text">{msg.text}</div>
-                            </div>
-                          {/each}
-                        </div>
-                      {/if}
-                      <div class="follow-up-input-row">
-                        <textarea
-                          class="follow-up-input"
-                          placeholder={["running", "preparing"].includes(run.status) ? "Steer or follow up on the active run…" : "Send a follow-up message to continue this run…"}
-                          bind:value={followUpTexts[run.run_id]}
-                          on:keydown={(e) => handleFollowUpKeydown(e, run)}
-                          rows="2"
-                          disabled={sendingFollowUp[run.run_id]}
-                        ></textarea>
-                        <button
-                          class="follow-up-send"
-                          on:click={() => handleSendFollowUp(run)}
-                          disabled={sendingFollowUp[run.run_id] || !(followUpTexts[run.run_id] || '').trim()}
-                        >
-                          {sendingFollowUp[run.run_id] ? 'Sending…' : 'Send'}
-                        </button>
-                      </div>
-                    </div>
-                  {/if}
-
-                  {#if run.result_summary}
-                    <details>
-                      <summary>Result summary</summary>
-                      <pre>{run.result_summary}</pre>
-                    </details>
-                  {/if}
-
-                  <details class="scratchpad-details" on:toggle={(e) => handleScratchpadToggle(e, run.run_id)}>
-                    <summary>Scratchpad</summary>
-                    <div class="scratchpad-content">
-                      {#if scratchpadLoading[run.run_id]}
-                        <p class="muted small-text">Loading scratchpad…</p>
-                      {:else if scratchpadContent[run.run_id]}
-                        <div class="scratchpad-rendered">{@html renderMarkdown(scratchpadContent[run.run_id])}</div>
-                      {:else if scratchpadContent[run.run_id] === null}
-                        <p class="muted small-text">No scratchpad available for this run.</p>
-                      {/if}
-                    </div>
-                  </details>
-
-                  {#if run.changed_files?.length}
-                    <details>
-                      <summary>Changed files</summary>
-                      <ul>
-                        {#each run.changed_files as path}<li>{path}</li>{/each}
-                      </ul>
-                    </details>
-                  {/if}
-
-                  {#if run.errors?.length}
-                    <details>
-                      <summary>Errors</summary>
-                      <ul>
-                        {#each run.errors as item}<li><strong>{item.code}</strong>: {item.message}</li>{/each}
-                      </ul>
-                    </details>
-                  {/if}
-                </article>
-              {/each}
-            </div>
-          {/if}
-        </section>
-      </aside>
     </div>
   {/if}
 </section>
 
 <style>
-  .execution-toolbar {
-    flex-wrap: wrap;
-    justify-content: flex-end;
-  }
-
-  .execute-summary-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-
-  .execute-layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1.35fr) minmax(360px, 0.95fr);
-    gap: 1rem;
-    align-items: start;
-  }
-
-  .execute-primary-column,
-  .execute-sidebar-column {
-    display: grid;
-    gap: 1rem;
-  }
-
-  .execute-sidebar-column {
-    position: sticky;
-    top: 1rem;
-  }
-
-  .dispatch-subgroup {
-    padding: 0.85rem;
-    background: rgba(15, 23, 42, 0.35);
-  }
-
-  .execute-node-card,
-  .execution-run-card,
-  .execute-sidebar-card {
-    background: rgba(2, 6, 23, 0.58);
-  }
-
-  .node-action-cluster,
-  .execute-card-actions {
+  /* Top bar */
+  .exec-topbar {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
     align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    flex-shrink: 0;
+    padding: 0 2px;
   }
 
-  .execution-context-row {
+  .exec-topbar-left {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+    align-items: center;
+    gap: 8px;
   }
 
-  .context-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    max-width: 100%;
-    padding: 0.45rem 0.65rem;
-    border-radius: 999px;
-    background: rgba(30, 41, 59, 0.9);
-    border: 1px solid rgba(148, 163, 184, 0.16);
-    color: #dbeafe;
+  .exec-stat {
+    font-size: 11px;
+    color: var(--text-muted, #566070);
+  }
+
+  .exec-stat.warn {
+    color: var(--red, #f85149);
+  }
+
+  /* Three-column layout */
+  .exec-columns {
+    display: grid;
+    grid-template-columns: 220px 300px minmax(0, 1fr);
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
   }
 
-  .context-chip code {
+  .exec-col-dispatch {
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    border-right: 1px solid var(--border, #2b3245);
+    padding: 6px;
+  }
+
+  .exec-col-details {
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    border-right: 1px solid var(--border, #2b3245);
+  }
+
+  .exec-col-workspace {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Run pill strip */
+  .run-pill-strip {
+    display: flex;
+    gap: 2px;
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border, #2b3245);
+    background: var(--bg-surface, #13171f);
+    overflow-x: auto;
+    overflow-y: hidden;
+    flex-shrink: 0;
+  }
+
+  .run-pill-strip::-webkit-scrollbar {
+    height: 3px;
+  }
+
+  .run-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm, 3px);
+    color: var(--text-secondary, #8b95a5);
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .run-pill:hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: var(--border, #2b3245);
+  }
+
+  .run-pill.active {
+    background: var(--accent-muted, rgba(37, 99, 235, 0.25));
+    border-color: rgba(37, 99, 235, 0.5);
+    color: var(--text-primary, #e2e8f0);
+  }
+
+  .run-pill-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted, #566070);
+    flex-shrink: 0;
+  }
+
+  .run-pill-dot.healthy { background: var(--green, #3fb950); }
+  .run-pill-dot.info { background: var(--accent, #2563eb); }
+  .run-pill-dot.disambiguating { background: var(--purple, #a371f7); }
+  .run-pill-dot.warn { background: var(--yellow, #d29922); }
+  .run-pill-dot.danger { background: var(--red, #f85149); }
+
+  .run-pill-label {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
-  .context-path {
-    max-width: 100%;
-  }
-
-  .context-label {
-    color: #93c5fd;
-    font-size: 0.78rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .safety-summary-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  .execute-scope-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .run-stat-grid {
+  /* Workspace top (header + expandable sections, scrollable if tall) */
+  .workspace-top {
+    flex-shrink: 0;
+    max-height: 45%;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 8px 8px 4px;
     display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.75rem;
+    gap: 6px;
+    border-bottom: 1px solid var(--border, #2b3245);
   }
 
-  .compact-stat {
+  /* Workspace feed (scrollable middle) */
+  .workspace-feed-scroll {
+    flex: 1;
     min-height: 0;
-  }
-
-  .run-list {
-    max-height: calc(100vh - 18rem);
-    overflow: auto;
-    padding-right: 0.25rem;
-  }
-
-  .run-context-row {
-    margin-top: -0.1rem;
-  }
-
-  .run-timestamp-grid {
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    padding: 6px 8px;
     display: grid;
-    gap: 0.2rem;
+    gap: 4px;
+    align-content: start;
   }
 
-  .run-progress-message {
+  /* Workspace input (pinned bottom) */
+  .workspace-input-pinned {
+    flex-shrink: 0;
+    padding: 6px 8px;
+    border-top: 1px solid var(--border, #2b3245);
+    display: grid;
+    gap: 4px;
+  }
+
+  .workspace-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .workspace-header h3 { margin: 0; font-size: 14px; }
+
+  .workspace-progress {
+    padding: 5px 8px;
+    border-radius: var(--radius-sm, 3px);
+    background: rgba(37, 99, 235, 0.1);
+    border: 1px solid rgba(37, 99, 235, 0.25);
+    color: #bfdbfe;
+    font-size: 12px;
+  }
+
+  .workspace-section {
+    display: grid;
+    gap: 6px;
+  }
+
+  .workspace-section-hdr {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .workspace-section-hdr h4 {
     margin: 0;
-  }
-
-  .activity-log-details {
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    border-radius: 8px;
-    overflow: hidden;
-  }
-
-  .activity-log-details summary {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-    background: rgba(15, 23, 42, 0.5);
-    color: #93c5fd;
-    user-select: none;
-  }
-
-  .activity-log {
-    max-height: 240px;
-    overflow-y: auto;
-    display: grid;
-    gap: 0;
-    font-size: 0.8rem;
-  }
-
-  .activity-entry {
-    display: grid;
-    grid-template-columns: 1.4em 5.2em 1fr;
-    gap: 0.35rem;
-    align-items: baseline;
-    padding: 0.25rem 0.75rem;
-    border-top: 1px solid rgba(148, 163, 184, 0.06);
-  }
-
-  .activity-entry:first-child {
-    border-top: none;
-  }
-
-  .activity-icon {
-    font-size: 0.75rem;
-    text-align: center;
-  }
-
-  .activity-time {
-    color: #64748b;
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-  }
-
-  .activity-message {
-    color: #e2e8f0;
-    word-break: break-word;
-  }
-
-  .activity-reasoning .activity-message {
-    color: #fde68a;
-    font-style: italic;
-  }
-
-  .activity-error .activity-message {
-    color: #fca5a5;
-  }
-
-  .activity-tool_start .activity-message,
-  .activity-tool_end .activity-message {
-    color: #93c5fd;
-  }
-
-  .activity-log-placeholder {
-    padding: 0.5rem 0;
-  }
-
-  /* Follow-up chat */
-  .follow-up-chat {
-    border: 1px solid rgba(148, 163, 184, 0.14);
-    border-radius: 8px;
-    overflow: hidden;
-    background: rgba(15, 23, 42, 0.45);
-  }
-
-  .follow-up-messages {
-    max-height: 200px;
-    overflow-y: auto;
-    padding: 0.5rem 0.65rem;
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  .follow-up-msg {
-    display: grid;
-    gap: 0.15rem;
-  }
-
-  .follow-up-role {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: 11px;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary, #8b95a5);
   }
 
-  .follow-up-user .follow-up-role {
-    color: #93c5fd;
+  .workspace-empty {
+    padding: 8px;
+    font-size: 11px;
   }
 
-  .follow-up-assistant .follow-up-role {
-    color: #86efac;
+  .workspace-empty.large {
+    min-height: 8rem;
+    display: grid;
+    place-items: center;
   }
 
-  .follow-up-time {
-    font-size: 0.7rem;
-    color: #64748b;
+  /* Unified feed */
+  .unified-feed {
+    display: grid;
+    gap: 2px;
   }
 
-  .follow-up-text {
-    font-size: 0.82rem;
-    color: #e2e8f0;
+  /* Chat entries — prominent */
+  .feed-chat {
+    display: grid;
+    gap: 2px;
+    padding: 6px 8px;
+    border-radius: var(--radius-sm, 3px);
+    border: 1px solid var(--border, #2b3245);
+    background: var(--bg-surface, #13171f);
+    font-size: 12px;
+  }
+
+  .feed-chat-assistant { border-color: rgba(63, 185, 80, 0.2); }
+  .feed-chat-user { border-color: rgba(37, 99, 235, 0.25); background: rgba(37, 99, 235, 0.06); }
+
+  .feed-chat-hdr { display: flex; justify-content: space-between; gap: 4px; }
+  .feed-chat-role { font-size: 10.5px; font-weight: 600; color: var(--text-secondary, #8b95a5); }
+  .feed-chat-ts { font-size: 10.5px; color: var(--text-muted, #566070); }
+
+  .feed-chat-body {
     white-space: pre-wrap;
     word-break: break-word;
-    max-height: 80px;
-    overflow-y: auto;
+    line-height: 1.5;
   }
 
-  .follow-up-input-row {
-    display: flex;
-    gap: 0.5rem;
-    padding: 0.5rem 0.65rem;
-    border-top: 1px solid rgba(148, 163, 184, 0.1);
-    align-items: flex-end;
-  }
-
-  .follow-up-input {
-    flex: 1;
-    resize: vertical;
-    min-height: 2.2rem;
-    max-height: 6rem;
-    padding: 0.45rem 0.6rem;
-    border-radius: 6px;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    background: rgba(2, 6, 23, 0.6);
-    color: #e2e8f0;
-    font-size: 0.85rem;
-    font-family: inherit;
-    line-height: 1.4;
-  }
-
-  .follow-up-input::placeholder {
-    color: #64748b;
-  }
-
-  .follow-up-input:focus {
-    outline: none;
-    border-color: rgba(96, 165, 250, 0.5);
-  }
-
-  .follow-up-send {
-    align-self: flex-end;
-    white-space: nowrap;
-  }
-
-  .ghost-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 10px;
-    padding: 0.7rem 1rem;
-    text-decoration: none;
-    background: rgba(15, 23, 42, 0.85);
-    border: 1px solid rgba(148, 163, 184, 0.18);
-    color: #e2e8f0;
-  }
-
-  .ghost-link.small {
-    padding: 0.35rem 0.7rem;
-    font-size: 0.875rem;
-  }
-
-  /* Disambiguation status pill */
-  .status-pill.disambiguating {
-    background: rgba(139, 92, 246, 0.85);
-    color: #ede9fe;
-    animation: pulse-disambiguating 2s ease-in-out infinite;
-  }
-
-  @keyframes pulse-disambiguating {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.7; }
-  }
-
-  /* Disambiguation chat styling */
-  .disambiguating-chat {
-    border-color: rgba(139, 92, 246, 0.35);
-    background: rgba(76, 29, 149, 0.12);
-  }
-
-  .disambiguation-banner {
-    display: flex;
-    gap: 0.65rem;
-    align-items: flex-start;
-    padding: 0.65rem 0.75rem;
-    background: rgba(139, 92, 246, 0.12);
-    border-bottom: 1px solid rgba(139, 92, 246, 0.2);
-  }
-
-  .disambiguation-icon {
-    font-size: 1.15rem;
-    line-height: 1;
-    flex-shrink: 0;
-    margin-top: 0.1rem;
-  }
-
-  .disambiguation-banner-text {
+  /* Activity entries — dimmed, compact, color-coded */
+  .feed-activity {
     display: grid;
-    gap: 0.2rem;
+    grid-template-columns: 3.2em 4.5em 1fr;
+    gap: 4px;
+    align-items: baseline;
+    padding: 2px 8px;
+    font-size: 11px;
+    opacity: 0.6;
+    transition: opacity 100ms;
   }
 
-  .disambiguation-banner-text strong {
-    color: #c4b5fd;
-    font-size: 0.88rem;
+  .feed-activity:hover {
+    opacity: 1;
   }
 
-  .disambiguation-banner-text span {
-    color: #a78bfa;
-    font-size: 0.78rem;
-    line-height: 1.4;
+  .feed-activity-kind {
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--activity-color);
   }
 
-  .disambiguation-messages {
-    max-height: 320px;
+  .feed-activity-ts {
+    font-size: 10px;
+    color: var(--text-muted, #566070);
   }
 
-  .disambiguation-waiting {
-    padding: 1rem 0.75rem;
-    text-align: center;
-    color: #a78bfa;
-    animation: pulse-disambiguating 2s ease-in-out infinite;
+  .feed-activity-msg {
+    color: var(--text-secondary, #8b95a5);
   }
 
-  .disambiguation-resolve-row {
+  /* Chat input area */
+  .feed-input-area {
     display: grid;
-    gap: 0.5rem;
-    padding: 0.65rem;
-    border-top: 1px solid rgba(139, 92, 246, 0.2);
-    background: rgba(139, 92, 246, 0.06);
+    gap: 4px;
+    padding-top: 4px;
+    border-top: 1px solid var(--border, #2b3245);
   }
 
-  .disambiguation-context-input {
-    width: 100%;
-    resize: vertical;
-    min-height: 2.2rem;
-    max-height: 6rem;
-    padding: 0.45rem 0.6rem;
-    border-radius: 6px;
-    border: 1px solid rgba(139, 92, 246, 0.25);
-    background: rgba(2, 6, 23, 0.6);
-    color: #e2e8f0;
-    font-size: 0.82rem;
-    font-family: inherit;
-    line-height: 1.4;
-    box-sizing: border-box;
+  .chat-input-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 4px;
+    align-items: end;
   }
 
-  .disambiguation-context-input::placeholder {
-    color: #7c3aed;
+  .disambig-banner {
+    display: grid;
+    gap: 2px;
+    padding: 5px 8px;
+    border-radius: var(--radius-sm, 3px);
+    background: rgba(163, 113, 247, 0.08);
+    border: 1px solid rgba(163, 113, 247, 0.2);
+    font-size: 12px;
   }
 
-  .disambiguation-context-input:focus {
-    outline: none;
-    border-color: rgba(139, 92, 246, 0.55);
+  /* Expandables */
+  .workspace-expandable {
+    padding: 6px 8px;
+    border: 1px solid var(--border, #2b3245);
+    border-radius: var(--radius-sm, 3px);
+    background: var(--bg-surface, #13171f);
+    font-size: 12px;
   }
 
-  .disambiguation-resolve-btn {
-    justify-self: end;
-    background: rgba(34, 197, 94, 0.15);
-    border: 1px solid rgba(34, 197, 94, 0.35);
-    color: #86efac;
-    padding: 0.5rem 1.2rem;
-    border-radius: 8px;
-    font-size: 0.88rem;
+  .workspace-expandable summary {
+    cursor: pointer;
     font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s, border-color 0.15s;
+    font-size: 11px;
+    color: var(--text-secondary, #8b95a5);
   }
 
-  .disambiguation-resolve-btn:hover:not(:disabled) {
-    background: rgba(34, 197, 94, 0.25);
-    border-color: rgba(34, 197, 94, 0.55);
+  .workspace-expandable pre {
+    margin: 4px 0 0;
+    white-space: pre-wrap;
+    line-height: 1.45;
+    font-size: 11px;
   }
 
-  .disambiguation-resolve-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .workspace-expandable ul {
+    margin: 4px 0 0;
+    padding-left: 14px;
+    font-size: 11px;
   }
 
-  .disambiguation-chat-btn {
-    border-color: rgba(139, 92, 246, 0.35) !important;
-    color: #c4b5fd !important;
-    background: rgba(139, 92, 246, 0.12) !important;
-  }
-
-  /* Scratchpad viewer */
-  .scratchpad-details {
-    border: 1px solid rgba(148, 163, 184, 0.12);
-    border-radius: 8px;
-    overflow: hidden;
-  }
-
-  .scratchpad-details summary {
-    padding: 0.5rem 0.75rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-    background: rgba(15, 23, 42, 0.5);
-    color: #93c5fd;
-    user-select: none;
-  }
-
-  .scratchpad-content {
-    padding: 0.5rem 0.75rem;
-  }
-
-  .scratchpad-rendered {
-    max-height: 400px;
-    overflow: auto;
-    font-size: 0.82rem;
-    line-height: 1.55;
-    color: #e2e8f0;
-    word-break: break-word;
-  }
+  .scratchpad-body { margin-top: 4px; }
 
   .scratchpad-rendered :global(h1),
   .scratchpad-rendered :global(h2),
-  .scratchpad-rendered :global(h3) {
-    margin: 0.6em 0 0.3em;
-    color: #93c5fd;
-    font-size: 0.92em;
-  }
-
-  .scratchpad-rendered :global(h1) {
-    font-size: 1.05em;
-  }
+  .scratchpad-rendered :global(h3) { margin: 6px 0 3px; }
 
   .scratchpad-rendered :global(ul),
-  .scratchpad-rendered :global(ol) {
-    margin: 0.3em 0;
-    padding-left: 1.4em;
-  }
+  .scratchpad-rendered :global(ol) { padding-left: 16px; }
 
-  .scratchpad-rendered :global(li) {
-    margin: 0.15em 0;
-  }
+  .scratchpad-rendered :global(code) { overflow-wrap: anywhere; }
 
-  .scratchpad-rendered :global(code) {
-    background: rgba(30, 41, 59, 0.8);
-    padding: 0.1em 0.35em;
-    border-radius: 4px;
-    font-size: 0.9em;
-  }
-
-  .scratchpad-rendered :global(pre) {
-    background: rgba(15, 23, 42, 0.7);
-    padding: 0.5rem 0.65rem;
-    border-radius: 6px;
-    overflow-x: auto;
-    font-size: 0.82em;
-    margin: 0.4em 0;
-  }
-
-  .scratchpad-rendered :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-
-  .scratchpad-rendered :global(p) {
-    margin: 0.35em 0;
-  }
-
-  .scratchpad-rendered :global(strong) {
-    color: #dbeafe;
-  }
-
-  .status-pill.info {
-    background: rgba(30, 64, 175, 0.9);
-    color: #dbeafe;
-  }
-
-  .status-pill.warn {
-    background: rgba(146, 64, 14, 0.9);
-    color: #fde68a;
-  }
-
-  .status-pill.danger {
-    background: rgba(127, 29, 29, 0.92);
-    color: #fecaca;
-  }
-
-  .execution-policy-note {
-    margin: 0;
-  }
-
+  /* Responsive */
   @media (max-width: 1100px) {
-    .execute-layout {
-      grid-template-columns: 1fr;
+    .exec-columns {
+      grid-template-columns: 200px minmax(0, 1fr);
     }
 
-    .execute-sidebar-column {
-      position: static;
-    }
-
-    .run-list {
-      max-height: none;
-      overflow: visible;
-      padding-right: 0;
+    .exec-col-details {
+      display: none;
     }
   }
 
-  @media (max-width: 820px) {
-    .execute-summary-grid,
-    .execute-scope-grid {
-      grid-template-columns: 1fr 1fr;
-    }
-  }
-
-  @media (max-width: 640px) {
-    .execute-summary-grid,
-    .execute-scope-grid,
-    .run-stat-grid {
+  @media (max-width: 860px) {
+    .exec-columns {
       grid-template-columns: 1fr;
+      overflow-y: auto;
     }
 
-    .dispatch-node-header {
-      flex-direction: column;
+    .exec-col-dispatch {
+      border-right: none;
+      border-bottom: 1px solid var(--border, #2b3245);
     }
   }
 </style>

--- a/web/src/components/ExecutionRunList.svelte
+++ b/web/src/components/ExecutionRunList.svelte
@@ -1,0 +1,144 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import ExecutionRunListItem from "./ExecutionRunListItem.svelte";
+
+  export let runs = [];
+  export let selectedRunId = null;
+  export let filter = "all";
+
+  const dispatch = createEventDispatcher();
+
+  const filters = [
+    { id: "all", label: "All" },
+    { id: "active", label: "Active" },
+    { id: "completed", label: "Done" },
+    { id: "failed", label: "Failed" },
+  ];
+
+  function matchesFilter(run, currentFilter) {
+    if (currentFilter === "active") {
+      return ["queued", "preparing", "running", "disambiguating"].includes(run.status);
+    }
+    if (currentFilter === "completed") {
+      return run.status === "completed";
+    }
+    if (currentFilter === "failed") {
+      return ["error", "blocked"].includes(run.status);
+    }
+    return true;
+  }
+
+  function countFor(currentFilter) {
+    return runs.filter((run) => matchesFilter(run, currentFilter)).length;
+  }
+
+  $: filteredRuns = runs.filter((run) => matchesFilter(run, filter));
+</script>
+
+<section class="run-list-section">
+  <div class="nav-section-header">
+    <h3>RUNS</h3>
+    <span class="nav-count">{runs.length}</span>
+  </div>
+
+  <div class="run-filter-tabs">
+    {#each filters as tab}
+      <button
+        class:selected={filter === tab.id}
+        class="run-filter-tab"
+        on:click={() => dispatch("changefilter", { filter: tab.id })}
+      >
+        {tab.label} <span class="filter-count">{countFor(tab.id)}</span>
+      </button>
+    {/each}
+  </div>
+
+  {#if filteredRuns.length === 0}
+    <div class="nav-empty muted">No runs match this filter.</div>
+  {:else}
+    <div class="run-list-items">
+      {#each filteredRuns as run}
+        <ExecutionRunListItem
+          {run}
+          selected={run.run_id === selectedRunId}
+          on:select={(event) => dispatch("select", event.detail)}
+        />
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .run-list-section {
+    display: grid;
+    gap: 4px;
+    align-content: start;
+  }
+
+  .nav-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px 2px;
+  }
+
+  .nav-section-header h3 {
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--text-secondary, #8b95a5);
+    letter-spacing: 0.08em;
+    margin: 0;
+  }
+
+  .nav-count {
+    font-size: 10.5px;
+    color: var(--text-muted, #566070);
+  }
+
+  .run-filter-tabs {
+    display: flex;
+    gap: 1px;
+    background: var(--border, #2b3245);
+    border-radius: var(--radius-sm, 3px);
+    overflow: hidden;
+  }
+
+  .run-filter-tab {
+    flex: 1;
+    display: inline-flex;
+    gap: 3px;
+    align-items: center;
+    justify-content: center;
+    padding: 3px 6px;
+    background: var(--bg-surface, #13171f);
+    color: var(--text-muted, #566070);
+    font-size: 10.5px;
+    font-weight: 600;
+    border-radius: 0;
+    border: none;
+  }
+
+  .run-filter-tab:hover {
+    background: var(--bg-raised, #1a1f2e);
+    color: var(--text-secondary, #8b95a5);
+  }
+
+  .run-filter-tab.selected {
+    background: var(--accent-muted, rgba(37, 99, 235, 0.25));
+    color: #bfdbfe;
+  }
+
+  .filter-count {
+    opacity: 0.7;
+  }
+
+  .run-list-items {
+    display: grid;
+    gap: 2px;
+  }
+
+  .nav-empty {
+    padding: 8px;
+    font-size: 11px;
+  }
+</style>

--- a/web/src/components/ExecutionRunListItem.svelte
+++ b/web/src/components/ExecutionRunListItem.svelte
@@ -1,0 +1,126 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let run;
+  export let selected = false;
+
+  const dispatch = createEventDispatcher();
+
+  function runStatusTone(status) {
+    if (status === "completed") return "healthy";
+    if (["running", "preparing", "queued"].includes(status)) return "info";
+    if (status === "disambiguating") return "disambiguating";
+    if (status === "blocked") return "warn";
+    if (status === "error") return "danger";
+    return "";
+  }
+
+  function formatUpdated(value) {
+    if (!value) return "";
+    try {
+      return new Date(value).toLocaleTimeString();
+    } catch {
+      return "";
+    }
+  }
+</script>
+
+<button class:selected class="run-item" on:click={() => dispatch("select", { run_id: run.run_id })}>
+  <div class="run-item-top">
+    <strong class="run-item-id">{run.work_item_id}</strong>
+    <span class="status-pill {runStatusTone(run.status)}">{run.status}</span>
+  </div>
+  <span class="run-item-name muted">{run.work_item_name}</span>
+  <div class="run-item-meta">
+    <code>{run.branch}</code>
+    {#if run.updated_at}<span>{formatUpdated(run.updated_at)}</span>{/if}
+  </div>
+  {#if run.pull_request || run.errors?.length || run.changed_files?.length}
+    <div class="run-item-badges">
+      {#if run.pull_request}<span class="mini-badge">PR #{run.pull_request.number}</span>{/if}
+      {#if run.errors?.length}<span class="mini-badge danger">{run.errors.length} err</span>{/if}
+      {#if run.changed_files?.length}<span class="mini-badge">{run.changed_files.length} files</span>{/if}
+    </div>
+  {/if}
+</button>
+
+<style>
+  .run-item {
+    width: 100%;
+    display: grid;
+    gap: 2px;
+    text-align: left;
+    padding: 5px 6px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm, 3px);
+    color: var(--text-primary, #e2e8f0);
+    font-size: 12px;
+  }
+
+  .run-item:hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: var(--border, #2b3245);
+  }
+
+  .run-item.selected {
+    background: var(--accent-muted, rgba(37, 99, 235, 0.25));
+    border-color: rgba(37, 99, 235, 0.5);
+  }
+
+  .run-item-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    align-items: center;
+  }
+
+  .run-item-id {
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .run-item-name {
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .run-item-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 4px;
+    font-size: 10.5px;
+    color: var(--text-muted, #566070);
+  }
+
+  .run-item-meta code {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 10.5px;
+  }
+
+  .run-item-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px;
+  }
+
+  .mini-badge {
+    display: inline-flex;
+    padding: 0 4px;
+    border-radius: 2px;
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--text-muted, #566070);
+    font-size: 10px;
+  }
+
+  .mini-badge.danger {
+    color: #fca5a5;
+    background: rgba(248, 81, 73, 0.1);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Restructures the execution panel into a three-column layout: dispatch queue (left), consolidated details/context (middle), workspace with run pill selector and unified feed (right)
- Unifies activity log and chat history into a single chronological event stream with `agent_message` and `user_message` entry kinds
- Adds turn-colored bands, collapsible long messages, and pinned summary cards to the workspace feed

## Changes

### Backend
- **`types.ts`**: Add `agent_message` and `user_message` to `ActivityLogEntryKind`
- **`execution.service.ts`**: Remove separate `chatHistories` Map, store full message text in activity_log, derive chat API from activity_log filtering, remove 50-entry activity log cap, chat history now persists to `status.json`

### Frontend
- **`ExecutionDispatchPanel.svelte`**: Three-column layout (220px dispatch / 300px details / flex workspace), run pill selector, unified feed grouped by turn with color bands, collapsible agent messages (>6 lines), auto-scroll to bottom, pinned result/files/errors cards at feed end
- **`ExecutionDetailPane.svelte`**: Consolidated context column with branch/worktree/timeline/PR/scratchpad/safety sections
- **`ExecutionDispatchList.svelte`** + **`ExecutionDispatchListItem.svelte`**: Dispatch queue sub-components
- **`ExecutionRunList.svelte`** + **`ExecutionRunListItem.svelte`**: Run list sub-components (currently unused — runs rendered as pills)
- **`ExecutionContextSidebar.svelte`**: Context sidebar (unused, kept for reference)
- **`app.css`**: Execution panel uses flex column layout, status pill variants

## Test plan
- [ ] Launch a dispatch candidate — verify run appears as pill, feed populates in real-time
- [ ] During disambiguation, verify chat input works and agent responses appear in feed
- [ ] Verify turn bands alternate colors between turns
- [ ] Verify long agent messages collapse with "Show full message" link
- [ ] Click between run pills — workspace switches, details column updates
- [ ] Click dispatch candidates — details column shows scope/safety/context
- [ ] Verify scratchpad loads in details column on toggle
- [ ] Completed runs show result summary and changed files as pinned cards at feed bottom
- [ ] Verify scroll containment — feed scrolls independently, input stays pinned