### PR TITLE
[#141] Studio: only allow launch execution actions for frontier nodes

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,24 +1,24 @@
-# Scratchpad: studio-90 — Studio: auto-staged graph proposals can use stale placeholder work item IDs after GitHub assigns final issue numbers
+# Scratchpad: studio-141 — Studio: only allow launch execution actions for frontier nodes
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/90
-- **Branch:** studio-90-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/141
+- **Branch:** studio-141-branch
 - **Base ref:** develop
-- **Scope hint:** Fix auto-staged graph proposals so issue-backed IDs are rewritten to the actual GitHub issue number returned by GitHub before proposal staging and child references are generated.
-- **Created:** 2026-04-08T20:29:59.289Z
+- **Scope hint:** Gate launch-execution actions from graph nodes and node details so they are only available for frontier/dispatchable work items.
+- **Created:** 2026-04-09T02:43:27.481Z
 
 ## Summary
-- The failing path is `github_create_issue` in `src/modules/planning/planning.service.ts`: it creates the GitHub issue first, but then still trusts the caller-supplied `work_item_id` when staging the `create_work_item` mutation. If the caller guessed `studio-82` and GitHub returned `#83`, the proposal ends up with a misaligned issue-backed ID and fails graph validation.
-- That same auto-staging flow also builds `create_edge` mutations from `parent_id` / `depends_on_ids`, so grouped epic + child creation in one turn can accumulate edges that still point at placeholder IDs instead of the final canonical `studio-{issue_number}` ID.
-- The fix should canonicalize issue-backed IDs from the actual GitHub issue number before staging the proposal, then rewrite related parent/dependency references so all staged mutations consistently reference the final aligned ID.
+The current execution launch path is already partially frontier-gated in `src/modules/execution/execution.service.ts`: `launch()` only accepts work items that appear in the dispatch preview, and blocked launches produce a `not_dispatchable` result. However, that eligibility is implicit inside the execution module and the planning UI does not currently expose a shared per-node eligibility model.
+
+The implementation should centralize launch-eligibility evaluation in the execution module so the same rules are used everywhere: the work item must be currently dispatchable from the frontier and pass existing execution safety checks. The planning graph surfaces that expose launch actions (graph node context menu and selected-node details panel) should consume that shared result instead of re-implementing frontier checks in the browser.
+
+During coding, the user clarified that gating should be based on **frontier membership**. The shared execution path and the planning UI should therefore align on dispatchability/frontier status rather than an additional issue-backed restriction.
 
 ## File Ownership
 
 ### Owned
-- web/src/lib/api.js
-- src/modules/git
-- README.md
+- (none predicted)
 
 ### Shared
 - (none)
@@ -26,53 +26,70 @@
 ### Forbidden
 - docs/contracts/github-sync.md
 - docs/contracts/run-artifacts.md
-- src/modules/execution
+- src/modules/github
+- src/modules/graph
 - src/modules/settings
-- web/src/App.svelte
+- web/src/app.css
+- web/src/components
 - web/src/components/ExecutionDispatchPanel.svelte
-- web/src/components/GraphView.svelte
+- web/src/components/PlannerChatAdapter.svelte
 - web/src/components/SettingsPanel.svelte
-- web/src/components/Sidebar.svelte
 - web/src/lib/api.js
+- web/src/lib/graph.js
 
 ## Acceptance Criteria
-- [x] After GitHub creates an issue, the staged graph proposal uses the actual assigned GitHub issue number to derive the issue-backed work item ID.
-- [x] For issue-backed items created through auto-staging, `entity_id` / graph work item ID always aligns with `issue_number`.
-- [x] Epic/child and dependency relationships created during grouped issue flows reference the final aligned parent ID, not a pre-creation placeholder ID.
-- [x] Multi-issue auto-staged proposals do not accumulate invalid child/dependency references when placeholder IDs differ from the final GitHub issue number.
-- [x] Regression coverage exists for epic + child issue creation flows that previously produced misaligned IDs or missing-parent validation failures.
+- [x] Graph context menu launch action is frontier-gated.
+- [x] Node details panel launch action is frontier-gated.
+- [x] Ineligible nodes explain why launch is unavailable when appropriate.
+- [x] Eligibility logic is shared with the existing execution/dispatch path rather than duplicated ad hoc.
 
 ## Implementation Plan
-- [x] Update `src/modules/planning/planning.service.ts` so `github_create_issue` always derives the staged issue-backed work item ID from `created.number` (reusing the graph ID convention helper), rewrites the `create_work_item` mutation's `entity_id` and `payload.id`, and never stages the pre-creation placeholder ID after GitHub responds.
-- [x] Extend `src/modules/planning/planning.service.ts` with same-turn placeholder-to-final ID resolution for accumulated multi-issue proposals so `parent_id` and `depends_on_ids` are rewritten to the final aligned IDs before `create_edge` mutations are staged.
-- [x] Add focused regression tests in `src/modules/planning/__tests__/planning.service.test.ts` for: (1) single issue creation where requested `work_item_id` and returned issue number differ, (2) epic + child creation where the child references the parent's placeholder ID, and (3) dependency references in grouped proposals use the rewritten final ID.
-- [x] Verify with `npm run check` and targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` (plus full `npm test` if the worktree environment allows it), then record any environment-related test limitations in this scratchpad.
+- [x] **Centralize launch eligibility in the execution backend** — updated `src/modules/execution/execution.service.ts`, `src/modules/execution/types.ts`, and `src/modules/execution/execution.controller.ts` so one shared helper/API determines whether a work item is launchable, why it is ineligible (`not_dispatchable`, safety failure, etc.), and any dispatch-node data needed by the UI.
+- [x] **Tighten the existing execution path to use the shared eligibility contract** — updated `src/modules/execution/execution.service.ts` so `getPreview()` / dispatch-node data and `launch()` both rely on the same eligibility helper, aligned to the clarified frontier-membership rule.
+- [x] **Wire planning-view state to the shared eligibility result** — updated `web/src/App.svelte` and `web/src/lib/api.js` to fetch/cache launch eligibility for the currently selected graph node, reuse it for graph context menus, and launch execution through the existing shared backend path.
+- [x] **Add the gated launch affordance to the node details panel** — updated `web/src/components/Sidebar.svelte` to show launch availability, disable launch when the node is ineligible, and surface the backend-provided reason.
+- [x] **Add the gated launch affordance to graph-node context actions** — updated `web/src/components/GraphView.svelte` and `web/src/lib/graph.js` so right-click node actions use the same eligibility payload and launch handler as the details panel.
+- [ ] **Cover shared eligibility behavior and verify end-to-end** — added backend eligibility coverage under `src/modules/execution/__tests__/`, ran `npm run check`, targeted `vitest` execution tests, `npm test`, and `npm run build:web`; the full suite is still blocked by an existing local `better-sqlite3` native-binding failure in graph tests, and manual browser verification has not been performed in this session.
 
 ## Affected Files
-- `src/modules/planning/planning.service.ts` — canonicalize issue-backed IDs after GitHub issue creation, track placeholder-to-final aliases during proposal accumulation, and ensure staged edges reference final aligned IDs.
-- `src/modules/planning/__tests__/planning.service.test.ts` — add regression coverage for placeholder-ID rewriting and grouped epic/child creation flows.
+- `src/modules/execution/execution.service.ts` — add the shared launch-eligibility evaluator and reuse it from preview + launch.
+- `src/modules/execution/types.ts` — define response/types for launch eligibility and richer dispatch-node availability state.
+- `src/modules/execution/execution.controller.ts` — expose launch-eligibility data to the planning UI if needed.
+- `src/modules/execution/__tests__/` (new test file) — cover frontier vs blocked behavior and preview reuse of the shared eligibility helper.
+- `web/src/App.svelte` — fetch selected-node eligibility, coordinate planning-tab launch behavior, and render the graph node context menu.
+- `web/src/components/Sidebar.svelte` — render node-details launch action and unavailable reason.
+- `web/src/components/GraphView.svelte` — pass graph-node context-menu events up to the planning view.
+- `web/src/lib/api.js` — expose the execution eligibility endpoint to the planning UI.
+- `web/src/lib/graph.js` — emit graph node right-click actions for the shared context menu.
 
 ## Quality Checks
 - [x] TypeScript compilation passes (`npm run check`)
-- [ ] Tests pass (`npm test`) — targeted `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` passed, but full `npm test` is blocked by missing `better-sqlite3` native bindings in existing graph tests in this worktree.
+- [ ] Tests pass (`npm test`) — blocked by local `better-sqlite3` binding failure in existing graph-writer tests
 - [x] Build succeeds (`npm run build:web`)
+- [x] Targeted execution tests pass (`npx vitest run src/modules/execution/__tests__/launch-eligibility.test.ts src/modules/execution/__tests__/build-scratchpad.test.ts`)
+- [ ] Manual verification: frontier node can launch from planning surfaces
+- [ ] Manual verification: blocked / non-frontier node shows unavailable reason and cannot launch
 
 ## Questions / Concerns
-- Assumption: for `github_create_issue`, any caller-supplied `work_item_id` is only a pre-creation hint and may be silently canonicalized to `studio-${created.number}` once GitHub returns the real issue number. That matches the issue scope and existing graph validation rules.
-- No other blockers found from the current code surface.
-- Everything else is clear.
+- User granted permission to edit the required planning UI files during coding.
+- User clarified that launch gating should be based on **frontier membership**.
+- Remaining concern: full `npm test` is still blocked by the local `better-sqlite3` native binding issue in existing graph tests.
 
 ## Work Log
 
-### 2026-04-08 - Setup
+### 2026-04-09 - Setup
 - Scratchpad created by Studio execution service
-- Branch: studio-90-branch
-- Reviewed the `github_create_issue` auto-staging path in `src/modules/planning/planning.service.ts` plus graph ID-alignment validation in `src/modules/graph/types.ts` / `src/modules/graph/graph-writer.service.ts` to scope the fix and test surface.
-- Implemented the first fix in `src/modules/planning/planning.service.ts`: auto-staged issue-backed work items now derive their staged ID from `deriveIssueWorkItemId(created.number)` instead of trusting a stale pre-creation `work_item_id` hint.
-- Extended `src/modules/planning/planning.service.ts` with turn-scoped placeholder→final ID alias tracking so grouped `github_create_issue` flows rewrite `parent_id`, `depends_on_ids`, and previously accumulated proposal references to the final canonical issue-backed IDs.
-- Added `src/modules/planning/__tests__/planning.service.test.ts` with regression coverage for mismatched placeholder IDs, epic/child parent rewrites, dependency rewrites, and the case where a later issue creation retroactively fixes an earlier accumulated child reference.
-- Verified the change with `npm run check` ✅, `npx vitest run src/modules/planning/__tests__/planning.service.test.ts` ✅, and `npm run build:web` ✅. Full `npm test` still fails in pre-existing graph tests because this worktree is missing `better-sqlite3` native bindings.
-- Completion summary: `github_create_issue` now stages issue-backed work items with canonical IDs derived from the actual GitHub issue number, grouped proposal edges resolve placeholder parent/dependency IDs to the final canonical IDs, and regression coverage now protects the previously failing multi-issue proposal paths.
+- Branch: studio-141-branch
+- Read current planning and execution surfaces (`web/src/App.svelte`, `web/src/components/Sidebar.svelte`, `web/src/components/GraphView.svelte`, `web/src/lib/graph.js`, `web/src/components/ExecutionDetailPane.svelte`, `web/src/components/ExecutionDispatchPanel.svelte`) and the backend dispatch/launch path (`src/modules/execution/execution.service.ts`, `src/modules/execution/types.ts`, `src/modules/graph/graph.service.ts`).
+- Identified that frontier gating already exists in `ExecutionService.launch()` for dispatchable nodes, but the logic is not exposed as a shared per-work-item eligibility contract for planning-tab node actions.
+- Implemented a shared execution launch-eligibility contract in the backend, exposed it via `GET /api/execution/eligibility`, and reused it from both execution preview generation and `launch()`.
+- Aligned the shared backend rule to the user clarification that eligibility should be based on frontier membership.
+- Added backend tests covering dispatchable frontier items, blocked items, and preview reuse of the shared eligibility helper.
+- Wired the planning UI to the shared eligibility endpoint from both the selected-node details panel and a new graph right-click context menu.
+- Added frontend API access for execution eligibility and planning-tab launch handling that routes into the existing execution launch flow.
+- Ran `npm run check` ✅, targeted `vitest` execution tests ✅, and `npm run build:web` ✅.
+- Ran `npm test`, but the suite fails in existing graph-writer tests because `better-sqlite3` native bindings are unavailable in this worktree.
+- Created commits `feat(execution): share launch eligibility rules` and `feat(planning): gate launch actions from graph nodes`.
 
 ## Blockers
-- Full `npm test` is blocked by missing `better-sqlite3` native bindings in this worktree (`Could not locate the bindings file` from existing `src/modules/graph/__tests__/graph-writer.service.test.ts`).
+- `npm test` is currently blocked by an existing local environment issue: `better-sqlite3` native bindings are missing for the graph-writer test suite in this worktree.

--- a/src/modules/execution/__tests__/build-scratchpad.test.ts
+++ b/src/modules/execution/__tests__/build-scratchpad.test.ts
@@ -46,6 +46,7 @@ function makeNode(overrides: Partial<ExecutionDispatchNodePreview> = {}): Execut
     worktree_path: "/tmp/worktrees/studio-42-branch",
     safety_checks: [],
     can_launch: true,
+    issue_backed: true,
     ...overrides,
   };
 }

--- a/src/modules/execution/__tests__/launch-eligibility.test.ts
+++ b/src/modules/execution/__tests__/launch-eligibility.test.ts
@@ -97,7 +97,7 @@ describe("launch eligibility", () => {
     expect(eligibility.dispatch_node?.issue_backed).toBe(true);
   });
 
-  it("blocks launch for frontier capability items even when dispatchable", () => {
+  it("allows launch for frontier capability items when they are dispatchable", () => {
     const workItem = makeWorkItem({
       id: "capability-1",
       kind: "capability",
@@ -112,12 +112,11 @@ describe("launch eligibility", () => {
 
     const eligibility = service.getLaunchEligibility(workItem.id);
 
-    expect(eligibility.can_launch).toBe(false);
+    expect(eligibility.can_launch).toBe(true);
     expect(eligibility.issue_backed).toBe(false);
-    expect(eligibility.launch_unavailable_code).toBe("not_issue_backed");
-    expect(eligibility.launch_unavailable_reason).toContain("issue-backed");
-    expect(eligibility.dispatch_node?.can_launch).toBe(false);
-    expect(eligibility.dispatch_node?.launch_unavailable_code).toBe("not_issue_backed");
+    expect(eligibility.launch_unavailable_code).toBeNull();
+    expect(eligibility.launch_unavailable_reason).toBeNull();
+    expect(eligibility.dispatch_node?.can_launch).toBe(true);
   });
 
   it("blocks launch for non-frontier work items", () => {
@@ -152,9 +151,9 @@ describe("launch eligibility", () => {
     const node = preview.groups[0]?.nodes[0];
 
     expect(node).toBeTruthy();
-    expect(node.can_launch).toBe(false);
+    expect(node.can_launch).toBe(true);
     expect(node.issue_backed).toBe(false);
-    expect(node.launch_unavailable_code).toBe("not_issue_backed");
-    expect(node.launch_unavailable_reason).toContain("issue-backed");
+    expect(node.launch_unavailable_code).toBeNull();
+    expect(node.launch_unavailable_reason).toBeNull();
   });
 });

--- a/src/modules/execution/__tests__/launch-eligibility.test.ts
+++ b/src/modules/execution/__tests__/launch-eligibility.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionSafetyCheck } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-141",
+    name: "Gate launch actions to frontier nodes",
+    kind: "issue",
+    state: "planned",
+    repo: "fusupo/escapement-studio",
+    issue_number: 141,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/141",
+    scope_hint: "Only allow launch for dispatchable frontier items.",
+    branch: "studio-141-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makePlanNode(id: string, name: string, branch: string) {
+  return {
+    id,
+    name,
+    branch,
+    issue_url: `https://github.com/fusupo/escapement-studio/issues/${id.replace("studio-", "")}`,
+    files_owned: ["src/example.ts"],
+    files_shared: [],
+    files_forbidden: ["src/forbidden.ts"],
+  };
+}
+
+function makePlan(nodes: Array<ReturnType<typeof makePlanNode>>) {
+  return {
+    generated_at: "2026-04-09T00:00:00.000Z",
+    assumptions: [],
+    parallel_groups: [{ repo: "fusupo/escapement-studio", nodes }],
+    sequential: [],
+    validation_policy: {
+      max_concurrent_node_heavy_tasks: 1,
+      serialized_checks: [],
+    },
+    summary: {
+      frontier_count: nodes.length,
+      dispatchable_now: nodes.length,
+      blocked_count: 0,
+      human_gate_count: 0,
+    },
+  };
+}
+
+function makeService(params: {
+  workItems: WorkItemRecord[];
+  plan: ReturnType<typeof makePlan>;
+  safetyChecks?: ExecutionSafetyCheck[];
+}): ExecutionService {
+  const service = Object.create(ExecutionService.prototype) as ExecutionService;
+  const workItemsById = new Map(params.workItems.map((item) => [item.id, item]));
+
+  (service as any).graphService = {
+    getPlan: () => params.plan,
+  };
+  (service as any).workItemsService = {
+    get: (id: string) => {
+      const item = workItemsById.get(id);
+      if (!item) {
+        throw new Error(`Unknown work item: ${id}`);
+      }
+      return item;
+    },
+  };
+  (service as any).worktreeRoot = "/tmp/studio-worktrees";
+  (service as any).evaluateSafety = () => params.safetyChecks ?? [{ code: "base_ref_exists", status: "pass", message: "Base ref exists." }];
+
+  return service;
+}
+
+describe("launch eligibility", () => {
+  it("allows launch for issue-backed frontier work items", () => {
+    const workItem = makeWorkItem();
+    const service = makeService({
+      workItems: [workItem],
+      plan: makePlan([makePlanNode(workItem.id, workItem.name, workItem.branch ?? "studio-141-branch")]),
+    });
+
+    const eligibility = service.getLaunchEligibility(workItem.id);
+
+    expect(eligibility.can_launch).toBe(true);
+    expect(eligibility.issue_backed).toBe(true);
+    expect(eligibility.launch_unavailable_code).toBeNull();
+    expect(eligibility.dispatch_node?.can_launch).toBe(true);
+    expect(eligibility.dispatch_node?.issue_backed).toBe(true);
+  });
+
+  it("blocks launch for frontier capability items even when dispatchable", () => {
+    const workItem = makeWorkItem({
+      id: "capability-1",
+      kind: "capability",
+      issue_number: null,
+      issue_url: null,
+      branch: "capability-1-branch",
+    });
+    const service = makeService({
+      workItems: [workItem],
+      plan: makePlan([makePlanNode(workItem.id, workItem.name, workItem.branch ?? "capability-1-branch")]),
+    });
+
+    const eligibility = service.getLaunchEligibility(workItem.id);
+
+    expect(eligibility.can_launch).toBe(false);
+    expect(eligibility.issue_backed).toBe(false);
+    expect(eligibility.launch_unavailable_code).toBe("not_issue_backed");
+    expect(eligibility.launch_unavailable_reason).toContain("issue-backed");
+    expect(eligibility.dispatch_node?.can_launch).toBe(false);
+    expect(eligibility.dispatch_node?.launch_unavailable_code).toBe("not_issue_backed");
+  });
+
+  it("blocks launch for non-frontier work items", () => {
+    const workItem = makeWorkItem({ id: "studio-142", branch: "studio-142-branch" });
+    const service = makeService({
+      workItems: [workItem],
+      plan: makePlan([]),
+    });
+
+    const eligibility = service.getLaunchEligibility(workItem.id);
+
+    expect(eligibility.can_launch).toBe(false);
+    expect(eligibility.launch_unavailable_code).toBe("not_dispatchable");
+    expect(eligibility.launch_unavailable_reason).toContain("dispatchable");
+    expect(eligibility.dispatch_node).toBeNull();
+  });
+
+  it("reuses shared eligibility logic when building the execution preview", () => {
+    const workItem = makeWorkItem({
+      id: "capability-2",
+      kind: "capability",
+      issue_number: null,
+      issue_url: null,
+      branch: "capability-2-branch",
+    });
+    const service = makeService({
+      workItems: [workItem],
+      plan: makePlan([makePlanNode(workItem.id, workItem.name, workItem.branch ?? "capability-2-branch")]),
+    });
+
+    const preview = service.getPreview();
+    const node = preview.groups[0]?.nodes[0];
+
+    expect(node).toBeTruthy();
+    expect(node.can_launch).toBe(false);
+    expect(node.issue_backed).toBe(false);
+    expect(node.launch_unavailable_code).toBe("not_issue_backed");
+    expect(node.launch_unavailable_reason).toContain("issue-backed");
+  });
+});

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -18,6 +18,11 @@ export class ExecutionController {
     return this.executionService.listRecentRuns();
   }
 
