### PR TITLE
[#142] Studio: visually indicate frontier nodes in the graph with non-conflicting styling

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,24 +1,19 @@
-# Scratchpad: studio-90 — Studio: auto-staged graph proposals can use stale placeholder work item IDs after GitHub assigns final issue numbers
+# Scratchpad: studio-142 — Studio: visually indicate frontier nodes in the graph with non-conflicting styling
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/90
-- **Branch:** studio-90-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/142
+- **Branch:** studio-142-branch
 - **Base ref:** develop
-- **Scope hint:** Fix auto-staged graph proposals so issue-backed IDs are rewritten to the actual GitHub issue number returned by GitHub before proposal staging and child references are generated.
-- **Created:** 2026-04-08T20:29:59.289Z
-
-## Summary
-- The failing path is `github_create_issue` in `src/modules/planning/planning.service.ts`: it creates the GitHub issue first, but then still trusts the caller-supplied `work_item_id` when staging the `create_work_item` mutation. If the caller guessed `studio-82` and GitHub returned `#83`, the proposal ends up with a misaligned issue-backed ID and fails graph validation.
-- That same auto-staging flow also builds `create_edge` mutations from `parent_id` / `depends_on_ids`, so grouped epic + child creation in one turn can accumulate edges that still point at placeholder IDs instead of the final canonical `studio-{issue_number}` ID.
-- The fix should canonicalize issue-backed IDs from the actual GitHub issue number before staging the proposal, then rewrite related parent/dependency references so all staged mutations consistently reference the final aligned ID.
+- **Scope hint:** Add a non-conflicting visual indicator for frontier/dispatchable graph nodes, potentially using diagonal striping.
+- **Created:** 2026-04-09T02:40:58.965Z
 
 ## File Ownership
 
 ### Owned
-- web/src/lib/api.js
-- src/modules/git
-- README.md
+- web/src/app.css
+- web/src/lib/graph.js
+- web/src/components/GraphView.svelte
 
 ### Shared
 - (none)
@@ -27,52 +22,68 @@
 - docs/contracts/github-sync.md
 - docs/contracts/run-artifacts.md
 - src/modules/execution
+- src/modules/github
+- src/modules/graph
+- src/modules/planning
 - src/modules/settings
-- web/src/App.svelte
 - web/src/components/ExecutionDispatchPanel.svelte
-- web/src/components/GraphView.svelte
+- web/src/components/PlannerChatAdapter.svelte
 - web/src/components/SettingsPanel.svelte
 - web/src/components/Sidebar.svelte
 - web/src/lib/api.js
 
+## Summary
+The planning graph is rendered as an SVG via `web/src/components/GraphView.svelte`, with node visuals created in `web/src/lib/graph.js`. Today, node fill color communicates work-item state, while selection and hover are both expressed through node stroke changes on the rendered `<rect>`. The issue asks for frontier / dispatchable nodes to gain an additional visual treatment that remains readable without colliding with those existing selection and hover affordances.
+
+Based on the current implementation surface, a non-stroke treatment such as a subtle diagonal stripe overlay is the right direction because selection and hover already consume stroke color/width. However, the current graph renderer appears to set node styles inline and does not expose any frontier-specific class or data attribute in the SVG output, so I do not currently see a CSS-only hook that would let `web/src/app.css` distinguish frontier nodes from non-frontier nodes.
+
 ## Acceptance Criteria
-- [x] After GitHub creates an issue, the staged graph proposal uses the actual assigned GitHub issue number to derive the issue-backed work item ID.
-- [x] For issue-backed items created through auto-staging, `entity_id` / graph work item ID always aligns with `issue_number`.
-- [x] Epic/child and dependency relationships created during grouped issue flows reference the final aligned parent ID, not a pre-creation placeholder ID.
-- [x] Multi-issue auto-staged proposals do not accumulate invalid child/dependency references when placeholder IDs differ from the final GitHub issue number.
-- [x] Regression coverage exists for epic + child issue creation flows that previously produced misaligned IDs or missing-parent validation failures.
+- [x] Frontier nodes are visually distinguishable in the graph.
+- [x] The styling does not conflict with selected-node highlighting.
+- [x] Hover, selected, and frontier states compose cleanly.
+- [ ] If diagonal striping is used, it remains legible at the current node sizes and density. (Needs human visual spot-check.)
 
 ## Implementation Plan
-- [x] Update `src/modules/planning/planning.service.ts` so `github_create_issue` always derives the staged issue-backed work item ID from `created.number` (reusing the graph ID convention helper), rewrites the `create_work_item` mutation's `entity_id` and `payload.id`, and never stages the pre-creation placeholder ID after GitHub responds.
-- [x] Extend `src/modules/planning/planning.service.ts` with same-turn placeholder-to-final ID resolution for accumulated multi-issue proposals so `parent_id` and `depends_on_ids` are rewritten to the final aligned IDs before `create_edge` mutations are staged.
-- [x] Add focused regression tests in `src/modules/planning/__tests__/planning.service.test.ts` for: (1) single issue creation where requested `work_item_id` and returned issue number differ, (2) epic + child creation where the child references the parent's placeholder ID, and (3) dependency references in grouped proposals use the rewritten final ID.
-- [x] Verify with `npm run check` and targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` (plus full `npm test` if the worktree environment allows it), then record any environment-related test limitations in this scratchpad.
+- [x] Confirm the available styling hooks for graph nodes and determine whether frontier membership is already exposed to the DOM; if not, request ownership expansion because the current SVG node output in `web/src/lib/graph.js` does not appear to expose a frontier-specific selector. Files: `SCRATCHPAD.md` (tracking), context reads in `web/src/lib/graph.js`, `web/src/components/GraphView.svelte`, `web/src/app.css`.
+- [x] Define the intended frontier treatment in `web/src/app.css` so it layers with existing state fill colors and leaves stroke-based hover/selection intact; prefer an interior overlay/pattern treatment over a new border treatment.
+- [x] Pending ownership expansion, add the frontier hook where graph nodes are rendered so CSS can target dispatchable items cleanly without relying on brittle DOM assumptions. Files likely required: `web/src/lib/graph.js`; possibly `web/src/components/GraphView.svelte` if the graph legend also needs a frontier entry.
+- [ ] Verify the composed states visually in the planning graph: frontier only, frontier + hover, frontier + selected, and dense-node readability at current graph zoom/size. Files: `web/src/app.css` plus manual browser verification. **Blocked:** no browser session is available in this harness for an actual visual spot-check.
 
 ## Affected Files
-- `src/modules/planning/planning.service.ts` — canonicalize issue-backed IDs after GitHub issue creation, track placeholder-to-final aliases during proposal accumulation, and ensure staged edges reference final aligned IDs.
-- `src/modules/planning/__tests__/planning.service.test.ts` — add regression coverage for placeholder-ID rewriting and grouped epic/child creation flows.
+- `SCRATCHPAD.md` — setup notes, scope understanding, implementation plan, and execution log.
+- `web/src/app.css` — frontier overlay styling, hover/selected composition rules, and legend swatch styling.
+- `web/src/lib/graph.js` — frontier-aware node classification, stripe pattern definition, overlay rect rendering, selected class toggling, and tooltip metadata.
+- `web/src/components/GraphView.svelte` — fetch current frontier IDs, pass them to the renderer, and add a legend entry for frontier nodes.
 
 ## Quality Checks
 - [x] TypeScript compilation passes (`npm run check`)
-- [ ] Tests pass (`npm test`) — targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` passed, but full `npm test` is blocked by missing `better-sqlite3` native bindings in existing graph tests in this worktree.
-- [x] Build succeeds (`npm run build:web`)
+- [ ] Tests pass (`npm test`) — blocked by missing `better-sqlite3` native bindings in existing graph tests in this worktree.
+- [x] Build succeeds (`npm run build:web`) — build completed with pre-existing Svelte accessibility / unused-selector warnings in forbidden files.
 
 ## Questions / Concerns
-- Assumption: for `github_create_issue`, any caller-supplied `work_item_id` is only a pre-creation hint and may be silently canonicalized to `studio-${created.number}` once GitHub returns the real issue number. That matches the issue scope and existing graph validation rules.
-- No other blockers found from the current code surface.
-- Everything else is clear.
+- Ownership expansion resolved the renderer-hook concern.
+- Remaining limitation: I can validate structure/build behavior from the harness, but I cannot perform an actual browser-eye visual check here. A quick human spot-check in Studio is still recommended.
 
 ## Work Log
 
-### 2026-04-08 - Setup
+### 2026-04-09 - Setup
 - Scratchpad created by Studio execution service
-- Branch: studio-90-branch
-- Reviewed the `github_create_issue` auto-staging path in `src/modules/planning/planning.service.ts` plus graph ID-alignment validation in `src/modules/graph/types.ts` / `src/modules/graph/graph-writer.service.ts` to scope the fix and test surface.
-- Implemented the first fix in `src/modules/planning/planning.service.ts`: auto-staged issue-backed work items now derive their staged ID from `deriveIssueWorkItemId(created.number)` instead of trusting a stale pre-creation `work_item_id` hint.
-- Extended `src/modules/planning/planning.service.ts` with turn-scoped placeholder→final ID alias tracking so grouped `github_create_issue` flows rewrite `parent_id`, `depends_on_ids`, and previously accumulated proposal references to the final canonical issue-backed IDs.
-- Added `src/modules/planning/__tests__/planning.service.test.ts` with regression coverage for mismatched placeholder IDs, epic/child parent rewrites, dependency rewrites, and the case where a later issue creation retroactively fixes an earlier accumulated child reference.
-- Verified the change with `npm run check` ✅, `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` ✅, and `npm run build:web` ✅. Full `npm test` still fails in pre-existing graph tests because this worktree is missing `better-sqlite3` native bindings.
-- Completion summary: `github_create_issue` now stages issue-backed work items with canonical IDs derived from the actual GitHub issue number, grouped proposal edges resolve placeholder parent/dependency IDs to the final canonical IDs, and regression coverage now protects the previously failing multi-issue proposal paths.
+- Branch: studio-142-branch
+- Reviewed `web/src/app.css`, `web/src/components/GraphView.svelte`, `web/src/lib/graph.js`, `web/src/App.svelte`, and supporting graph API/backend files for frontier data flow.
+- Identified a likely scope/ownership mismatch: the requested behavior appears to require a renderer/data hook outside the owned stylesheet.
+
+### 2026-04-09 - Coding
+- Confirmed the graph renderer did not initially emit a frontier-specific class, id, data attribute, or pattern definition that stylesheet-only work could target.
+- Added initial frontier styling hooks to `web/src/app.css` for a non-stroke glow plus diagonal-stripe overlay/legend treatment designed to compose with hover and selection stroke states.
+- Ran `npm run check` ✅, `npm test` ❌ (environmental failure: missing `better-sqlite3` native bindings in existing graph tests), and `npm run build:web` ✅ (with pre-existing warnings in forbidden Svelte files).
+- Created commit `ca23d4d` — `style(graph): scaffold frontier node styling hooks`.
+- After ownership expansion, updated `web/src/lib/graph.js` to classify frontier nodes, define a diagonal stripe SVG pattern, render inset overlay rects, and preserve selected-node stroke highlighting.
+- Updated `web/src/components/GraphView.svelte` to fetch `/api/frontier`, intersect with currently visible graph items, pass frontier IDs into the renderer, and expose a legend row for frontier nodes.
+- Refined `web/src/app.css` so the overlay stays interior to the node and composes with hover/selection.
+- Re-ran `npm run check` ✅, `npm test` ❌ (same pre-existing `better-sqlite3` binding failure), and `npm run build:web` ✅ (same pre-existing warnings in forbidden Svelte files).
+- Created commit `199de3a` — `feat(graph): highlight frontier nodes in the graph`.
+- Final status: implementation is complete in code and builds successfully; remaining follow-up is a quick in-browser visual spot-check for stripe legibility at real graph density.
 
 ## Blockers
-- Full `npm test` is blocked by missing `better-sqlite3` native bindings in this worktree (`Could not locate the bindings file` from existing `src/modules/graph/__tests__/graph-writer.service.test.ts`).
+- Manual visual spot-check is still pending because this harness does not provide a browser session for interactive verification.
+- `npm test` remains blocked by missing `better-sqlite3` native bindings in existing graph tests in this worktree.

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -245,10 +245,8 @@ a:hover {
   --graph-frontier-glow: rgba(240, 246, 252, 0.16);
 }
 
-/* Frontier styling is intentionally hook-based so it composes with the
-   graph renderer's existing state fill plus hover/selection stroke affordances.
-   The current renderer does not yet expose a frontier selector or SVG pattern
-   definition, so these rules are dormant until that hook exists. */
+/* Frontier styling uses an interior overlay so it composes with the graph
+   renderer's existing state fill plus hover/selection stroke affordances. */
 .graph-canvas .node.graph-node--frontier,
 .graph-canvas .node.frontier,
 .graph-canvas .node[data-frontier="true"] {
@@ -265,6 +263,7 @@ a:hover {
 .graph-canvas .node.frontier .frontier-overlay,
 .graph-canvas .node[data-frontier="true"] .frontier-overlay {
   fill: url("#graph-frontier-diagonal-stripes");
+  stroke: none;
   opacity: 0.34;
   pointer-events: none;
 }
@@ -286,7 +285,7 @@ a:hover {
   background-color: rgba(88, 166, 255, 0.24);
   background-image: repeating-linear-gradient(
     135deg,
-    var(--graph-frontier-stripe-color) 0 2px,
+    var(--graph-frontier-stripe-color, rgba(240, 246, 252, 0.24)) 0 2px,
     transparent 2px 6px
   );
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -241,6 +241,54 @@ a:hover {
   min-height: 0;
   border-radius: var(--radius-md);
   background: rgba(13, 17, 23, 0.9);
+  --graph-frontier-stripe-color: rgba(240, 246, 252, 0.24);
+  --graph-frontier-glow: rgba(240, 246, 252, 0.16);
+}
+
+/* Frontier styling is intentionally hook-based so it composes with the
+   graph renderer's existing state fill plus hover/selection stroke affordances.
+   The current renderer does not yet expose a frontier selector or SVG pattern
+   definition, so these rules are dormant until that hook exists. */
+.graph-canvas .node.graph-node--frontier,
+.graph-canvas .node.frontier,
+.graph-canvas .node[data-frontier="true"] {
+  filter: drop-shadow(0 0 0.35rem var(--graph-frontier-glow));
+}
+
+.graph-canvas .node.graph-node--frontier rect,
+.graph-canvas .node.frontier rect,
+.graph-canvas .node[data-frontier="true"] rect {
+  shape-rendering: geometricPrecision;
+}
+
+.graph-canvas .node.graph-node--frontier .frontier-overlay,
+.graph-canvas .node.frontier .frontier-overlay,
+.graph-canvas .node[data-frontier="true"] .frontier-overlay {
+  fill: url("#graph-frontier-diagonal-stripes");
+  opacity: 0.34;
+  pointer-events: none;
+}
+
+.graph-canvas .node.graph-node--frontier.selected .frontier-overlay,
+.graph-canvas .node.frontier.selected .frontier-overlay,
+.graph-canvas .node[data-frontier="true"].selected .frontier-overlay {
+  opacity: 0.26;
+}
+
+.graph-canvas .node.graph-node--frontier:hover .frontier-overlay,
+.graph-canvas .node.frontier:hover .frontier-overlay,
+.graph-canvas .node[data-frontier="true"]:hover .frontier-overlay {
+  opacity: 0.4;
+}
+
+.graph-legend .legend-swatch.frontier {
+  border: 1px solid rgba(240, 246, 252, 0.28);
+  background-color: rgba(88, 166, 255, 0.24);
+  background-image: repeating-linear-gradient(
+    135deg,
+    var(--graph-frontier-stripe-color) 0 2px,
+    transparent 2px 6px
+  );
 }
 
 /* ── Sidebar (node editor) ── */

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -10,17 +10,55 @@
   let handle = { cleanup() {}, updateSelection() {}, resize() {} };
   let resizeObserver;
   let prevGraph = null;
+  let prevFrontierSignature = "";
   let mounted = false;
+  let frontierIds = [];
+  let frontierSignature = "";
+  let frontierLookupToken = 0;
 
   function fullRedraw() {
     handle.cleanup();
-    handle = renderGraph(svg, graph, selectedId, onSelect);
+    handle = renderGraph(svg, graph, selectedId, onSelect, { frontierIds });
     prevGraph = graph;
+    prevFrontierSignature = frontierSignature;
   }
 
-  // Mount + graph data changes → full re-layout
+  async function loadFrontier(currentGraph) {
+    const token = ++frontierLookupToken;
+    frontierIds = [];
+    frontierSignature = "";
+    if (!currentGraph?.items?.length) {
+      return;
+    }
+
+    const params = new URLSearchParams();
+    const repo = currentGraph.filters?.repo;
+    if (repo) params.set("repo", repo);
+
+    try {
+      const response = await fetch(`/api/frontier${params.toString() ? `?${params.toString()}` : ""}`);
+      if (!response.ok) throw new Error(`Failed to load frontier: ${response.status}`);
+      const frontier = await response.json();
+      if (token !== frontierLookupToken) return;
+      const visibleIds = new Set(currentGraph.items.map((item) => item.id));
+      frontierIds = frontier
+        .map((item) => item.id)
+        .filter((id) => visibleIds.has(id))
+        .sort();
+      frontierSignature = frontierIds.join("|");
+    } catch (error) {
+      if (token !== frontierLookupToken) return;
+      console.warn("Failed to load frontier graph styling data", error);
+      frontierIds = [];
+      frontierSignature = "";
+    }
+  }
+
+  $: void loadFrontier(graph);
+
+  // Mount + graph/frontier data changes → full re-layout
   $: if (svg && graph) {
-    if (!mounted || graph !== prevGraph) {
+    if (!mounted || graph !== prevGraph || frontierSignature !== prevFrontierSignature) {
       mounted = true;
       fullRedraw();
     }
@@ -59,6 +97,7 @@
         <div class="legend-row"><span class="legend-swatch" style="background:#d29922"></span><code>in_progress</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#a371f7"></span><code>open_pr</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#58a6ff"></span><code>planned</code></div>
+        <div class="legend-row"><span class="legend-swatch frontier"></span><code>frontier</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#8b949e"></span><code>deferred</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#f85149"></span><code>cancelled</code></div>
       </div>

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -79,6 +79,7 @@ function buildTooltipHtml(data, links) {
   let body = `<div style="font-weight:600;color:#e6edf3;margin-bottom:4px;">${data.id}: ${data.name}</div>`;
   body += `<div style="color:#8b949e;margin:2px 0;">Kind: <span style="color:#c9d1d9">${data.kind}</span></div>`;
   body += `<div style="color:#8b949e;margin:2px 0;">State: <span style="color:#c9d1d9">${data.state}</span></div>`;
+  if (data._isFrontier) body += `<div style="color:#8b949e;margin:2px 0;">Frontier: <span style="color:#c9d1d9">dispatchable</span></div>`;
   body += `<div style="color:#8b949e;margin:2px 0;">Edges: <span style="color:#c9d1d9">${inbound} in / ${outbound} out</span></div>`;
   if (data.issue_number) body += `<div style="color:#8b949e;margin:2px 0;">Issue: <span style="color:#c9d1d9">#${data.issue_number}</span></div>`;
   if (data.repo) body += `<div style="color:#8b949e;margin:2px 0;">Repo: <span style="color:#c9d1d9">${data.repo}</span></div>`;
@@ -122,6 +123,8 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     }
   }
 
+  const frontierIds = new Set(options.frontierIds ?? []);
+
   const nodes = graph.items.map((item) => {
     const node = { ...item };
     if (!extractPullRequest(node) && runPrByWorkItem.has(node.id)) {
@@ -129,6 +132,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     }
     node._pr = extractPullRequest(node);
     node._prStatus = classifyPrStatus(node._pr);
+    node._isFrontier = frontierIds.has(node.id);
     return node;
   });
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
@@ -152,6 +156,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     const isSelected = node.id === selectedId;
     g.setNode(node.id, {
       label: node.id,
+      class: node._isFrontier ? "graph-node--frontier" : "graph-node",
       style: `fill: ${color}; stroke: ${isSelected ? "#e6edf3" : "rgba(255,255,255,0.15)"}; stroke-width: ${isSelected ? "2.5px" : "1px"};`,
       labelStyle: "fill: #fff; font-size: 11px; font-weight: 500;",
       rx: 5, ry: 5,
@@ -202,6 +207,26 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       .attr("opacity", 0.8);
   }
 
+  const frontierPattern = defs.append("pattern")
+    .attr("id", "graph-frontier-diagonal-stripes")
+    .attr("patternUnits", "userSpaceOnUse")
+    .attr("width", 8)
+    .attr("height", 8)
+    .attr("patternTransform", "rotate(135)");
+
+  frontierPattern.append("rect")
+    .attr("width", 8)
+    .attr("height", 8)
+    .attr("fill", "transparent");
+
+  frontierPattern.append("line")
+    .attr("x1", 0)
+    .attr("y1", 0)
+    .attr("x2", 0)
+    .attr("y2", 8)
+    .attr("stroke", "rgba(240, 246, 252, 0.92)")
+    .attr("stroke-width", 2);
+
   // Swap marker-end to marker-start on all edge paths
   inner.selectAll("g.edgePath path.path").each(function () {
     const path = d3.select(this);
@@ -245,22 +270,49 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     }
   }
 
-  // Post-render: merged PR badges
+  // Post-render: frontier overlays + merged PR badges
   inner.selectAll("g.node").each(function (id) {
+    const nodeGroup = d3.select(this);
     const data = g.node(id)?._data;
-    if (!data || data._prStatus !== "merged" || data.state !== "done") return;
-    const bbox = d3.select(this).select("rect").node()?.getBBox();
-    if (bbox) {
-      d3.select(this).append("text")
-        .text("✓PR")
-        .attr("x", bbox.x + bbox.width / 2)
-        .attr("y", bbox.y + bbox.height + 12)
-        .attr("text-anchor", "middle")
-        .attr("fill", PR_MERGED_RING_COLOR)
-        .attr("font-size", "9px")
-        .attr("font-weight", "600")
-        .attr("pointer-events", "none");
+    if (!data) return;
+
+    nodeGroup
+      .classed("selected", data.id === selectedId)
+      .attr("data-frontier", data._isFrontier ? "true" : "false");
+
+    const baseRect = nodeGroup.select("rect");
+    const rectNode = baseRect.node();
+    if (data._isFrontier && rectNode) {
+      const x = Number(baseRect.attr("x"));
+      const y = Number(baseRect.attr("y"));
+      const width = Number(baseRect.attr("width"));
+      const height = Number(baseRect.attr("height"));
+      const rx = Number(baseRect.attr("rx") || 0);
+      const ry = Number(baseRect.attr("ry") || 0);
+      const inset = Math.min(1.5, width / 6, height / 6);
+
+      nodeGroup.insert("rect", "g.label")
+        .attr("class", "frontier-overlay")
+        .attr("fill", "url(#graph-frontier-diagonal-stripes)")
+        .attr("x", x + inset)
+        .attr("y", y + inset)
+        .attr("width", Math.max(0, width - inset * 2))
+        .attr("height", Math.max(0, height - inset * 2))
+        .attr("rx", Math.max(0, rx - inset / 2))
+        .attr("ry", Math.max(0, ry - inset / 2));
     }
+
+    if (data._prStatus !== "merged" || data.state !== "done" || !rectNode) return;
+    const bbox = rectNode.getBBox();
+    nodeGroup.append("text")
+      .text("✓PR")
+      .attr("x", bbox.x + bbox.width / 2)
+      .attr("y", bbox.y + bbox.height + 12)
+      .attr("text-anchor", "middle")
+      .attr("fill", PR_MERGED_RING_COLOR)
+      .attr("font-size", "9px")
+      .attr("font-weight", "600")
+      .attr("pointer-events", "none");
   });
 
   // Node interactions
@@ -319,7 +371,9 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       const data = g.node(nodeId)?._data;
       if (!data) return;
       const sel = data.id === newSelectedId;
-      d3.select(this).select("rect")
+      d3.select(this)
+        .classed("selected", sel)
+        .select("rect")
         .style("stroke", sel ? "#e6edf3" : "rgba(255,255,255,0.15)")
         .style("stroke-width", sel ? "2.5px" : "1px");
     });


### PR DESCRIPTION
## Summary
Completed the implementation, with one remaining manual follow-up.

### What I changed

- `web/src/lib/graph.js`
  - Added frontier-aware node rendering.
  - Accepts `frontierIds` from the view layer.
  - Marks frontier nodes with a stable class/data attribute.
  - Defines an SVG diagonal-stripe pattern.
  - Renders an inset `frontier-overlay` rect so selection/hover stroke remains visible.
  - Adds frontier status to node tooltips.
  - Preserves selected-node highlighting via `.selected` class updates.

- `web/src/components/GraphView.svelte`
  - Fetches `/api/frontier` directly.
  - Intersects frontier IDs with currently visible graph items.
  - Passes frontier IDs into `renderGraph(...)`.
  - Adds a frontier entry to the graph legend.

- `web/src/app.css`
  - Added frontier overlay styling and glow treatment.
  - Kept the frontier treatment interior to the node so it composes with existing hover/selected stroke behavior.
  - Added legend swatch styling for frontier nodes.

### Commits

- `ca23d4d` — `style(graph): scaffold frontier node styling hooks`
- `199de3a` — `feat(graph): highlight frontier nodes in the graph`

### Checks run

Final checks:
- `npm run check` — ✅ passed
- `npm test` — ❌ failed due pre-existing environment issue:
  - missing `better-sqlite3` native bindings in existing graph tests
- `npm run build:web` — ✅ passed

Build warnings:
- `npm run build:web` emits pre-existing Svelte warnings in forbidden files (`App.svelte`, `PlannerChatAdapter.svelte`, `ExecutionDispatchPanel.svelte`), but build succeeds.

### Remaining blockers / follow-up

- Manual visual verification is still recommended:
  - confirm stripe legibility at real graph density
  - confirm hover + selected + frontier composition looks right in-browser
- Automated tests remain blocked by the worktree’s missing `better-sqlite3` native binding, unrelated to this change.

actual_files synced: 1 file(s).

## Context
- Work item: studio-142
- Issue: https://github.com/fusupo/escapement-studio/issues/142
- Base branch: develop
- Head branch: studio-142-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775702458965
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-142-branch
- Scope hint: Add a non-conflicting visual indicator for frontier/dispatchable graph nodes, potentially using diagonal striping.

## Changed files
- `SCRATCHPAD.md`