### PR TITLE
feat: introduce plans/ vs runs/ filesystem split (ADR 014 step 1)

### DIFF
--- a/src/lib/__tests__/context-layout.test.ts
+++ b/src/lib/__tests__/context-layout.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ARCHIVES_DIR,
+  PLANS_DIR,
+  PLAN_METADATA_FILE,
+  RUNS_DIR,
+  WORKTREES_DIR,
+  archiveDir,
+  archivesRoot,
+  ensurePlanDir,
+  planDir,
+  plansRoot,
+  runDir,
+  runsRoot,
+  workItemSlug,
+  worktreeDir,
+  worktreesRoot,
+} from "../context-layout.js";
+
+describe("workItemSlug", () => {
+  it("passes alphanumeric ids through unchanged", () => {
+    expect(workItemSlug("studio1234")).toBe("studio1234");
+    expect(workItemSlug("Abc123")).toBe("Abc123");
+  });
+
+  it("replaces non-alphanumeric characters with underscores", () => {
+    expect(workItemSlug("studio-1234")).toBe("studio_1234");
+    expect(workItemSlug("Studio Foo")).toBe("Studio_Foo");
+    expect(workItemSlug("foo.bar")).toBe("foo_bar");
+    expect(workItemSlug("foo/bar")).toBe("foo_bar");
+  });
+
+  it("collapses runs of separators into a single underscore", () => {
+    expect(workItemSlug("foo---bar")).toBe("foo_bar");
+    expect(workItemSlug("foo   bar")).toBe("foo_bar");
+    expect(workItemSlug("foo-_-bar")).toBe("foo_bar");
+    expect(workItemSlug("a!!!b???c")).toBe("a_b_c");
+  });
+
+  it("trims leading and trailing separators", () => {
+    expect(workItemSlug("__foo__")).toBe("foo");
+    expect(workItemSlug("/foo/bar/")).toBe("foo_bar");
+    expect(workItemSlug("---studio-1---")).toBe("studio_1");
+  });
+
+  it("throws when the result would be empty", () => {
+    expect(() => workItemSlug("")).toThrow(/empty slug/);
+    expect(() => workItemSlug("!!!")).toThrow(/empty slug/);
+    expect(() => workItemSlug("___")).toThrow(/empty slug/);
+    expect(() => workItemSlug("  ")).toThrow(/empty slug/);
+  });
+
+  it("throws on non-string input", () => {
+    // @ts-expect-error — intentional invalid input
+    expect(() => workItemSlug(undefined)).toThrow(TypeError);
+    // @ts-expect-error — intentional invalid input
+    expect(() => workItemSlug(null)).toThrow(TypeError);
+  });
+});
+
+describe("path builders", () => {
+  const root = "/tmp/fake-ctx";
+
+  it("builds top-level root paths using the directory constants", () => {
+    expect(plansRoot(root)).toBe(join(root, PLANS_DIR));
+    expect(runsRoot(root)).toBe(join(root, RUNS_DIR));
+    expect(worktreesRoot(root)).toBe(join(root, WORKTREES_DIR));
+    expect(archivesRoot(root)).toBe(join(root, ARCHIVES_DIR));
+  });
+
+  it("builds a plan dir path from a work item id", () => {
+    expect(planDir(root, "studio-1234")).toBe(join(root, PLANS_DIR, "studio_1234"));
+  });
+
+  it("builds a run dir path from a run id", () => {
+    expect(runDir(root, "exec_1775629090122")).toBe(join(root, RUNS_DIR, "exec_1775629090122"));
+  });
+
+  it("builds a worktree dir path from a branch", () => {
+    expect(worktreeDir(root, "studio-42-branch")).toBe(join(root, WORKTREES_DIR, "studio-42-branch"));
+  });
+
+  it("builds an archive dir path from a work item id", () => {
+    expect(archiveDir(root, "studio-1234")).toBe(join(root, ARCHIVES_DIR, "studio_1234"));
+  });
+});
+
+describe("ensurePlanDir", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-151-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("creates the plan dir and writes a metadata marker on first call", () => {
+    const dir = ensurePlanDir(tmpRoot, "studio-1234");
+
+    expect(dir).toBe(join(tmpRoot, PLANS_DIR, "studio_1234"));
+    expect(existsSync(dir)).toBe(true);
+
+    const metadataPath = join(dir, PLAN_METADATA_FILE);
+    expect(existsSync(metadataPath)).toBe(true);
+
+    const marker = JSON.parse(readFileSync(metadataPath, "utf8"));
+    expect(marker.plan_id).toBe("studio_1234");
+    expect(marker.work_item_id).toBe("studio-1234");
+    expect(typeof marker.created_at).toBe("string");
+  });
+
+  it("is idempotent when called twice for the same work item id", () => {
+    const first = ensurePlanDir(tmpRoot, "studio-1234");
+    const firstMarker = readFileSync(join(first, PLAN_METADATA_FILE), "utf8");
+
+    const second = ensurePlanDir(tmpRoot, "studio-1234");
+    const secondMarker = readFileSync(join(second, PLAN_METADATA_FILE), "utf8");
+
+    expect(second).toBe(first);
+    // The second call should NOT rewrite the marker (preserves original created_at)
+    expect(secondMarker).toBe(firstMarker);
+  });
+
+  it("throws on slug collision when a different work item id already owns the slug", () => {
+    ensurePlanDir(tmpRoot, "studio-1234");
+
+    // Both of these normalize to "studio_1234" but reference different work items
+    expect(() => ensurePlanDir(tmpRoot, "studio_1234")).toThrow(/slug collision/);
+    expect(() => ensurePlanDir(tmpRoot, "studio.1234")).toThrow(/slug collision/);
+  });
+
+  it("throws a clear error when an existing metadata marker is corrupt", () => {
+    const slug = workItemSlug("studio-1234");
+    const dir = join(tmpRoot, PLANS_DIR, slug);
+    const metadataPath = join(dir, PLAN_METADATA_FILE);
+    // Create a corrupt marker file
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(metadataPath, "{ this is not json", "utf8");
+
+    expect(() => ensurePlanDir(tmpRoot, "studio-1234")).toThrow(/could not be parsed/);
+  });
+
+  it("throws when the work item id would produce an empty slug", () => {
+    expect(() => ensurePlanDir(tmpRoot, "!!!")).toThrow(/empty slug/);
+  });
+});

