### PR TITLE
feat: canonical scratchpad at plans/<slug>/SCRATCHPAD_<slug>.md (ADR 014 step 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ web-dist/
 .env
 *.db
 SCRATCHPAD.md
+SCRATCHPAD_*.md

--- a/src/lib/__tests__/context-layout.test.ts
+++ b/src/lib/__tests__/context-layout.test.ts
@@ -10,6 +10,7 @@ import {
   WORKTREES_DIR,
   archiveDir,
   archivesRoot,
+  canonicalScratchpadPath,
   ensurePlanDir,
   planDir,
   plansRoot,
@@ -85,6 +86,27 @@ describe("path builders", () => {
 
   it("builds an archive dir path from a work item id", () => {
     expect(archiveDir(root, "studio-1234")).toBe(join(root, ARCHIVES_DIR, "studio_1234"));
+  });
+
+  it("builds a canonical scratchpad path from a work item id", () => {
+    expect(canonicalScratchpadPath(root, "studio-1234")).toBe(
+      join(root, PLANS_DIR, "studio_1234", "SCRATCHPAD_studio_1234.md"),
+    );
+  });
+
+  it("places the canonical scratchpad inside the plan dir", () => {
+    const workItemId = "studio-42";
+    const scratchpad = canonicalScratchpadPath(root, workItemId);
+    expect(scratchpad.startsWith(planDir(root, workItemId) + "/")).toBe(true);
+  });
+
+  it("normalizes the slug inside canonical scratchpad filename", () => {
+    expect(canonicalScratchpadPath(root, "Studio Foo")).toBe(
+      join(root, PLANS_DIR, "Studio_Foo", "SCRATCHPAD_Studio_Foo.md"),
+    );
+    expect(canonicalScratchpadPath(root, "123-abc")).toBe(
+      join(root, PLANS_DIR, "123_abc", "SCRATCHPAD_123_abc.md"),
+    );
   });
 });
 

--- a/src/lib/context-layout.ts
+++ b/src/lib/context-layout.ts
@@ -99,6 +99,18 @@ export function archiveDir(artifactRoot: string, workItemId: string): string {
   return join(archivesRoot(artifactRoot), workItemSlug(workItemId));
 }
 
+/**
+ * Path to the canonical scratchpad file for a work item's plan.
+ *
+ * Returns `plans/<slug>/SCRATCHPAD_<slug>.md`. This is the single source of
+ * truth for plan content per ADR 014 — execution copies this file into the
+ * worktree at run launch and syncs it back at phase boundaries.
+ */
+export function canonicalScratchpadPath(artifactRoot: string, workItemId: string): string {
+  const slug = workItemSlug(workItemId);
+  return join(planDir(artifactRoot, workItemId), `SCRATCHPAD_${slug}.md`);
+}
+
 /* ── Plan dir creation with collision detection ──────────────────────────── */
 
 interface PlanMetadataMarker {

--- a/src/modules/execution/__tests__/scratchpad-canonical.test.ts
+++ b/src/modules/execution/__tests__/scratchpad-canonical.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionRunRecord } from "../types.js";
+import { canonicalScratchpadPath, planDir } from "../../../lib/context-layout.js";
+
+/**
+ * Canonical scratchpad behavior (ADR 014 step 2).
+ *
+ * Tests use Object.create to bypass DI and inject the artifactRoot + a
+ * minimal run record, matching the pattern in build-scratchpad.test.ts and
+ * launch-eligibility.test.ts.
+ */
+
+interface HarnessService {
+  artifactRoot: string;
+  logger: { warn: (msg: string) => void };
+  warnings: string[];
+  syncScratchpadToCanonical: ExecutionService["syncScratchpadToCanonical"];
+  getRunScratchpad: ExecutionService["getRunScratchpad"];
+  writeScratchpad: ExecutionService["writeScratchpad"];
+  getRun: (runId: string) => ExecutionRunRecord | undefined;
+}
+
+function makeService(artifactRoot: string, run?: ExecutionRunRecord): HarnessService {
+  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  service.artifactRoot = artifactRoot;
+  service.warnings = [];
+  service.logger = {
+    warn: (msg: string) => {
+      service.warnings.push(msg);
+    },
+  };
+  service.getRun = (runId: string) => (run && run.run_id === runId ? run : undefined);
+  return service;
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_test",
+    run_type: "execution",
+    work_item_id: "studio-999",
+    work_item_name: "Test work item",
+    status: "running",
+    created_at: "2026-04-09T00:00:00.000Z",
+    updated_at: "2026-04-09T00:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "studio-999-branch",
+    base_ref: "develop",
+    worktree_path: "",
+    artifact_dir: "",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+describe("ExecutionService scratchpad canonical flow", () => {
+  let tmpRoot: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-152-"));
+    worktree = join(tmpRoot, "wt");
+    mkdirSync(worktree, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("syncScratchpadToCanonical", () => {
+    it("copies the worktree scratchpad to canonical when present", () => {
+      const run = makeRun({ worktree_path: worktree });
+      const service = makeService(tmpRoot, run);
+
+      // Seed the canonical plan dir and the worktree scratchpad
+      mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
+      const worktreeScratchpad = join(worktree, "SCRATCHPAD_studio_999.md");
+      writeFileSync(worktreeScratchpad, "agent-authored content", "utf8");
+
+      service.syncScratchpadToCanonical(run);
+
+      const canonical = canonicalScratchpadPath(tmpRoot, run.work_item_id);
+      expect(existsSync(canonical)).toBe(true);
+      expect(readFileSync(canonical, "utf8")).toBe("agent-authored content");
+    });
+
+    it("leaves canonical unchanged and logs a warning when worktree file is missing", () => {
+      const run = makeRun({ worktree_path: worktree });
+      const service = makeService(tmpRoot, run);
+
+      // Seed canonical with prior content; no worktree scratchpad
+      mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
+      const canonical = canonicalScratchpadPath(tmpRoot, run.work_item_id);
+      writeFileSync(canonical, "last-known-good", "utf8");
+
+      expect(() => service.syncScratchpadToCanonical(run)).not.toThrow();
+      expect(readFileSync(canonical, "utf8")).toBe("last-known-good");
+      expect(service.warnings.some((w) => w.includes("worktree scratchpad missing"))).toBe(true);
+    });
+  });
+
+  describe("getRunScratchpad", () => {
+    it("prefers the canonical plan file", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeService(tmpRoot, run);
+
+      mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
+      writeFileSync(canonicalScratchpadPath(tmpRoot, run.work_item_id), "canonical content", "utf8");
+      // Also write a worktree copy — canonical should win
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree content", "utf8");
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe("canonical content");
+      expect(result).not.toHaveProperty("source");
+    });
+
+    it("falls back to the worktree live copy when canonical is absent", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeService(tmpRoot, run);
+
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree only", "utf8");
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe("worktree only");
+    });
+
+    it("returns null content when neither canonical nor worktree exists", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeService(tmpRoot, run);
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe(null);
+    });
+
+    it("returns null content when run is not found", () => {
+      const service = makeService(tmpRoot);
+      const result = service.getRunScratchpad("nonexistent");
+      expect(result.content).toBe(null);
+    });
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -5,7 +5,13 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileS
 import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
-import { runDir, worktreesRoot } from "../../lib/context-layout.js";
+import {
+  canonicalScratchpadPath,
+  ensurePlanDir,
+  runDir,
+  workItemSlug,
+  worktreesRoot,
+} from "../../lib/context-layout.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -662,7 +668,7 @@ export class ExecutionService {
     this.appendEvent(run, { type: "scratchpad_written", path: scratchpadPath });
     this.emitChecklistIfChanged(run);
 
-    // Ensure SCRATCHPAD.md is gitignored so the agent can't accidentally commit it
+    // Ensure SCRATCHPAD_*.md is gitignored so the agent can't accidentally commit it
     this.ensureScratchpadIgnored(run.worktree_path);
 
     // --- Create agent session ---
@@ -696,8 +702,9 @@ export class ExecutionService {
       // ============================================================
       // PHASE 1: SETUP (like setup-work skill)
       // Agent reads issue, analyzes codebase, writes implementation
-      // plan into SCRATCHPAD.md, surfaces questions
+      // plan into the canonical scratchpad, surfaces questions
       // ============================================================
+      const scratchpadName = `SCRATCHPAD_${workItemSlug(run.work_item_id)}.md`;
       if (disambiguate) {
         run = this.updateRun(runId, {
           status: "running",
@@ -709,6 +716,10 @@ export class ExecutionService {
 
         const setupPrompt = this.buildSetupPrompt(run, node, workItem, issueBody, projectContext);
         await session.prompt(setupPrompt);
+
+        // Sync the agent's scratchpad edits back to the canonical plan file
+        // (end of setup phase, before the approval gate).
+        this.syncScratchpadToCanonical(run);
 
         // Setup prompt finished — now switch to disambiguating so the UI shows the approval gate
         this.emitChecklistIfChanged(run);
@@ -728,8 +739,9 @@ export class ExecutionService {
 
         if (additionalContext) {
           await session.prompt(
-            `The user provided feedback on your plan:\n\n${additionalContext}\n\nUpdate the SCRATCHPAD.md implementation plan accordingly, then confirm you're ready to start coding.`
+            `The user provided feedback on your plan:\n\n${additionalContext}\n\nUpdate the ${scratchpadName} implementation plan accordingly, then confirm you're ready to start coding.`
           );
+          this.syncScratchpadToCanonical(run);
           this.emitChecklistIfChanged(run);
         }
 
@@ -748,6 +760,10 @@ export class ExecutionService {
       // ============================================================
       const doWorkPrompt = this.buildDoWorkPrompt(run, node, workItem, projectContext);
       await session.prompt(doWorkPrompt);
+
+      // Sync the agent's final scratchpad state back to canonical
+      // (end of do-work phase).
+      this.syncScratchpadToCanonical(run);
 
       this.emitChecklistIfChanged(run);
     } finally {
@@ -768,11 +784,9 @@ export class ExecutionService {
     mkdirSync(join(run.artifact_dir, "outputs"), { recursive: true });
     writeFileSync(join(run.artifact_dir, "outputs", "response.json"), JSON.stringify({ assistant_text: assistantText, changed_files: changedFiles, actual_files_sync: actualFilesSync }, null, 2), "utf8");
 
-    // Copy final scratchpad to artifacts
-    const finalScratchpad = join(run.worktree_path, "SCRATCHPAD.md");
-    if (existsSync(finalScratchpad)) {
-      writeFileSync(join(run.artifact_dir, "scratchpad-final.md"), readFileSync(finalScratchpad, "utf8"), "utf8");
-    }
+    // The canonical scratchpad at plans/<slug>/SCRATCHPAD_<slug>.md is the
+    // post-run snapshot — synced above at each phase boundary. No separate
+    // scratchpad-final.md is written under the run artifact dir anymore.
 
     this.pushActivity(run.run_id, "status_change", `Execution completed. ${changedFiles.length} file(s) changed.`);
     run = this.updateRun(initialRun.run_id, {
@@ -818,25 +832,26 @@ export class ExecutionService {
     };
   }
 
-  getRunScratchpad(runId: string): { run_id: string; content: string | null; source: "worktree" | "artifact" | null } {
+  getRunScratchpad(runId: string): { run_id: string; content: string | null } {
     const run = this.getRun(runId);
     if (!run) {
-      return { run_id: runId, content: null, source: null };
+      return { run_id: runId, content: null };
     }
 
-    // Prefer the live scratchpad in the worktree
-    const worktreePath = join(run.worktree_path, "SCRATCHPAD.md");
+    // Prefer the canonical plan file (source of truth, synced at each phase boundary)
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+    if (existsSync(canonicalPath)) {
+      return { run_id: runId, content: readFileSync(canonicalPath, "utf8") };
+    }
+
+    // Fall back to the live worktree copy (active run before first sync-back)
+    const slug = workItemSlug(run.work_item_id);
+    const worktreePath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
     if (existsSync(worktreePath)) {
-      return { run_id: runId, content: readFileSync(worktreePath, "utf8"), source: "worktree" };
+      return { run_id: runId, content: readFileSync(worktreePath, "utf8") };
     }
 
-    // Fall back to the initial snapshot in the artifact directory
-    const artifactPath = join(run.artifact_dir, "scratchpad-initial.md");
-    if (existsSync(artifactPath)) {
-      return { run_id: runId, content: readFileSync(artifactPath, "utf8"), source: "artifact" };
-    }
-
-    return { run_id: runId, content: null, source: null };
+    return { run_id: runId, content: null };
   }
 
   async sendFollowUp(input: FollowUpMessageDto): Promise<FollowUpMessageResult> {
@@ -1036,7 +1051,8 @@ export class ExecutionService {
   }
 
   private readChecklistFromWorktree(run: ExecutionRunRecord): ChecklistItem[] {
-    const scratchpadPath = join(run.worktree_path, "SCRATCHPAD.md");
+    const slug = workItemSlug(run.work_item_id);
+    const scratchpadPath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
     if (!existsSync(scratchpadPath)) {
       return [];
     }
@@ -1223,6 +1239,7 @@ export class ExecutionService {
     issueBody: string | null,
     projectContext: string | null,
   ): string {
+    const scratchpadName = `SCRATCHPAD_${workItemSlug(run.work_item_id)}.md`;
     const owned = node.files_owned.length ? node.files_owned.map((p) => `- ${p}`).join("\n") : "- (none predicted)";
     const shared = node.files_shared.length
       ? node.files_shared.map((f) => `- ${f.path} (${f.assessment}/${f.confidence})`).join("\n")
@@ -1239,7 +1256,7 @@ export class ExecutionService {
       "",
       "1. Read and understand the issue scope below",
       "2. Read relevant source files in the codebase to understand the implementation surface",
-      "3. Update SCRATCHPAD.md with a detailed implementation plan:",
+      `3. Update ${scratchpadName} with a detailed implementation plan:`,
       "   - Fill in the Summary section with your understanding",
       "   - Fill in Acceptance Criteria from the issue",
       "   - Replace the placeholder Implementation Plan checklist with specific, concrete tasks",
@@ -1286,7 +1303,7 @@ export class ExecutionService {
       "## Important",
       "",
       "- Do NOT start coding. This is setup only.",
-      "- Update SCRATCHPAD.md with your detailed plan.",
+      `- Update ${scratchpadName} with your detailed plan.`,
       "- The user will review your plan before coding begins.",
     );
 
@@ -1299,19 +1316,20 @@ export class ExecutionService {
     workItem: WorkItemRecord,
     projectContext: string | null,
   ): string {
+    const scratchpadName = `SCRATCHPAD_${workItemSlug(run.work_item_id)}.md`;
     const lines = [
       `# Coding Phase for ${run.work_item_id}: ${run.work_item_name}`,
       "",
-      "Your implementation plan in SCRATCHPAD.md has been approved. Now execute it.",
+      `Your implementation plan in ${scratchpadName} has been approved. Now execute it.`,
       "",
       "## Workflow",
       "",
-      "For each unchecked task in the ## Implementation Plan section of SCRATCHPAD.md:",
+      `For each unchecked task in the ## Implementation Plan section of ${scratchpadName}:`,
       "",
       "1. **Implement** the change",
-      "2. **Update SCRATCHPAD.md**: check off the task (`- [x]`), add a note to ## Work Log",
+      `2. **Update ${scratchpadName}**: check off the task (\`- [x]\`), add a note to ## Work Log`,
       "3. **Commit** your changes:",
-      "   - Stage specific files (never `git add .`, never stage SCRATCHPAD.md)",
+      `   - Stage specific files (never \`git add .\`, never stage ${scratchpadName})`,
       "   - Write a descriptive commit message",
       "   - Use conventional format: `type(scope): description`",
       "4. **Run quality checks** after each significant change:",
@@ -1324,16 +1342,16 @@ export class ExecutionService {
       "",
       "- Work through tasks IN ORDER from the scratchpad",
       "- Commit after each logical task (not everything at the end)",
-      "- NEVER commit or stage SCRATCHPAD.md — it is a local working document",
+      `- NEVER commit or stage ${scratchpadName} — it is a local working document`,
       "- NEVER use `git add .` or `git add -A` — always stage specific files",
       "- Stay within your owned/shared files. Do NOT touch forbidden files.",
-      "- If blocked on a task, note it in SCRATCHPAD.md ## Blockers and move on",
+      `- If blocked on a task, note it in ${scratchpadName} ## Blockers and move on`,
       "",
       "## When finished",
       "",
       "After all tasks are complete:",
       "1. Run final quality checks (type check, tests, build)",
-      "2. Update SCRATCHPAD.md ## Work Log with a completion summary",
+      `2. Update ${scratchpadName} ## Work Log with a completion summary`,
       "3. Provide a structured final summary:",
       "   - What you changed (files and purpose)",
       "   - Tests/checks you ran and their results",
@@ -1419,10 +1437,10 @@ export class ExecutionService {
     ].join("\n");
   }
 
-  /** Ensure SCRATCHPAD.md is in the worktree's .gitignore so it can't be committed. */
+  /** Ensure `SCRATCHPAD_*.md` is in the worktree's .gitignore so canonical scratchpads can't be committed. */
   private ensureScratchpadIgnored(worktreePath: string): void {
     const gitignorePath = join(worktreePath, ".gitignore");
-    const entry = "SCRATCHPAD.md";
+    const entry = "SCRATCHPAD_*.md";
     try {
       if (existsSync(gitignorePath)) {
         const content = readFileSync(gitignorePath, "utf8");
@@ -1438,14 +1456,58 @@ export class ExecutionService {
     }
   }
 
-  /** Write the scratchpad to the execution worktree; returns the file path. */
+  /**
+   * Sync the agent's worktree scratchpad back to the canonical plan file.
+   *
+   * Called at each phase boundary in executeRun. If the worktree copy is
+   * missing (e.g. the agent deleted it), logs a warning and leaves the
+   * canonical file unchanged — the canonical retains its last-known-good
+   * state.
+   */
+  private syncScratchpadToCanonical(run: ExecutionRunRecord): void {
+    const slug = workItemSlug(run.work_item_id);
+    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    const canonical = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+    if (!existsSync(worktreeScratchpad)) {
+      this.logger.warn(
+        `syncScratchpadToCanonical: worktree scratchpad missing for run ${run.run_id} ` +
+          `at ${worktreeScratchpad}; canonical left unchanged.`,
+      );
+      return;
+    }
+    writeFileSync(canonical, readFileSync(worktreeScratchpad, "utf8"), "utf8");
+  }
+
+  /**
+   * Seed the worktree scratchpad from the canonical plan file.
+   *
+   * ADR 014 step 2: the canonical scratchpad lives at
+   * `plans/<slug>/SCRATCHPAD_<slug>.md` and is the source of truth. On first
+   * run for a work item the skeleton is generated and written to canonical;
+   * on subsequent runs the existing canonical content is carried forward
+   * (so plan edits from prior runs survive). The worktree always receives a
+   * copy named `SCRATCHPAD_<slug>.md`.
+   *
+   * Returns the worktree scratchpad path.
+   */
   private writeScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
-    const content = this.buildScratchpad(run, node);
-    const scratchpadPath = join(run.worktree_path, "SCRATCHPAD.md");
-    writeFileSync(scratchpadPath, content, "utf8");
-    // Also persist a copy in the artifact directory for post-run review
-    writeFileSync(join(run.artifact_dir, "scratchpad-initial.md"), content, "utf8");
-    return scratchpadPath;
+    ensurePlanDir(this.artifactRoot, run.work_item_id);
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+
+    let content: string;
+    if (existsSync(canonicalPath)) {
+      // Carry existing plan forward — edits from prior runs survive.
+      content = readFileSync(canonicalPath, "utf8");
+    } else {
+      // First run for this work item — generate skeleton and persist to canonical.
+      content = this.buildScratchpad(run, node);
+      writeFileSync(canonicalPath, content, "utf8");
+    }
+
+    const slug = workItemSlug(run.work_item_id);
+    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    writeFileSync(worktreeScratchpad, content, "utf8");
+    return worktreeScratchpad;
   }
 
   private createRunRecord(input: {


### PR DESCRIPTION
## Summary

- Canonical scratchpad ownership moves to `plans/<slug>/SCRATCHPAD_<slug>.md` under the context root
- Execution copies canonical → worktree at launch and syncs worktree → canonical at each phase boundary
- `scratchpad-initial.md` and `scratchpad-final.md` are removed entirely — canonical is the only source of truth

Closes #152. Builds on #159 (step 1).

## What changed

**`src/lib/context-layout.ts`**
- New `canonicalScratchpadPath(artifactRoot, workItemId)` pure helper returning `plans/<slug>/SCRATCHPAD_<slug>.md`

**`src/modules/execution/execution.service.ts`**
- `writeScratchpad` — `ensurePlanDir` → if canonical exists carry it forward, else build skeleton and write canonical → copy to `<worktree>/SCRATCHPAD_<slug>.md`. `scratchpad-initial.md` write removed.
- `syncScratchpadToCanonical` — new private method. Missing worktree file logs a warning and leaves canonical unchanged.
- `executeRun` — sync-back at end of setup phase, after feedback-driven plan updates, and at end of do-work phase. `scratchpad-final.md` write removed at completion.
- `buildSetupPrompt` / `buildDoWorkPrompt` / inline feedback prompt — all reference `SCRATCHPAD_<slug>.md` via a local `scratchpadName` variable.
- `ensureScratchpadIgnored` — uses `SCRATCHPAD_*.md` glob.
- `readChecklistFromWorktree` — reads slug-specific filename.
- `getRunScratchpad` — canonical → worktree fallback; `source` discriminant dropped from return type (frontend only reads `content`).

**`.gitignore`**
- Broadens to include `SCRATCHPAD_*.md` alongside the existing `SCRATCHPAD.md` entry.

**New tests**
- `src/lib/__tests__/context-layout.test.ts` — 3 new tests for `canonicalScratchpadPath` (now 19 tests total).
- `src/modules/execution/__tests__/scratchpad-canonical.test.ts` — 6 new tests: sync-back (present + missing + warn), getRunScratchpad (canonical > worktree > null, no `source` field).

## Key decisions (resolved via interactive Q&A during setup)

1. Worktree filename is slug-specific (`SCRATCHPAD_studio_999.md`), not generic — consistent with canonical, gitignore glob covers it cleanly.
2. Canonical carries forward on re-run — reads existing content instead of regenerating, forward-compatible with ADR 014 step 4 (prepare-plan).
3. Missing worktree file at sync-back → warning only, canonical preserved (last-known-good).
4. `scratchpad-initial.md` / `scratchpad-final.md` removed entirely — canonical is the single source of truth, no debug snapshots kept.
5. `source` field dropped from `getRunScratchpad` response — canonical is the source of truth so the discriminant is no longer meaningful.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 135/135 tests across 16 files (9 new tests vs base)
- [x] `npx vite build --config web/vite.config.ts` — clean
- [ ] Manual: launch an execution run from the Studio UI and verify:
  - [ ] First run for a work item creates `plans/<slug>/SCRATCHPAD_<slug>.md`
  - [ ] Worktree gets `SCRATCHPAD_<slug>.md` (not `SCRATCHPAD.md`)
  - [ ] Agent prompts reference the slug-specific filename
  - [ ] After setup phase, canonical file reflects agent's plan
  - [ ] After do-work phase, canonical file reflects final state
  - [ ] Second run for the same work item carries the canonical forward