### PR TITLE
[#139] Studio: add graph node context menu with launch execution action

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,19 +1,12 @@
-# Scratchpad: studio-141 — Studio: only allow launch execution actions for frontier nodes
+# Scratchpad: studio-139 — Studio: add graph node context menu with launch execution action
 
 ## Context
 - **Repo:** fusupo/escapement-studio
-- **Issue:** https://github.com/fusupo/escapement-studio/issues/141
-- **Branch:** studio-141-branch
+- **Issue:** https://github.com/fusupo/escapement-studio/issues/139
+- **Branch:** studio-139-branch
 - **Base ref:** develop
-- **Scope hint:** Gate launch-execution actions from graph nodes and node details so they are only available for frontier/dispatchable work items.
-- **Created:** 2026-04-09T02:43:27.481Z
-
-## Summary
-The current execution launch path is already partially frontier-gated in `src/modules/execution/execution.service.ts`: `launch()` only accepts work items that appear in the dispatch preview, and blocked launches produce a `not_dispatchable` result. However, that eligibility is implicit inside the execution module and the planning UI does not currently expose a shared per-node eligibility model.
-
-The implementation should centralize launch-eligibility evaluation in the execution module so the same rules are used everywhere: the work item must be currently dispatchable from the frontier and pass existing execution safety checks. The planning graph surfaces that expose launch actions (graph node context menu and selected-node details panel) should consume that shared result instead of re-implementing frontier checks in the browser.
-
-During coding, the user clarified that gating should be based on **frontier membership**. The shared execution path and the planning UI should therefore align on dispatchability/frontier status rather than an additional issue-backed restriction.
+- **Scope hint:** Add a graph-node context menu with issue actions, including launching execution directly from the graph.
+- **Created:** 2026-04-09T03:37:06.696Z
 
 ## File Ownership
 
@@ -26,75 +19,73 @@ During coding, the user clarified that gating should be based on **frontier memb
 ### Forbidden
 - docs/contracts/github-sync.md
 - docs/contracts/run-artifacts.md
+- src/modules/execution
 - src/modules/github
 - src/modules/graph
+- src/modules/planning
 - src/modules/settings
-- web/src/app.css
-- web/src/components
 - web/src/components/ExecutionDispatchPanel.svelte
 - web/src/components/PlannerChatAdapter.svelte
 - web/src/components/SettingsPanel.svelte
-- web/src/lib/api.js
-- web/src/lib/graph.js
+- web/src/components/Sidebar.svelte
 
 ## Summary
-The planning graph is rendered as an SVG via `web/src/components/GraphView.svelte`, with node visuals created in `web/src/lib/graph.js`. Today, node fill color communicates work-item state, while selection and hover are both expressed through node stroke changes on the rendered `<rect>`. The issue asks for frontier / dispatchable nodes to gain an additional visual treatment that remains readable without colliding with those existing selection and hover affordances.
-
-Based on the current implementation surface, a non-stroke treatment such as a subtle diagonal stripe overlay is the right direction because selection and hover already consume stroke color/width. However, the current graph renderer appears to set node styles inline and does not expose any frontier-specific class or data attribute in the SVG output, so I do not currently see a CSS-only hook that would let `web/src/app.css` distinguish frontier nodes from non-frontier nodes.
+- The planning graph already exposes node right-click events from the D3 renderer (`web/src/lib/graph.js`) up through `GraphView.svelte` into `web/src/App.svelte`, and `App.svelte` currently contains an inline graph context menu plus launch-eligibility lookup/launch handlers.
+- For #139, the implementation work appears to be about hardening and polishing that graph-node action surface so it behaves like a real extensible context menu: anchored to the cursor/node, clear about which actions are available, and routed through the existing execution flow rather than inventing a parallel path.
+- The most likely frontend surface is the planning view (`web/src/App.svelte`) plus the graph interaction layer (`web/src/components/GraphView.svelte` and `web/src/lib/graph.js`). If the menu is meant to grow, it would be cleaner to extract it into its own component instead of keeping all action rendering inline in `App.svelte`.
 
 ## Acceptance Criteria
-- [x] Graph context menu launch action is frontier-gated.
-- [x] Node details panel launch action is frontier-gated.
-- [x] Ineligible nodes explain why launch is unavailable when appropriate.
-- [x] Eligibility logic is shared with the existing execution/dispatch path rather than duplicated ad hoc.
+- [ ] Right-clicking an eligible graph node opens a context menu anchored to the node/cursor.
+- [ ] Eligible issues expose a **Launch execution** action from that menu.
+- [ ] The launch action routes into the existing execution flow instead of creating a separate special-case path.
+- [ ] Ineligible nodes show disabled or omitted actions with clear affordances.
+- [ ] The menu can grow to support additional node actions over time.
+- [ ] The menu dismisses cleanly and does not interfere with normal graph selection/pan behavior.
 
 ## Implementation Plan
-- [x] **Centralize launch eligibility in the execution backend** — updated `src/modules/execution/execution.service.ts`, `src/modules/execution/types.ts`, and `src/modules/execution/execution.controller.ts` so one shared helper/API determines whether a work item is launchable, why it is ineligible (`not_dispatchable`, safety failure, etc.), and any dispatch-node data needed by the UI.
-- [x] **Tighten the existing execution path to use the shared eligibility contract** — updated `src/modules/execution/execution.service.ts` so `getPreview()` / dispatch-node data and `launch()` both rely on the same eligibility helper, aligned to the clarified frontier-membership rule.
-- [x] **Wire planning-view state to the shared eligibility result** — updated `web/src/App.svelte` and `web/src/lib/api.js` to fetch/cache launch eligibility for the currently selected graph node, reuse it for graph context menus, and launch execution through the existing shared backend path.
-- [x] **Add the gated launch affordance to the node details panel** — updated `web/src/components/Sidebar.svelte` to show launch availability, disable launch when the node is ineligible, and surface the backend-provided reason.
-- [x] **Add the gated launch affordance to graph-node context actions** — updated `web/src/components/GraphView.svelte` and `web/src/lib/graph.js` so right-click node actions use the same eligibility payload and launch handler as the details panel.
-- [ ] **Cover shared eligibility behavior and verify end-to-end** — added backend eligibility coverage under `src/modules/execution/__tests__/`, ran `npm run check`, targeted `vitest` execution tests, `npm test`, and `npm run build:web`; the full suite is still blocked by an existing local `better-sqlite3` native-binding failure in graph tests, and manual browser verification has not been performed in this session.
+- [x] Audit the existing graph right-click plumbing and identify the exact acceptance gaps versus the current inline implementation. Files: `web/src/App.svelte`, `web/src/components/GraphView.svelte`, `web/src/lib/graph.js`, plus read-only context from `src/modules/execution/execution.service.ts` and `src/modules/execution/types.ts`.
+- [x] Extract or reshape the graph-node context menu into a reusable/extensible UI surface so future node actions can be added without growing `App.svelte` further. Files: `web/src/App.svelte`; likely new `web/src/components/GraphNodeContextMenu.svelte`; optional new helper such as `web/src/lib/graph-node-actions.js`.
+- [x] Reuse the existing launch-eligibility and launch-execution flow from the planning screen so the menu action follows the same execution path, tab switch, and error handling used elsewhere. Files: `web/src/App.svelte`, and `web/src/lib/api.js` only if a small helper/API wrapper adjustment is needed.
+- [x] Tighten menu interaction behavior: anchor/clamp placement, outside-click/Escape dismissal, disabled-state messaging for ineligible nodes, and right-click behavior that does not break normal graph selection or pan/zoom. Files: `web/src/App.svelte`, `web/src/components/GraphView.svelte`, `web/src/lib/graph.js`, and menu styling in component-local CSS or `web/src/app.css`.
+- [x] Add targeted coverage for any extracted pure helper logic (if introduced) and then verify the end-to-end UX manually in the planning graph: open menu, launch an eligible node, confirm blocked affordances for ineligible nodes, and confirm dismissal behavior. Files: likely new test file for any helper plus the touched web files above.
 
 ## Affected Files
-- `src/modules/execution/execution.service.ts` — add the shared launch-eligibility evaluator and reuse it from preview + launch.
-- `src/modules/execution/types.ts` — define response/types for launch eligibility and richer dispatch-node availability state.
-- `src/modules/execution/execution.controller.ts` — expose launch-eligibility data to the planning UI if needed.
-- `src/modules/execution/__tests__/` (new test file) — cover frontier vs blocked behavior and preview reuse of the shared eligibility helper.
-- `web/src/App.svelte` — fetch selected-node eligibility, coordinate planning-tab launch behavior, and render the graph node context menu.
-- `web/src/components/Sidebar.svelte` — render node-details launch action and unavailable reason.
-- `web/src/components/GraphView.svelte` — pass graph-node context-menu events up to the planning view.
-- `web/src/lib/api.js` — expose the execution eligibility endpoint to the planning UI.
-- `web/src/lib/graph.js` — emit graph node right-click actions for the shared context menu.
+- `SCRATCHPAD.md` — setup-phase plan and implementation notes.
+- `web/src/App.svelte` — primary planning-screen state for selected node, context-menu open/close behavior, launch-eligibility lookup, and routing into the existing execution flow.
+- `web/src/components/GraphView.svelte` — graph wrapper that passes right-click events and frontier-derived metadata into the renderer.
+- `web/src/lib/graph.js` — low-level D3 node interaction handling for click/right-click/tooltip/pan behavior.
+- `web/src/components/GraphNodeContextMenu.svelte` *(likely new)* — dedicated graph-node actions menu so the surface can grow beyond a single inline button.
+- `web/src/lib/graph-node-actions.js` *(possible new helper)* — pure action-model helper for enabled/disabled/hidden menu items and user-facing reasons.
+- `web/src/app.css` *(maybe)* — shared menu/overlay styling if it is not kept component-local.
 
 ## Quality Checks
 - [x] TypeScript compilation passes (`npm run check`)
-- [ ] Tests pass (`npm test`) — blocked by local `better-sqlite3` binding failure in existing graph-writer tests
+- [ ] Tests pass (`npm test`)
 - [x] Build succeeds (`npm run build:web`)
-- [x] Targeted execution tests pass (`npx vitest run src/modules/execution/__tests__/launch-eligibility.test.ts src/modules/execution/__tests__/build-scratchpad.test.ts`)
-- [ ] Manual verification: frontier node can launch from planning surfaces
-- [ ] Manual verification: blocked / non-frontier node shows unavailable reason and cannot launch
 
 ## Questions / Concerns
-- User granted permission to edit the required planning UI files during coding.
-- User clarified that launch gating should be based on **frontier membership**.
-- Remaining concern: full `npm test` is still blocked by the local `better-sqlite3` native binding issue in existing graph tests.
+- **Scope ambiguity:** the issue text emphasizes eligible **issue-backed** nodes, but the current execution eligibility backend also allows dispatchable capability nodes. Please confirm whether the graph context menu should expose **Launch execution** only for issue-backed items, or for any work item that the existing execution flow considers launchable.
+- **Current-code overlap:** `web/src/App.svelte`, `web/src/components/GraphView.svelte`, and `web/src/lib/graph.js` already contain substantial context-menu and launch wiring on `develop`. I will treat #139 as refinement/completion of that surface unless you want a stricter rework.
+- **Test surface:** there is no existing frontend component test harness in `web/`. If needed, I can add lightweight Vitest coverage only for extracted pure helpers, then rely on manual UI verification for the actual Svelte interaction behavior.
+- Aside from the issue-only vs any-launchable-node question above, the implementation surface is clear.
 
 ## Work Log
 
 ### 2026-04-09 - Setup
 - Scratchpad created by Studio execution service
-- Branch: studio-141-branch
-- Read current planning and execution surfaces (`web/src/App.svelte`, `web/src/components/Sidebar.svelte`, `web/src/components/GraphView.svelte`, `web/src/lib/graph.js`, `web/src/components/ExecutionDetailPane.svelte`, `web/src/components/ExecutionDispatchPanel.svelte`) and the backend dispatch/launch path (`src/modules/execution/execution.service.ts`, `src/modules/execution/types.ts`, `src/modules/graph/graph.service.ts`).
-- Identified that frontier gating already exists in `ExecutionService.launch()` for dispatchable nodes, but the logic is not exposed as a shared per-work-item eligibility contract for planning-tab node actions.
-- Implemented a shared execution launch-eligibility contract in the backend, exposed it via `GET /api/execution/eligibility`, and reused it from both execution preview generation and `launch()`.
-- Aligned the shared backend rule to the user clarification that eligibility should be based on frontier membership.
-- Added backend tests covering dispatchable frontier items, blocked items, and preview reuse of the shared eligibility helper.
-- Wired the planning UI to the shared eligibility endpoint from both the selected-node details panel and a new graph right-click context menu.
-- Added frontend API access for execution eligibility and planning-tab launch handling that routes into the existing execution launch flow.
-- Ran `npm run check` ✅, targeted `vitest` execution tests ✅, and `npm run build:web` ✅.
-- Ran `npm test`, but the suite fails in existing graph-writer tests because `better-sqlite3` native bindings are unavailable in this worktree.
-- Created commits `feat(execution): share launch eligibility rules` and `feat(planning): gate launch actions from graph nodes`.
+- Branch: studio-139-branch
+
+### 2026-04-09 - Coding
+- Audited the current implementation: `GraphView.svelte` and `web/src/lib/graph.js` already emit node right-click events, and `web/src/App.svelte` already has an inline menu plus launch-eligibility lookup. The main remaining gaps are extensibility, clearer action modeling, and more robust menu positioning/dismissal behavior.
+- Extracted the inline planning-graph menu into `web/src/components/GraphNodeContextMenu.svelte` and introduced `web/src/lib/graph-node-actions.js` so actions are modeled separately from `App.svelte` rendering.
+- Kept launch execution routed through the existing `handleLaunchExecution()` path in `web/src/App.svelte`, and added an `Open issue` action when a node has a linked GitHub issue.
+- Quality checks after extraction/refactor: `npm run check` ✅, `npm run build:web` ✅ (existing Svelte a11y/CSS warnings only), `npm test` ⚠️ fails in existing `graph-writer.service.test.ts` because `better-sqlite3` native bindings are unavailable in this worktree.
+- Polished the menu behavior by clamping it to the viewport after render, focusing it so Escape works reliably, and closing it on outside click, outside right-click, scroll, or window resize.
+- Quality checks after menu-behavior polish: `npm run check` ✅, `npm run build:web` ✅ (same pre-existing Svelte warnings), `npm test` ⚠️ same existing `better-sqlite3` binding failure.
+- Added targeted helper coverage in `src/__tests__/graph-node-actions.test.ts` for action modeling and viewport clamping. `npx vitest run src/__tests__/graph-node-actions.test.ts` passes locally.
+- Final pre-summary checks: `npm run check` ✅, `npm run build:web` ✅ (same pre-existing Svelte warnings), `npm test` ⚠️ still blocked by the existing missing `better-sqlite3` native binding in `src/modules/graph/__tests__/graph-writer.service.test.ts`.
+- Confirmed the focused helper coverage still passes after the final import-typing fix: `npx vitest run src/__tests__/graph-node-actions.test.ts` ✅.
+- Completion summary: the graph context menu is now a dedicated component with a reusable action model, includes launch execution plus issue-link actions, clamps cleanly within the viewport, and continues to route launch requests through the existing execution flow in `App.svelte`.
 
 ## Blockers
-- `npm test` is currently blocked by an existing local environment issue: `better-sqlite3` native bindings are missing for the graph-writer test suite in this worktree.
+- Full `npm test` runs are blocked in this worktree by an existing environment issue: `better-sqlite3` native bindings are missing, causing `src/modules/graph/__tests__/graph-writer.service.test.ts` to fail before/independent of this change.

--- a/src/__tests__/graph-node-actions.test.ts
+++ b/src/__tests__/graph-node-actions.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- test imports the browser-side helper directly.
+import { buildGraphNodeContextMenu, clampContextMenuPosition } from "../../web/src/lib/graph-node-actions.js";
+
+function makeItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "studio-139",
+    name: "Add graph node context menu",
+    repo: "fusupo/escapement-studio",
+    issue_number: 139,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/139",
+    ...overrides,
+  };
+}
+
+function makeEligibility(overrides: Record<string, unknown> = {}) {
+  return {
+    can_launch: true,
+    launch_unavailable_reason: null,
+    dispatch_node: {
+      branch: "studio-139-branch",
+      default_base_ref: "develop",
+    },
+    ...overrides,
+  };
+}
+
+describe("buildGraphNodeContextMenu", () => {
+  it("returns null when there is no selected item", () => {
+    expect(buildGraphNodeContextMenu()).toBeNull();
+  });
+
+  it("builds issue and launch actions for dispatchable nodes", () => {
+    const menu = buildGraphNodeContextMenu({
+      item: makeItem(),
+      launchEligibility: makeEligibility(),
+    });
+
+    expect(menu.title).toBe("studio-139");
+    expect(menu.status).toEqual({ label: "Dispatchable", tone: "ready" });
+    expect(menu.sections[0].actions).toEqual([
+      {
+        id: "open-issue",
+        kind: "link",
+        label: "Open issue #139",
+        description: "fusupo/escapement-studio",
+        href: "https://github.com/fusupo/escapement-studio/issues/139",
+        external: true,
+      },
+      {
+        id: "launch-execution",
+        kind: "button",
+        label: "Launch execution",
+        description: "Branch studio-139-branch · Base develop",
+        disabled: false,
+        emphasis: "primary",
+      },
+    ]);
+  });
+
+  it("disables launch with a clear reason when the node is blocked", () => {
+    const menu = buildGraphNodeContextMenu({
+      item: makeItem({ issue_url: null, issue_number: null }),
+      launchEligibility: makeEligibility({
+        can_launch: false,
+        launch_unavailable_reason: "Work item is not currently dispatchable from the frontier.",
+      }),
+    });
+
+    expect(menu.status).toEqual({ label: "Blocked", tone: "blocked" });
+    expect(menu.sections[0].actions).toHaveLength(1);
+    expect(menu.sections[0].actions[0]).toMatchObject({
+      id: "launch-execution",
+      disabled: true,
+      description: "Work item is not currently dispatchable from the frontier.",
+    });
+  });
+
+  it("shows a loading state while launch eligibility is being fetched", () => {
+    const menu = buildGraphNodeContextMenu({
+      item: makeItem(),
+      launchEligibilityLoading: true,
+      launchEligibility: null,
+    });
+
+    expect(menu.status).toEqual({ label: "Checking…", tone: "loading" });
+    expect(menu.sections[0].actions[1]).toMatchObject({
+      id: "launch-execution",
+      label: "Launch execution",
+      disabled: true,
+      description: "Checking launch eligibility…",
+    });
+  });
+});
+
+describe("clampContextMenuPosition", () => {
+  it("leaves coordinates unchanged when they already fit", () => {
+    expect(clampContextMenuPosition({
+      x: 120,
+      y: 80,
+      menuWidth: 180,
+      menuHeight: 140,
+      viewportWidth: 800,
+      viewportHeight: 600,
+    })).toEqual({ x: 120, y: 80 });
+  });
+
+  it("clamps the menu inside the viewport padding", () => {
+    expect(clampContextMenuPosition({
+      x: 790,
+      y: 590,
+      menuWidth: 180,
+      menuHeight: 140,
+      viewportWidth: 800,
+      viewportHeight: 600,
+    })).toEqual({ x: 608, y: 448 });
+  });
+
+  it("pins very large menus to the viewport padding", () => {
+    expect(clampContextMenuPosition({
+      x: 4,
+      y: 7,
+      menuWidth: 1200,
+      menuHeight: 900,
+      viewportWidth: 800,
+      viewportHeight: 600,
+    })).toEqual({ x: 12, y: 12 });
+  });
+});

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -291,12 +291,10 @@
     }
 
     selectedId = detail.item.id;