--- a/src/lib/context-layout.ts
+++ b/src/lib/context-layout.ts
@@ -1,0 +1,160 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Centralized filesystem layout for the Studio context root.
+ *
+ * Implements ADR 014 step 1: introduces the `plans/<slug>/` directory
+ * convention and derives stable slugs from work item ids. This module is the
+ * single source of truth for context-root path construction — execution and
+ * sub-agent services should reference these helpers instead of inlining joins.
+ *
+ * See docs/adr/014-plans-runs-state-model.md and
+ * docs/contracts/plan-and-run-lifecycle.md.
+ */
+
+/** Top-level directory names under the context root. */
+export const PLANS_DIR = "plans";
+export const RUNS_DIR = "runs";
+export const WORKTREES_DIR = "worktrees";
+export const ARCHIVES_DIR = "archives";
+
+/** Per-plan metadata sidecar filename, used for slug collision detection. */
+export const PLAN_METADATA_FILE = "metadata.json";
+
+/**
+ * Derive a stable plan-dir slug from a work item id.
+ *
+ * Rules (from ADR 014):
+ *   1. Replace every non-alphanumeric character with `_`
+ *   2. Collapse runs of `_` to a single `_`
+ *   3. Trim leading/trailing `_`
+ *
+ * Throws if the resulting slug is empty (e.g. input was empty or contained
+ * only non-alphanumeric characters).
+ *
+ * @example
+ *   workItemSlug("studio-1234")  // → "studio_1234"
+ *   workItemSlug("Studio Foo")   // → "Studio_Foo"
+ *   workItemSlug("foo---bar")    // → "foo_bar"
+ *   workItemSlug("__foo__")      // → "foo"
+ */
+export function workItemSlug(workItemId: string): string {
+  if (typeof workItemId !== "string") {
+    throw new TypeError(`workItemSlug: expected string, got ${typeof workItemId}`);
+  }
+
+  const replaced = workItemId.replace(/[^a-zA-Z0-9]+/g, "_");
+  const trimmed = replaced.replace(/^_+|_+$/g, "");
+
+  if (!trimmed) {
+    throw new Error(
+      `workItemSlug: work item id ${JSON.stringify(workItemId)} produced an empty slug after normalization`,
+    );
+  }
+
+  return trimmed;
+}
+
+/* ── Top-level root path builders ────────────────────────────────────────── */
+
+export function plansRoot(artifactRoot: string): string {
+  return join(artifactRoot, PLANS_DIR);
+}
+
+export function runsRoot(artifactRoot: string): string {
+  return join(artifactRoot, RUNS_DIR);
+}
+
+export function worktreesRoot(artifactRoot: string): string {
+  return join(artifactRoot, WORKTREES_DIR);
+}
+
+export function archivesRoot(artifactRoot: string): string {
+  return join(artifactRoot, ARCHIVES_DIR);
+}
+
+/* ── Entity path builders ────────────────────────────────────────────────── */
+
+/**
+ * Path to the canonical plan directory for a work item.
+ * Does not touch the filesystem — use `ensurePlanDir` to create it.
+ */
+export function planDir(artifactRoot: string, workItemId: string): string {
+  return join(plansRoot(artifactRoot), workItemSlug(workItemId));
+}
+
+/** Path to a run directory by run id. */
+export function runDir(artifactRoot: string, runId: string): string {
+  return join(runsRoot(artifactRoot), runId);
+}
+
+/** Path to a worktree directory by branch name (or any safe directory name). */
+export function worktreeDir(artifactRoot: string, branch: string): string {
+  return join(worktreesRoot(artifactRoot), branch);
+}
+
+/** Path to an archive directory for a work item. */
+export function archiveDir(artifactRoot: string, workItemId: string): string {
+  return join(archivesRoot(artifactRoot), workItemSlug(workItemId));
+}
+
+/* ── Plan dir creation with collision detection ──────────────────────────── */
+
+interface PlanMetadataMarker {
+  plan_id: string;
+  work_item_id: string;
+  created_at: string;
+}
+
+/**
+ * Ensure the plan directory for a work item exists, creating it (and a
+ * minimal metadata sidecar) on first call. Idempotent when called repeatedly
+ * for the same work item id.
+ *
+ * Detects slug collisions: if another work item id already owns a plan dir at
+ * the same slug path, throws with a clear error. This matches the collision
+ * detection requirement in ADR 014 step 1.
+ *
+ * Returns the absolute path to the plan directory.
+ *
+ * @throws if a different work item id already owns the slug
+ */
+export function ensurePlanDir(artifactRoot: string, workItemId: string): string {
+  const slug = workItemSlug(workItemId);
+  const dir = join(plansRoot(artifactRoot), slug);
+  const metadataPath = join(dir, PLAN_METADATA_FILE);
+
+  if (existsSync(metadataPath)) {
+    let existing: PlanMetadataMarker | null = null;
+    try {
+      existing = JSON.parse(readFileSync(metadataPath, "utf8")) as PlanMetadataMarker;
+    } catch {
+      // Corrupt marker — treat as a collision the caller must resolve manually.
+      throw new Error(
+        `ensurePlanDir: existing plan metadata at ${metadataPath} could not be parsed; refusing to overwrite`,
+      );
+    }
+
+    if (existing?.work_item_id && existing.work_item_id !== workItemId) {
+      throw new Error(
+        `ensurePlanDir: slug collision — work item ${JSON.stringify(workItemId)} normalizes to ${JSON.stringify(slug)}, ` +
+          `but that slug is already owned by ${JSON.stringify(existing.work_item_id)}`,
+      );
+    }
+
+    // Same work item id — idempotent no-op.
+    return dir;
+  }
+
+  mkdirSync(dir, { recursive: true });
+
+  const marker: PlanMetadataMarker = {
+    plan_id: slug,
+    work_item_id: workItemId,
+    created_at: new Date().toISOString(),
+  };
+  writeFileSync(metadataPath, JSON.stringify(marker, null, 2), "utf8");
+
+  return dir;
+}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -5,6 +5,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileS
 import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