+  @Get("eligibility")
+  getLaunchEligibility(@Query("work_item_id") workItemId?: string, @Query("base_ref") baseRef?: string) {
+    return this.executionService.getLaunchEligibility(workItemId, baseRef);
+  }
+
   @Get("runs/:runId/activity")
   getRunActivity(@Param("runId") runId: string) {
     return this.executionService.getRunActivityLog(runId);

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -20,6 +20,7 @@ import type {
   ExecutionDispatchGroupPreview,
   ExecutionDispatchNodePreview,
   ExecutionDispatchPreview,
+  ExecutionLaunchEligibility,
   ExecutionPullRequestRecord,
   ExecutionRunRecord,
   ExecutionSafetyCheck,
@@ -82,23 +83,62 @@ export class ExecutionService {
       merge_order: group.merge_order,
       nodes: group.nodes.map((node) => {
         const workItem = this.safeGetWorkItem(node.id);
-        const worktreePath = this.getWorktreePath(node.branch);
-        const defaultBaseRef = getDefaultWorkingBranch(workItem?.repo ?? (group.repo === "unknown" ? null : group.repo));
-        const safetyChecks = this.evaluateSafety(node.branch, worktreePath, defaultBaseRef);
+        if (!workItem) {
+          const repoValue = group.repo === "unknown" ? null : group.repo;
+          const defaultBaseRef = getDefaultWorkingBranch(repoValue);
+          const worktreePath = this.getWorktreePath(node.branch);
+          const safetyChecks: ExecutionSafetyCheck[] = [{
+            code: "missing_work_item",
+            status: "fail",
+            message: `Work item ${node.id} could not be loaded from the graph store.`,
+          }];
+          return {
+            id: node.id,
+            name: node.name,
+            repo: repoValue,
+            branch: node.branch,
+            issue_url: node.issue_url,
+            scope_hint: null,
+            default_base_ref: defaultBaseRef,
+            files_owned: node.files_owned,
+            files_shared: node.files_shared,
+            files_forbidden: node.files_forbidden,
+            worktree_path: worktreePath,
+            safety_checks: safetyChecks,
+            can_launch: false,
+            issue_backed: false,
+            launch_unavailable_code: "missing_work_item",
+            launch_unavailable_reason: safetyChecks[0].message,
+          } satisfies ExecutionDispatchNodePreview;
+        }
+
+        const eligibility = this.resolveLaunchEligibility(workItem, { baseRef: getDefaultWorkingBranch(workItem.repo), plan });
+        if (eligibility.dispatch_node) {
+          return eligibility.dispatch_node;
+        }
+
+        const fallbackChecks: ExecutionSafetyCheck[] = [{
+          code: "not_dispatchable",
+          status: "fail",
+          message: "Work item is not currently dispatchable from the frontier.",
+        }];
         return {
           id: node.id,
           name: node.name,
-          repo: group.repo === "unknown" ? null : group.repo,
+          repo: workItem.repo,
           branch: node.branch,
           issue_url: node.issue_url,
-          scope_hint: workItem?.scope_hint ?? null,
-          default_base_ref: defaultBaseRef,
+          scope_hint: workItem.scope_hint,
+          default_base_ref: getDefaultWorkingBranch(workItem.repo),
           files_owned: node.files_owned,
           files_shared: node.files_shared,
           files_forbidden: node.files_forbidden,
-          worktree_path: worktreePath,
-          safety_checks: safetyChecks,
-          can_launch: !safetyChecks.some((check) => check.status === "fail"),
+          worktree_path: this.getWorktreePath(node.branch),
+          safety_checks: fallbackChecks,
+          can_launch: false,
+          issue_backed: workItem.kind === "issue",
+          launch_unavailable_code: fallbackChecks[0].code,
+          launch_unavailable_reason: fallbackChecks[0].message,
         } satisfies ExecutionDispatchNodePreview;
       }),
     }));