-    const x = Math.min(detail.x, Math.max(16, window.innerWidth - 280));
-    const y = Math.min(detail.y, Math.max(16, window.innerHeight - 180));
     graphContextMenu = {
       open: true,
-      x,
-      y,
+      x: detail.x,
+      y: detail.y,
       item: detail.item,
     };
     await ensureLaunchEligibility(detail.item.id);
@@ -350,7 +348,13 @@
   <title>Escapement Studio</title>
 </svelte:head>
 
-<svelte:window on:click={closeGraphContextMenu} on:keydown={handleGlobalKeydown} on:scroll={closeGraphContextMenu} />
+<svelte:window
+  on:click={closeGraphContextMenu}
+  on:contextmenu={closeGraphContextMenu}
+  on:keydown={handleGlobalKeydown}
+  on:resize={closeGraphContextMenu}
+  on:scroll={closeGraphContextMenu}
+/>
 
 <div class="app-shell">
   <!-- Activity Bar (far left icon rail) -->

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -4,6 +4,7 @@
   import ReconciliationPanel from "./components/ReconciliationPanel.svelte";
   import SettingsPanel from "./components/SettingsPanel.svelte";
   import GraphView from "./components/GraphView.svelte";
+  import GraphNodeContextMenu from "./components/GraphNodeContextMenu.svelte";
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
   import {
@@ -19,6 +20,7 @@
     listWorkItems,
     updateWorkItem,
   } from "./lib/api.js";