+import { runDir, worktreesRoot } from "../../lib/context-layout.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -45,7 +46,7 @@ export class ExecutionService {
   private readonly streamId = "execution-runs";
   private readonly eventSubject = new Subject<MessageEvent>();
   private readonly artifactRoot = resolve(getConfig().artifactRoot);
-  private readonly worktreeRoot = join(this.artifactRoot, "worktrees");
+  private readonly worktreeRoot = worktreesRoot(this.artifactRoot);
   private readonly recentRuns: ExecutionRunRecord[] = [];
   private readonly recentRunLimit = 16;
   // No cap on activity log — full history preserved in status.json
@@ -1473,7 +1474,7 @@ export class ExecutionService {
       branch: input.branch,
       base_ref: input.baseRef,
       worktree_path: input.worktreePath,
-      artifact_dir: join(this.artifactRoot, "runs", runId),
+      artifact_dir: runDir(this.artifactRoot, runId),
       prompt: input.prompt,
       progress_message: input.resultSummary ?? (input.status === "queued" ? "Execution run queued." : undefined),
       result_summary: input.resultSummary,

--- a/src/modules/planning/sub-agent.service.ts
+++ b/src/modules/planning/sub-agent.service.ts
@@ -10,6 +10,7 @@ import {
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
+import { runDir } from "../../lib/context-layout.js";
 import type {
   DelegateSubAgentToolInput,
   SubAgentResultEnvelope,
@@ -37,7 +38,7 @@ export class SubAgentService {
   async runDelegation(input: DelegateSubAgentToolInput, hooks: RunHooks = {}): Promise<SubAgentRunRecord> {
     const runId = `sub_${Date.now()}`;
     const createdAt = this.now();
-    const artifactDir = join(this.artifactRoot, "runs", runId);
+    const artifactDir = runDir(this.artifactRoot, runId);
     mkdirSync(artifactDir, { recursive: true });
 
     let run: SubAgentRunRecord = {


### PR DESCRIPTION
Closes #151

## Summary
Foundational no-op step for ADR 014. Centralizes filesystem layout constants, adds stable slug derivation from work item ids, and introduces the `plans/<slug>/` directory convention. No existing behavior changes — subsequent ADR 014 steps will build on this foundation.

## Changes

### New: `src/lib/context-layout.ts`
- Directory name constants: `PLANS_DIR`, `RUNS_DIR`, `WORKTREES_DIR`, `ARCHIVES_DIR`, `PLAN_METADATA_FILE`
- `workItemSlug()` — pure derivation: non-alphanumeric → `_`, collapse runs, trim ends, throws on empty result
- Path builders (pure, no fs): `plansRoot`, `runsRoot`, `worktreesRoot`, `archivesRoot`, `planDir`, `runDir`, `worktreeDir`, `archiveDir`
- `ensurePlanDir()` — creates a plan dir and writes a minimal `metadata.json` marker (`plan_id`, `work_item_id`, `created_at`). Idempotent for the same work item id, throws on slug collision when a different work item id already owns the slug

### New: `src/lib/__tests__/context-layout.test.ts`
16 unit tests covering:
- Slug derivation: alnum passthrough, separator replacement, run collapse, trim, empty-result error, type error
- Path builder outputs for all top-level and entity paths
- `ensurePlanDir`: creation, idempotence, collision detection, corrupt marker handling, empty slug

### Refactored
- **`src/modules/execution/execution.service.ts`**: `worktreeRoot` now derived via `worktreesRoot()`; run `artifact_dir` now uses `runDir()`. Kept `getWorktreePath` reading the cached `this.worktreeRoot` field so the `Object.create`-based test harness in `launch-eligibility.test.ts` can continue to stub it directly.
- **`src/modules/planning/sub-agent.service.ts`**: specialist run `artifactDir` now uses `runDir()` instead of inline `join(artifactRoot, "runs", runId)`

## Design notes
- Helper lives in `src/lib/` because both execution and sub-agent services need it — not in `execution/`
- Slug derivation is pure (same input → same slug); collision detection happens at `ensurePlanDir` via marker file comparison
- Neither `plans/` nor `archives/` is created eagerly — no caller invokes `ensurePlanDir` yet. Step 2 (canonical scratchpad move) will wire that in

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Full `npx vitest run` — 126/126 tests passing across 15 files
- [x] `npx vite build --config web/vite.config.ts` clean
- [ ] Manual sanity check: launching an execution run from the Studio UI still produces a worktree and a `runs/<run_id>/` directory

## References
- `docs/adr/014-plans-runs-state-model.md`
- `docs/contracts/plan-and-run-lifecycle.md`