@@ -116,47 +156,47 @@ export class ExecutionService {
     };
   }
 
+  getLaunchEligibility(workItemId?: string, baseRef?: string): ExecutionLaunchEligibility {
+    const normalizedWorkItemId = workItemId?.trim();
+    if (!normalizedWorkItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+
+    const workItem = this.workItemsService.get(normalizedWorkItemId);
+    const normalizedBaseRef = baseRef?.trim() || getDefaultWorkingBranch(workItem.repo);
+    return this.resolveLaunchEligibility(workItem, { baseRef: normalizedBaseRef });
+  }
+
   async launch(input: LaunchExecutionRunDto): Promise<LaunchExecutionRunResult> {
     const workItemId = input.work_item_id?.trim();
     if (!workItemId) {
       throw new BadRequestException("work_item_id is required");
     }
 
-    const preview = this.getPreview();
-    const node = preview.groups.flatMap((group) => group.nodes).find((candidate) => candidate.id === workItemId);
     const workItem = this.workItemsService.get(workItemId);
     const baseRef = input.base_ref?.trim() || getDefaultWorkingBranch(workItem.repo);
+    const eligibility = this.resolveLaunchEligibility(workItem, { baseRef });
+    const node = eligibility.dispatch_node;
 
-    if (!node) {
+    if (!eligibility.can_launch || !node) {
+      const branch = node?.branch ?? workItem.branch ?? `${workItem.id}-branch`;
+      const worktreePath = node?.worktree_path ?? this.getWorktreePath(branch);
+      const blockedReason = eligibility.launch_unavailable_reason ?? "Work item is not currently launchable.";
+      const blockedCode = eligibility.launch_unavailable_code ?? "launch_unavailable";
       const run = this.createRunRecord({
         workItem,
-        branch: workItem.branch ?? `${workItem.id}-branch`,
+        branch,
         baseRef,
-        worktreePath: this.getWorktreePath(workItem.branch ?? `${workItem.id}-branch`),
-        safetyChecks: [{ code: "not_dispatchable", status: "fail", message: "Work item is not currently dispatchable from the frontier." }],
-        prompt: input.prompt?.trim() || "",
+        worktreePath,
+        safetyChecks: eligibility.safety_checks,
+        prompt: input.prompt?.trim() || (node ? this.buildPrompt(workItem, node) : ""),
         status: "blocked",
-        resultSummary: "Launch blocked because the work item is not currently dispatchable.",
-        errors: [{ code: "not_dispatchable", message: "Work item is not currently dispatchable from the frontier." }],
+        resultSummary: `Launch blocked: ${blockedReason}`,
+        errors: eligibility.safety_checks.filter((check) => check.status === "fail").map((check) => ({ code: check.code, message: check.message })),
       });
-      this.persistRun(run);
-      this.emitRun("execution_result", run);
-      return { accepted: false, run };
-    }
-
-    const safetyChecks = this.evaluateSafety(node.branch, node.worktree_path, baseRef);
-    if (safetyChecks.some((check) => check.status === "fail")) {
-      const run = this.createRunRecord({
-        workItem,
-        branch: node.branch,
-        baseRef,
-        worktreePath: node.worktree_path,
-        safetyChecks,
-        prompt: input.prompt?.trim() || this.buildPrompt(workItem, node),
-        status: "blocked",
-        resultSummary: "Launch blocked by execution safety checks.",
-        errors: safetyChecks.filter((check) => check.status === "fail").map((check) => ({ code: check.code, message: check.message })),
-      });
+      if (run.errors == null || run.errors.length === 0) {
+        run.errors = [{ code: blockedCode, message: blockedReason }];
+      }
       this.persistRun(run);
       this.emitRun("execution_result", run);
       return { accepted: false, run };
@@ -167,7 +207,7 @@ export class ExecutionService {
       branch: node.branch,
       baseRef,
       worktreePath: node.worktree_path,
-      safetyChecks,
+      safetyChecks: eligibility.safety_checks,
       prompt: input.prompt?.trim() || this.buildPrompt(workItem, node),
       status: "queued",
       resultSummary: undefined,
@@ -969,6 +1009,97 @@ export class ExecutionService {
     }
     const entry: ActivityLogEntry = { timestamp: this.now(), kind, message, ...(detail ? { detail } : {}) };
     run.activity_log.push(entry);
+  }
+
+  private resolveLaunchEligibility(
+    workItem: WorkItemRecord,
+    options: { baseRef?: string; plan?: ReturnType<GraphService["getPlan"]> } = {},
+  ): ExecutionLaunchEligibility {
+    const baseRef = options.baseRef?.trim() || getDefaultWorkingBranch(workItem.repo);
+    const plan = options.plan ?? this.graphService.getPlan(workItem.repo ?? undefined);
+    const groupedNode = this.findPlannedNode(plan, workItem.id);
+    const branch = groupedNode?.node.branch ?? workItem.branch ?? `${workItem.id}-branch`;
+    const worktreePath = this.getWorktreePath(branch);
+    const safetyChecks: ExecutionSafetyCheck[] = [];
+    const issueBacked = this.isIssueBacked(workItem);
+
+    if (!issueBacked) {
+      safetyChecks.push({
+        code: "not_issue_backed",
+        status: "fail",
+        message: "Launch execution is only available for issue-backed work items.",
+      });
+    }
+
+    if (!groupedNode) {
+      safetyChecks.push({
+        code: "not_dispatchable",
+        status: "fail",
+        message: "Work item is not currently dispatchable from the frontier.",
+      });
+    } else {
+      safetyChecks.push(...this.evaluateSafety(branch, worktreePath, baseRef));
+    }
+
+    const firstFailure = safetyChecks.find((check) => check.status === "fail") ?? null;
+    const dispatchNode = groupedNode
+      ? this.createDispatchNodePreview(groupedNode.group.repo, groupedNode.node, workItem, baseRef, worktreePath, safetyChecks)
+      : null;
+
+    return {
+      work_item_id: workItem.id,
+      repo: workItem.repo,
+      issue_url: workItem.issue_url,
+      issue_backed: issueBacked,
+      can_launch: firstFailure == null,
+      safety_checks: safetyChecks,
+      launch_unavailable_code: firstFailure?.code ?? null,
+      launch_unavailable_reason: firstFailure?.message ?? null,
+      dispatch_node: dispatchNode,
+    };
+  }
+
+  private createDispatchNodePreview(
+    repo: string,
+    node: { id: string; name: string; branch: string; files_owned: string[]; files_shared: Array<{ path: string; assessment: string; confidence: string; notes: string }>; files_forbidden: string[]; issue_url?: string },
+    workItem: WorkItemRecord,
+    baseRef: string,
+    worktreePath: string,
+    safetyChecks: ExecutionSafetyCheck[],
+  ): ExecutionDispatchNodePreview {
+    const firstFailure = safetyChecks.find((check) => check.status === "fail") ?? null;
+    return {
+      id: node.id,
+      name: node.name,
+      repo: repo === "unknown" ? null : repo,
+      branch: node.branch,
+      issue_url: node.issue_url,
+      scope_hint: workItem.scope_hint,
+      default_base_ref: baseRef,
+      files_owned: node.files_owned,
+      files_shared: node.files_shared,
+      files_forbidden: node.files_forbidden,
+      worktree_path: worktreePath,
+      safety_checks: safetyChecks,
+      can_launch: firstFailure == null,
+      issue_backed: this.isIssueBacked(workItem),
+      launch_unavailable_code: firstFailure?.code ?? null,
+      launch_unavailable_reason: firstFailure?.message ?? null,
+    };
+  }
+
+  private findPlannedNode(plan: ReturnType<GraphService["getPlan"]>, workItemId: string): { group: ReturnType<GraphService["getPlan"]>["parallel_groups"][number]; node: ReturnType<GraphService["getPlan"]>["parallel_groups"][number]["nodes"][number] } | null {
+    for (const group of plan.parallel_groups) {
+      const node = group.nodes.find((candidate) => candidate.id === workItemId);
+      if (node) {
+        return { group, node };
+      }
+    }
+    return null;
+  }
+
+  private isIssueBacked(workItem: WorkItemRecord): boolean {
+    return workItem.kind === "issue";
   }
 
   private evaluateSafety(branch: string, worktreePath: string, baseRef = getDefaultWorkingBranch(null)): ExecutionSafetyCheck[] {

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1023,14 +1023,6 @@ export class ExecutionService {
     const safetyChecks: ExecutionSafetyCheck[] = [];
     const issueBacked = this.isIssueBacked(workItem);
 
-    if (!issueBacked) {
-      safetyChecks.push({
-        code: "not_issue_backed",
-        status: "fail",
-        message: "Launch execution is only available for issue-backed work items.",
-      });
-    }
-
     if (!groupedNode) {
       safetyChecks.push({
         code: "not_dispatchable",

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -34,6 +34,21 @@ export interface ExecutionDispatchNodePreview {
   worktree_path: string;
   safety_checks: ExecutionSafetyCheck[];
   can_launch: boolean;
+  issue_backed: boolean;
+  launch_unavailable_code?: string | null;
+  launch_unavailable_reason?: string | null;
+}
+
+export interface ExecutionLaunchEligibility {
+  work_item_id: string;
+  repo: string | null;
+  issue_url: string | null;
+  issue_backed: boolean;
+  can_launch: boolean;
+  safety_checks: ExecutionSafetyCheck[];
+  launch_unavailable_code: string | null;
+  launch_unavailable_reason: string | null;
+  dispatch_node: ExecutionDispatchNodePreview | null;
 }
 
 export interface ExecutionDispatchGroupPreview {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -11,9 +11,11 @@
     createEdge,
     createWorkItem,
     deleteEdge,
+    getExecutionEligibility,
     getGitHubIssueDetails,
     getGraph,
     getHealth,
+    launchExecutionRun,
     listWorkItems,
     updateWorkItem,
   } from "./lib/api.js";
@@ -31,6 +33,11 @@
   let selectedIssueDetails = null;
   let activeTab = "planning";
   let closingIssue = false;
+  let launchingExecution = false;
+  let launchEligibilityById = {};
+  let launchEligibilityLoadingIds = {};
+  let launchEligibilityRequestTokenById = {};
+  let graphContextMenu = { open: false, x: 0, y: 0, item: null };
 
   // Panel collapse state
   let chatCollapsed = false;
@@ -83,6 +90,10 @@
   ];
 
   $: selectedItem = graph.items.find((item) => item.id === selectedId) ?? null;
+  $: selectedLaunchEligibility = selectedItem ? launchEligibilityById[selectedItem.id] ?? null : null;
+  $: selectedLaunchEligibilityLoading = selectedItem ? !!launchEligibilityLoadingIds[selectedItem.id] : false;
+  $: contextMenuLaunchEligibility = graphContextMenu.item ? launchEligibilityById[graphContextMenu.item.id] ?? null : null;
+  $: contextMenuLaunchEligibilityLoading = graphContextMenu.item ? !!launchEligibilityLoadingIds[graphContextMenu.item.id] : false;
   $: filterOptions = {
     repos: [...new Set(catalog.map((item) => item.repo).filter(Boolean))].sort(),
     states: [...new Set(catalog.map((item) => item.state).filter(Boolean))].sort(),
@@ -91,6 +102,56 @@
   };
 
   $: activeFilterCount = Object.values(filters).filter(Boolean).length;
+  $: if (selectedItem?.id) {
+    void ensureLaunchEligibility(selectedItem.id);
+  }
+
+  function closeGraphContextMenu() {
+    graphContextMenu = { open: false, x: 0, y: 0, item: null };
+  }
+
+  function normalizeLaunchEligibilityError(workItemId, message) {
+    return {
+      work_item_id: workItemId,
+      repo: null,
+      issue_url: null,
+      issue_backed: false,
+      can_launch: false,
+      safety_checks: [],
+      launch_unavailable_code: "eligibility_lookup_failed",
+      launch_unavailable_reason: message,
+      dispatch_node: null,
+    };
+  }
+
+  async function ensureLaunchEligibility(workItemId, { force = false } = {}) {
+    if (!workItemId) return null;
+    if (!force && launchEligibilityById[workItemId]) {
+      return launchEligibilityById[workItemId];
+    }
+
+    const token = (launchEligibilityRequestTokenById[workItemId] || 0) + 1;
+    launchEligibilityRequestTokenById = { ...launchEligibilityRequestTokenById, [workItemId]: token };
+    launchEligibilityLoadingIds = { ...launchEligibilityLoadingIds, [workItemId]: true };
+
+    try {
+      const eligibility = await getExecutionEligibility({ work_item_id: workItemId });
+      if (launchEligibilityRequestTokenById[workItemId] === token) {
+        launchEligibilityById = { ...launchEligibilityById, [workItemId]: eligibility };
+      }
+      return eligibility;
+    } catch (lookupError) {
+      const fallback = normalizeLaunchEligibilityError(workItemId, lookupError.message);
+      if (launchEligibilityRequestTokenById[workItemId] === token) {
+        launchEligibilityById = { ...launchEligibilityById, [workItemId]: fallback };
+      }
+      return fallback;
+    } finally {
+      if (launchEligibilityRequestTokenById[workItemId] === token) {
+        launchEligibilityLoadingIds = { ...launchEligibilityLoadingIds, [workItemId]: false };
+      }
+    }
+  }
 
   async function loadGraph() {
     loading = true;
@@ -104,8 +165,12 @@
       graph = graphResponse;
       health = healthResponse;
       catalog = catalogResponse;
+      launchEligibilityById = {};
+      launchEligibilityLoadingIds = {};
+      launchEligibilityRequestTokenById = {};
       if (selectedId && !graph.items.some((item) => item.id === selectedId)) {
         selectedId = null;
+        closeGraphContextMenu();
       }
     } catch (loadError) {
       error = loadError.message;
@@ -206,6 +271,66 @@
     }
   }
 
+  function handleGraphSelect(item) {
+    selectedId = item?.id ?? null;
+    closeGraphContextMenu();
+  }
+
+  async function handleGraphContextMenu(detail) {
+    if (!detail?.item?.id) {
+      closeGraphContextMenu();
+      return;
+    }
+
+    selectedId = detail.item.id;
+    const x = Math.min(detail.x, Math.max(16, window.innerWidth - 280));
+    const y = Math.min(detail.y, Math.max(16, window.innerHeight - 180));
+    graphContextMenu = {
+      open: true,
+      x,
+      y,
+      item: detail.item,
+    };
+    await ensureLaunchEligibility(detail.item.id);
+  }
+
+  function handleGlobalKeydown(event) {
+    if (event.key === "Escape") {
+      closeGraphContextMenu();
+    }
+  }
+
+  function handleGraphContextMenuKeydown(event) {
+    if (event.key === "Escape") {
+      closeGraphContextMenu();
+    }
+  }
+
+  async function handleLaunchExecution(item = selectedItem) {
+    const workItemId = item?.id;
+    if (!workItemId) return;
+
+    launchingExecution = true;
+    error = "";
+    try {
+      const eligibility = await ensureLaunchEligibility(workItemId, { force: true });
+      if (!eligibility?.can_launch) {
+        error = eligibility?.launch_unavailable_reason || "Launch execution is not available for this node.";
+        return;
+      }
+
+      const result = await launchExecutionRun({ work_item_id: workItemId, disambiguate: true });
+      closeGraphContextMenu();
+      if (result?.run) {
+        activeTab = "execute";
+      }
+    } catch (launchError) {
+      error = launchError.message;
+    } finally {
+      launchingExecution = false;
+    }
+  }
+
   function handleFilterChange(nextFilters) {
     filters = nextFilters;
     loadGraph();
@@ -222,6 +347,8 @@
 <svelte:head>
   <title>Escapement Studio</title>
 </svelte:head>
+
+<svelte:window on:click={closeGraphContextMenu} on:keydown={handleGlobalKeydown} on:scroll={closeGraphContextMenu} />
 
 <div class="app-shell">
   <!-- Activity Bar (far left icon rail) -->
@@ -335,7 +462,12 @@
               {#if loading}
                 <div class="empty-state">Loading graph…</div>
               {:else}
-                <GraphView {graph} {selectedId} onSelect={(item) => (selectedId = item?.id ?? null)} />
+                <GraphView
+                  {graph}
+                  {selectedId}
+                  onSelect={handleGraphSelect}
+                  onContextMenu={handleGraphContextMenu}
+                />
               {/if}
             </div>
           </div>
@@ -360,6 +492,10 @@
                 <Sidebar
                   {selectedItem}
                   issueDetails={selectedIssueDetails}
+                  launchEligibility={selectedLaunchEligibility}
+                  launchEligibilityLoading={selectedLaunchEligibilityLoading}
+                  launchingExecution={launchingExecution}
+                  onLaunchExecution={handleLaunchExecution}
                   {graph}
                   {saving}
                   {edgeSaving}
@@ -405,6 +541,35 @@
         <div class="pane-body fullpane-body">
           <SettingsPanel {health} />
         </div>
+      </div>
+    {/if}
+
+    {#if activeTab === "planning" && graphContextMenu.open && graphContextMenu.item}
+      <div
+        class="graph-context-menu"
+        style={`left:${graphContextMenu.x}px; top:${graphContextMenu.y}px;`}
+        role="menu"
+        tabindex="-1"
+        aria-label={`Actions for ${graphContextMenu.item.id}`}
+        on:click|stopPropagation
+        on:keydown|stopPropagation={handleGraphContextMenuKeydown}
+      >
+        <div class="graph-context-menu-title">{graphContextMenu.item.id}</div>
+        <div class="graph-context-menu-name">{graphContextMenu.item.name}</div>
+        {#if contextMenuLaunchEligibilityLoading}
+          <div class="graph-context-menu-reason muted">Checking launch eligibility…</div>
+        {:else}
+          <button
+            class="graph-context-menu-action"
+            on:click={() => handleLaunchExecution(graphContextMenu.item)}
+            disabled={!contextMenuLaunchEligibility?.can_launch || launchingExecution}
+          >
+            {launchingExecution ? "Launching…" : "Launch execution"}
+          </button>
+          {#if contextMenuLaunchEligibility?.launch_unavailable_reason}
+            <div class="graph-context-menu-reason">{contextMenuLaunchEligibility.launch_unavailable_reason}</div>
+          {/if}
+        {/if}
       </div>
     {/if}
 
@@ -748,6 +913,43 @@
     flex: 1;
     color: #6b7a94;
     font-size: 12px;
+  }
+
+  .graph-context-menu {
+    position: fixed;
+    z-index: 40;
+    min-width: 220px;
+    max-width: 280px;
+    display: grid;
+    gap: 6px;
+    padding: 10px;
+    border-radius: 8px;
+    border: 1px solid #2b3245;
+    background: #13171f;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  .graph-context-menu-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: #e2e8f0;
+  }
+
+  .graph-context-menu-name {
+    font-size: 11px;
+    color: #8b95a5;
+    overflow-wrap: anywhere;
+  }
+
+  .graph-context-menu-action {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .graph-context-menu-reason {
+    font-size: 11px;
+    color: #8b95a5;
+    line-height: 1.4;
   }
 
   /* ── Responsive ── */

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -5,6 +5,7 @@
   export let graph = { items: [], edges: [] };
   export let selectedId = null;
   export let onSelect = () => {};
+  export let onContextMenu = () => {};
 
   let svg;
   let handle = { cleanup() {}, updateSelection() {}, resize() {} };
@@ -14,7 +15,7 @@
 
   function fullRedraw() {
     handle.cleanup();
-    handle = renderGraph(svg, graph, selectedId, onSelect);
+    handle = renderGraph(svg, graph, selectedId, onSelect, { onContextMenu });
     prevGraph = graph;
   }
 

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -20,6 +20,9 @@
 
   export let selectedItem = null;
   export let issueDetails = null;
+  export let launchEligibility = null;
+  export let launchEligibilityLoading = false;
+  export let launchingExecution = false;
   export let graph = { items: [], edges: [] };
   export let saving = false;
   export let edgeSaving = false;
@@ -28,6 +31,7 @@
   export let onCreateEdge = () => {};
   export let onDeleteEdge = () => {};
   export let onCloseIssue = () => {};
+  export let onLaunchExecution = () => {};
   export let closingIssue = false;
 
   let linkedPrDetails = null;
@@ -182,6 +186,34 @@
           {/if}
         </div>
       {/if}
+
+      <div class="issue-details-card">
+        <div class="issue-details-header">
+          <h3>Execution</h3>
+        </div>
+
+        {#if launchEligibilityLoading}
+          <p class="muted">Checking frontier eligibility…</p>
+        {:else if launchEligibility}
+          <span class="status-pill {launchEligibility.can_launch ? 'healthy' : 'warn'}">{launchEligibility.can_launch ? 'dispatchable' : 'blocked'}</span>
+          {#if launchEligibility.dispatch_node}
+            <p class="muted">
+              Branch <code>{launchEligibility.dispatch_node.branch}</code>
+              · Base <code>{launchEligibility.dispatch_node.default_base_ref}</code>
+            </p>
+          {/if}
+          {#if launchEligibility.launch_unavailable_reason}
+            <p class="muted">{launchEligibility.launch_unavailable_reason}</p>
+          {:else}
+            <p class="muted">This node is currently on the frontier and can be launched into execution.</p>
+          {/if}
+          <button on:click={() => onLaunchExecution(selectedItem)} disabled={!launchEligibility.can_launch || launchingExecution}>
+            {launchingExecution ? "Launching..." : "Launch execution"}
+          </button>
+        {:else}
+          <p class="muted">Select a node to inspect execution availability.</p>
+        {/if}
+      </div>
 
       <div class="stack">
         <label>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -99,6 +99,18 @@ export function listExecutionRuns() {
   return request("/api/execution/runs");
 }
 
+export function getExecutionEligibility(params = {}) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const search = query.toString();
+  return request(`/api/execution/eligibility${search ? `?${search}` : ""}`);
+}
+
 export function launchExecutionRun(payload) {
   return request("/api/execution/launch", {
     method: "POST",

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -271,6 +271,16 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       const data = g.node(id)?._data;
       if (data) onSelect(data);
     })
+    .on("contextmenu", function (event, id) {
+      event.preventDefault();
+      event.stopPropagation();
+      const data = g.node(id)?._data;
+      if (data) {
+        onSelect(data);
+        options.onContextMenu?.({ item: data, x: event.clientX, y: event.clientY });
+      }
+      hideTooltip(tooltip);
+    })
     .on("mouseenter", function (event) {
       const id = d3.select(this).datum();
       const data = g.node(id)?._data;
@@ -294,6 +304,10 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
 
   // Click background to deselect
   svg.on("click", () => onSelect(null));
+  svg.on("contextmenu", (event) => {
+    event.preventDefault();
+    options.onContextMenu?.(null);
+  });
 
   // Edge hover
   inner.selectAll("g.edgePath")


### PR DESCRIPTION
## Summary
Implemented the remaining work.

Commits
- `6b42a79` — `feat(execution): share launch eligibility rules`
- `905f555` — `feat(planning): gate launch actions from graph nodes`

What I changed

Backend/shared logic
- `src/modules/execution/execution.service.ts`
  - Centralized launch eligibility.
  - Reused it from both preview generation and `launch()`.
  - Updated it to follow your clarification: eligibility is based on frontier/dispatchability.
- `src/modules/execution/execution.controller.ts`
  - Added `GET /api/execution/eligibility`
- `src/modules/execution/types.ts`
  - Added shared eligibility response types and richer dispatch-node availability fields.
- `src/modules/execution/__tests__/launch-eligibility.test.ts`
  - Added/updated coverage for dispatchable vs blocked behavior and preview reuse.

Planning UI
- `web/src/lib/api.js`
  - Added frontend helper for execution eligibility API.
- `web/src/App.svelte`
  - Fetches/caches eligibility for selected graph nodes.
  - Uses the same eligibility for both details panel and graph context menu.
  - Launches via the existing execution launch path.
  - Opens a graph node context menu on right-click.
- `web/src/components/Sidebar.svelte`
  - Added launch execution section in node details.
  - Disabled ineligible launches with backend-provided reason.
- `web/src/components/GraphView.svelte`
  - Passed graph node context-menu events up.
- `web/src/lib/graph.js`
  - Added right-click handling on graph nodes.

Checks run
- `npm run check` ✅
- `npx vitest run src/modules/execution/__tests__/launch-eligibility.test.ts src/modules/execution/__tests__/build-scratchpad.test.ts` ✅
- `npm run build:web` ✅
- `npm test` ⚠️ blocked by existing environment issue:
  - missing `better-sqlite3` native bindings in existing graph-writer tests

Remaining blockers / follow-up
- Full test suite is still blocked by the local `better-sqlite3` binding issue.
- I did not perform manual browser verification in this session, so that remains unverified interactively.

`SCRATCHPAD.md` is updated with the completed plan status, work log, and remaining blocker.

actual_files synced: 1 file(s).

## Context
- Work item: studio-141
- Issue: https://github.com/fusupo/escapement-studio/issues/141
- Base branch: develop
- Head branch: studio-141-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775702607481
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-141-branch
- Scope hint: Gate launch-execution actions from graph nodes and node details so they are only available for frontier/dispatchable work items.

## Changed files
- `SCRATCHPAD.md`