+  import { buildGraphNodeContextMenu } from "./lib/graph-node-actions.js";
 
   const emptyGraph = { filters: {}, items: [], edges: [] };
   let graph = emptyGraph;
@@ -94,6 +96,12 @@
   $: selectedLaunchEligibilityLoading = selectedItem ? !!launchEligibilityLoadingIds[selectedItem.id] : false;
   $: contextMenuLaunchEligibility = graphContextMenu.item ? launchEligibilityById[graphContextMenu.item.id] ?? null : null;
   $: contextMenuLaunchEligibilityLoading = graphContextMenu.item ? !!launchEligibilityLoadingIds[graphContextMenu.item.id] : false;
+  $: graphContextMenuModel = buildGraphNodeContextMenu({
+    item: graphContextMenu.item,
+    launchEligibility: contextMenuLaunchEligibility,
+    launchEligibilityLoading: contextMenuLaunchEligibilityLoading,
+    launchingExecution,
+  });
   $: filterOptions = {
     repos: [...new Set(catalog.map((item) => item.repo).filter(Boolean))].sort(),
     states: [...new Set(catalog.map((item) => item.state).filter(Boolean))].sort(),
@@ -295,12 +303,6 @@
   }
 
   function handleGlobalKeydown(event) {
-    if (event.key === "Escape") {
-      closeGraphContextMenu();
-    }
-  }
-
-  function handleGraphContextMenuKeydown(event) {
     if (event.key === "Escape") {
       closeGraphContextMenu();
     }
@@ -544,33 +546,18 @@
       </div>
     {/if}
 
-    {#if activeTab === "planning" && graphContextMenu.open && graphContextMenu.item}
-      <div
-        class="graph-context-menu"
-        style={`left:${graphContextMenu.x}px; top:${graphContextMenu.y}px;`}
-        role="menu"
-        tabindex="-1"
-        aria-label={`Actions for ${graphContextMenu.item.id}`}
-        on:click|stopPropagation
-        on:keydown|stopPropagation={handleGraphContextMenuKeydown}
-      >
-        <div class="graph-context-menu-title">{graphContextMenu.item.id}</div>
-        <div class="graph-context-menu-name">{graphContextMenu.item.name}</div>
-        {#if contextMenuLaunchEligibilityLoading}
-          <div class="graph-context-menu-reason muted">Checking launch eligibility…</div>
-        {:else}
-          <button
-            class="graph-context-menu-action"
-            on:click={() => handleLaunchExecution(graphContextMenu.item)}
-            disabled={!contextMenuLaunchEligibility?.can_launch || launchingExecution}
-          >
-            {launchingExecution ? "Launching…" : "Launch execution"}
-          </button>
-          {#if contextMenuLaunchEligibility?.launch_unavailable_reason}
-            <div class="graph-context-menu-reason">{contextMenuLaunchEligibility.launch_unavailable_reason}</div>
-          {/if}
-        {/if}
-      </div>
+    {#if activeTab === "planning" && graphContextMenu.open && graphContextMenu.item && graphContextMenuModel}
+      <GraphNodeContextMenu
+        menu={graphContextMenuModel}
+        x={graphContextMenu.x}
+        y={graphContextMenu.y}
+        on:action={(event) => {
+          if (event.detail.id === "launch-execution") {
+            handleLaunchExecution(graphContextMenu.item);
+          }
+        }}
+        on:requestclose={closeGraphContextMenu}
+      />
     {/if}
 
     <!-- Status bar -->
@@ -913,43 +900,6 @@
     flex: 1;
     color: #6b7a94;
     font-size: 12px;
-  }
-
-  .graph-context-menu {
-    position: fixed;
-    z-index: 40;
-    min-width: 220px;
-    max-width: 280px;
-    display: grid;
-    gap: 6px;
-    padding: 10px;
-    border-radius: 8px;
-    border: 1px solid #2b3245;
-    background: #13171f;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
-  }
-
-  .graph-context-menu-title {
-    font-size: 11px;
-    font-weight: 700;
-    color: #e2e8f0;
-  }
-
-  .graph-context-menu-name {
-    font-size: 11px;
-    color: #8b95a5;
-    overflow-wrap: anywhere;
-  }
-
-  .graph-context-menu-action {
-    width: 100%;
-    justify-content: center;
-  }
-
-  .graph-context-menu-reason {
-    font-size: 11px;
-    color: #8b95a5;
-    line-height: 1.4;
   }
 
   /* ── Responsive ── */

--- a/web/src/components/GraphNodeContextMenu.svelte
+++ b/web/src/components/GraphNodeContextMenu.svelte
@@ -1,0 +1,195 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let menu = null;
+  export let x = 0;
+  export let y = 0;
+
+  const dispatch = createEventDispatcher();
+
+  function handleButtonAction(action) {
+    if (action.disabled) return;
+    dispatch("action", { id: action.id });
+  }
+
+  function handleLinkClick() {
+    dispatch("requestclose");
+  }
+
+  function handleKeydown(event) {
+    if (event.key === "Escape") {
+      dispatch("requestclose");
+    }
+  }
+</script>
+
+{#if menu}
+  <div
+    class="graph-context-menu"
+    style={`left:${x}px; top:${y}px;`}
+    role="menu"
+    tabindex="-1"
+    aria-label={`Actions for ${menu.title}`}
+    on:click|stopPropagation
+    on:contextmenu|preventDefault|stopPropagation
+    on:keydown|stopPropagation={handleKeydown}
+  >
+    <div class="graph-context-menu-header">
+      <div>
+        <div class="graph-context-menu-title">{menu.title}</div>
+        <div class="graph-context-menu-name">{menu.subtitle}</div>
+      </div>
+      {#if menu.status}
+        <span class="graph-context-menu-status {menu.status.tone}">{menu.status.label}</span>
+      {/if}
+    </div>
+
+    {#each menu.sections as section}
+      <section class="graph-context-menu-section" aria-label={section.label}>
+        <div class="graph-context-menu-section-label">{section.label}</div>
+        <div class="graph-context-menu-actions">
+          {#each section.actions as action}
+            <div class="graph-context-menu-action-row">
+              {#if action.kind === "link"}
+                <a
+                  class="graph-context-menu-action"
+                  href={action.href}
+                  target={action.external ? "_blank" : undefined}
+                  rel={action.external ? "noreferrer" : undefined}
+                  role="menuitem"
+                  on:click={handleLinkClick}
+                >
+                  {action.label}
+                </a>
+              {:else}
+                <button
+                  class="graph-context-menu-action"
+                  class:primary={action.emphasis === "primary"}
+                  on:click={() => handleButtonAction(action)}
+                  disabled={action.disabled}
+                  role="menuitem"
+                >
+                  {action.label}
+                </button>
+              {/if}
+              {#if action.description}
+                <div class="graph-context-menu-description">{action.description}</div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      </section>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .graph-context-menu {
+    position: fixed;
+    z-index: 40;
+    min-width: 240px;
+    max-width: 300px;
+    display: grid;
+    gap: 10px;
+    padding: 10px;
+    border-radius: 8px;
+    border: 1px solid #2b3245;
+    background: #13171f;
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  }
+
+  .graph-context-menu-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .graph-context-menu-title {
+    font-size: 11px;
+    font-weight: 700;
+    color: #e2e8f0;
+  }
+
+  .graph-context-menu-name {
+    margin-top: 2px;
+    font-size: 11px;
+    color: #8b95a5;
+    overflow-wrap: anywhere;
+  }
+
+  .graph-context-menu-status {
+    flex-shrink: 0;
+    padding: 2px 6px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+  }
+
+  .graph-context-menu-status.ready {
+    color: #3fb950;
+    background: rgba(63, 185, 80, 0.12);
+    border-color: rgba(63, 185, 80, 0.24);
+  }
+
+  .graph-context-menu-status.blocked {
+    color: #d29922;
+    background: rgba(210, 153, 34, 0.12);
+    border-color: rgba(210, 153, 34, 0.24);
+  }
+
+  .graph-context-menu-status.loading {
+    color: #58a6ff;
+    background: rgba(88, 166, 255, 0.12);
+    border-color: rgba(88, 166, 255, 0.24);
+  }
+
+  .graph-context-menu-section {
+    display: grid;
+    gap: 6px;
+  }
+
+  .graph-context-menu-section-label {
+    font-size: 10px;
+    font-weight: 700;
+    color: #8b95a5;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .graph-context-menu-actions {
+    display: grid;
+    gap: 6px;
+  }
+
+  .graph-context-menu-action-row {
+    display: grid;
+    gap: 4px;
+  }
+
+  .graph-context-menu-action {
+    width: 100%;
+    justify-content: flex-start;
+    text-align: left;
+  }
+
+  .graph-context-menu-action.primary {
+    background: rgba(37, 99, 235, 0.18);
+    border-color: rgba(37, 99, 235, 0.32);
+    color: #dbeafe;
+  }
+
+  .graph-context-menu-action.primary:hover:enabled {
+    background: rgba(37, 99, 235, 0.26);
+    border-color: rgba(37, 99, 235, 0.4);
+  }
+
+  .graph-context-menu-description {
+    font-size: 11px;
+    color: #8b95a5;
+    line-height: 1.4;
+  }
+</style>

--- a/web/src/components/GraphNodeContextMenu.svelte
+++ b/web/src/components/GraphNodeContextMenu.svelte
@@ -1,11 +1,43 @@
 <script>
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, tick } from "svelte";
+  import { clampContextMenuPosition } from "../lib/graph-node-actions.js";
 
   export let menu = null;
   export let x = 0;
   export let y = 0;
 
   const dispatch = createEventDispatcher();
+
+  let menuEl;
+  let position = { x, y };
+
+  async function updatePlacement() {
+    await tick();
+    if (!menuEl || !menu) return;
+
+    const rect = menuEl.getBoundingClientRect();
+    const next = clampContextMenuPosition({
+      x,
+      y,
+      menuWidth: rect.width,
+      menuHeight: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+
+    if (position.x !== next.x || position.y !== next.y) {
+      position = next;
+    }
+
+    if (document.activeElement !== menuEl) {
+      menuEl.focus();
+    }
+  }
+
+  $: if (menu) {
+    position = { x, y };
+    void updatePlacement();
+  }
 
   function handleButtonAction(action) {
     if (action.disabled) return;
@@ -25,8 +57,9 @@
 
 {#if menu}
   <div
+    bind:this={menuEl}
     class="graph-context-menu"
-    style={`left:${x}px; top:${y}px;`}
+    style={`left:${position.x}px; top:${position.y}px;`}
     role="menu"
     tabindex="-1"
     aria-label={`Actions for ${menu.title}`}

--- a/web/src/lib/graph-node-actions.js
+++ b/web/src/lib/graph-node-actions.js
@@ -1,0 +1,75 @@
+export function buildGraphNodeContextMenu({
+  item,
+  launchEligibility,
+  launchEligibilityLoading = false,
+  launchingExecution = false,
+} = {}) {
+  if (!item) {
+    return null;
+  }
+
+  const launchStatus = launchEligibilityLoading
+    ? { label: "Checking…", tone: "loading" }
+    : launchEligibility?.can_launch
+      ? { label: "Dispatchable", tone: "ready" }
+      : { label: "Blocked", tone: "blocked" };
+
+  const launchDescription = launchEligibilityLoading
+    ? "Checking launch eligibility…"
+    : launchEligibility?.can_launch
+      ? formatDispatchNodeSummary(launchEligibility.dispatch_node)
+      : launchEligibility?.launch_unavailable_reason || "Launch execution is unavailable for this node.";
+
+  const actions = [];
+
+  if (item.issue_url) {
+    actions.push({
+      id: "open-issue",
+      kind: "link",
+      label: item.issue_number ? `Open issue #${item.issue_number}` : "Open issue",
+      description: item.repo ? item.repo : "Open linked GitHub issue",
+      href: item.issue_url,
+      external: true,
+    });
+  }
+
+  actions.push({
+    id: "launch-execution",
+    kind: "button",
+    label: launchingExecution ? "Launching…" : "Launch execution",
+    description: launchDescription,
+    disabled: launchEligibilityLoading || launchingExecution || !launchEligibility?.can_launch,
+    emphasis: "primary",
+  });
+
+  return {
+    title: item.id,
+    subtitle: item.name,
+    status: launchStatus,
+    sections: [
+      {
+        id: "node-actions",
+        label: "Node actions",
+        actions,
+      },
+    ],
+  };
+}
+
+function formatDispatchNodeSummary(dispatchNode) {
+  if (!dispatchNode) {
+    return "Ready to launch using the standard execution flow.";
+  }
+
+  const parts = [];
+  if (dispatchNode.branch) {
+    parts.push(`Branch ${dispatchNode.branch}`);
+  }
+  if (dispatchNode.default_base_ref) {
+    parts.push(`Base ${dispatchNode.default_base_ref}`);
+  }
+
+  return parts.length > 0
+    ? parts.join(" · ")
+    : "Ready to launch using the standard execution flow.";
+}

--- a/web/src/lib/graph-node-actions.js
+++ b/web/src/lib/graph-node-actions.js
@@ -1,3 +1,5 @@
+const DEFAULT_MENU_PADDING = 12;
+
 export function buildGraphNodeContextMenu({
   item,
   launchEligibility,
@@ -53,6 +55,24 @@ export function buildGraphNodeContextMenu({
         actions,
       },
     ],
+  };
+}
+
+export function clampContextMenuPosition({
+  x = 0,
+  y = 0,
+  menuWidth = 0,
+  menuHeight = 0,
+  viewportWidth = 0,
+  viewportHeight = 0,
+  padding = DEFAULT_MENU_PADDING,
+} = {}) {
+  const maxX = Math.max(padding, viewportWidth - menuWidth - padding);
+  const maxY = Math.max(padding, viewportHeight - menuHeight - padding);
+
+  return {
+    x: Math.max(padding, Math.min(x, maxX)),
+    y: Math.max(padding, Math.min(y, maxY)),
   };
 }
 


### PR DESCRIPTION
## Summary
Understood.

- **Launch execution applies only to frontier nodes**
- **Yes, most of the base functionality was already present**
- I proceeded as a **polish/completion pass**, not a full rewrite

That matches the implementation I made:
- the menu still uses the existing execution eligibility/launch flow
- blocked/non-frontier nodes show disabled launch affordances with reasons
- the graph menu is now more reusable/extensible

If you want, I can next help with:
- reviewing the diff for possible overreach
- squashing/rewording commits
- drafting the PR summary

actual_files synced: 1 file(s).

## Context
- Work item: studio-139
- Issue: https://github.com/fusupo/escapement-studio/issues/139
- Base branch: develop
- Head branch: studio-139-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775705826696
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-139-branch
- Scope hint: Add a graph-node context menu with issue actions, including launching execution directly from the graph.

## Changed files
- `SCRATCHPAD.md`