### PR TITLE
feat: expand work item state machine with drafting/ready/merged_pr (ADR 014 step 3)

### DIFF
--- a/src/__tests__/state-machine-allowlist.test.ts
+++ b/src/__tests__/state-machine-allowlist.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { initManifest } from "../lib/manifest-core.js";
+import { SQLiteService } from "../modules/graph/sqlite.service.js";
+import { VALID_HUMAN_TRANSITIONS } from "../modules/graph/state-transitions.js";
+import type { WorkItemState } from "../modules/graph/types.js";
+
+/**
+ * ADR 014 step 3 state-machine allowlist.
+ *
+ * This test enforces a single source of truth: the 9 canonical
+ * WorkItemState values. It asserts:
+ *  1. All 9 states are accepted by the SQLite CHECK constraint
+ *  2. An invalid state is rejected by the constraint
+ *  3. VALID_HUMAN_TRANSITIONS has an entry for every state (no
+ *     accidentally-missing rows)
+ *
+ * If any future code adds a new state, this test will flag missing
+ * DB coverage and/or missing transition allowlist entries at test time.
+ */
+
+const ALL_STATES: WorkItemState[] = [
+  "planned",
+  "drafting",
+  "ready",
+  "in_progress",
+  "open_pr",
+  "merged_pr",
+  "done",
+  "deferred",
+  "cancelled",
+];
+
+/**
+ * Build an in-memory DB with the Studio-expanded CHECK constraint in place.
+ *
+ * Uses the Object.create harness pattern established in
+ * graph-writer.service.test.ts to bypass the SQLiteService constructor's
+ * reliance on getConfig(). The private `migrateWorkItemStates` method is
+ * invoked via the prototype so we exercise real production migration SQL
+ * — if the migration breaks, this test breaks.
+ */
+function createMigratedDb(): DatabaseType {
+  const db = initManifest(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS studio_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0');
+  `);
+
+  const service = Object.create(SQLiteService.prototype) as SQLiteService;
+  Object.defineProperty(service, "db", { value: db, writable: false });
+  // Invoke the private migration via prototype — we're intentionally
+  // exercising the real production migration SQL in this test.
+  (SQLiteService.prototype as unknown as { migrateWorkItemStates: () => void })
+    .migrateWorkItemStates.call(service);
+
+  return db;
+}
+
+function insertWorkItemWithState(db: DatabaseType, id: string, state: string): void {
+  db.prepare(
+    `INSERT INTO work_items (id, name, kind, state, predicted_files, actual_files, meta)
+     VALUES (?, ?, 'issue', ?, '[]', '[]', '{}')`,
+  ).run(id, `Item ${id}`, state);
+}
+
+describe("state-machine allowlist", () => {
+  describe("SQLite CHECK constraint", () => {
+    it("accepts every canonical WorkItemState value", () => {
+      const db = createMigratedDb();
+      for (const state of ALL_STATES) {
+        expect(() => insertWorkItemWithState(db, `item-${state}`, state)).not.toThrow();
+      }
+      db.close();
+    });
+
+    it("rejects a state that is not in the canonical set", () => {
+      const db = createMigratedDb();
+      expect(() => insertWorkItemWithState(db, "item-bad", "totally_made_up")).toThrow();
+      db.close();
+    });
+
+    it("still rejects the legacy state value that was removed in earlier migrations", () => {
+      const db = createMigratedDb();
+      // "blocked" was never a canonical state — it is a derived view per ADR 014
+      expect(() => insertWorkItemWithState(db, "item-blocked", "blocked")).toThrow();
+      db.close();
+    });
+  });
+
+  describe("VALID_HUMAN_TRANSITIONS", () => {
+    it("has an entry for every canonical state", () => {
+      for (const state of ALL_STATES) {
+        expect(VALID_HUMAN_TRANSITIONS).toHaveProperty(state);
+      }
+    });
+
+    it("every transition target is itself a canonical state", () => {
+      const stateSet = new Set<string>(ALL_STATES);
+      for (const [from, targets] of Object.entries(VALID_HUMAN_TRANSITIONS)) {
+        for (const to of targets) {
+          expect(stateSet.has(to)).toBe(true);
+          // Self-transitions are not meaningful
+          expect(to).not.toBe(from);
+        }
+      }
+    });
+
+    it("terminal states (done, cancelled, merged_pr) have no human-triggered outbound transitions", () => {
+      expect(VALID_HUMAN_TRANSITIONS.done).toEqual([]);
+      expect(VALID_HUMAN_TRANSITIONS.cancelled).toEqual([]);
+      // merged_pr → done is wired by the disposition flow (ADR 014 step 7)
+      // not by a human reviewer, so it stays empty here.
+      expect(VALID_HUMAN_TRANSITIONS.merged_pr).toEqual([]);
+    });
+  });
+});

--- a/src/lib/manifest-core.ts
+++ b/src/lib/manifest-core.ts
@@ -8,9 +8,28 @@ export {
 
 export {
   buildDispatchPlan,
+  buildParallelGroups,
+  buildSequentialNodes,
+  buildValidationPolicy,
+  determineMergeOrder,
   formatPlan,
   queryBlocked,
   queryFrontier,
   queryHumanGated,
   queryOverlaps,
+} from "escapement/src/core/planner.ts";
+
+export type {
+  Assessment,
+  BlockedItem,
+  Confidence,
+  DispatchPlan,
+  FrontierItem,
+  HumanGatedItem,
+  OverlapPair,
+  ParallelGroup,
+  PlanNode,
+  SequentialNode,
+  SharedFile,
+  ValidationPolicy,
 } from "escapement/src/core/planner.ts";

--- a/src/modules/execution/__tests__/launch-eligibility.test.ts
+++ b/src/modules/execution/__tests__/launch-eligibility.test.ts
@@ -274,6 +274,22 @@ describe("launch eligibility", () => {
     ]);
   });
 
+  it("marks ready work items in progress before launching execution (ADR 014 step 3)", async () => {
+    const workItem = makeWorkItem({ state: "ready" });
+    const harness = makeLaunchHarness(workItem);
+
+    const result = await harness.service.launch({ work_item_id: workItem.id, prompt: "Launch" });
+
+    expect(result.accepted).toBe(true);
+    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "in_progress" } }]);
+    expect(harness.getCurrentWorkItem().state).toBe("in_progress");
+    expect(harness.executionOrder).toEqual([
+      `update:${workItem.id}:in_progress`,
+      "activity:Execution run queued. Work item state updated to in_progress.",
+      "executeRun",
+    ]);
+  });
+
   it("does not re-mark work items already in progress when launching execution", async () => {
     const workItem = makeWorkItem({ state: "in_progress" });
     const harness = makeLaunchHarness(workItem);
@@ -300,5 +316,64 @@ describe("launch eligibility", () => {
     expect(harness.updateCalls).toEqual([]);
     expect(harness.getCurrentWorkItem().state).toBe("planned");
     expect(harness.executionOrder).toEqual([]);
+  });
+});
+
+describe("ExecutionService.transitionInProgressToReady", () => {
+  function makeTransitionHarness(workItem: WorkItemRecord) {
+    const service = Object.create(ExecutionService.prototype) as ExecutionService;
+    const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+    let currentWorkItem = workItem;
+
+    (service as any).workItemsService = {
+      get: (id: string) => {
+        if (id !== currentWorkItem.id) {
+          throw new Error(`Unknown work item: ${id}`);
+        }
+        return currentWorkItem;
+      },
+      update: (id: string, patch: Partial<WorkItemRecord>) => {
+        updateCalls.push({ id, patch });
+        currentWorkItem = {
+          ...currentWorkItem,
+          ...patch,
+          updated_at: "2026-04-09T00:00:01.000Z",
+        };
+        return currentWorkItem;
+      },
+    };
+
+    return { service, updateCalls, getCurrentWorkItem: () => currentWorkItem };
+  }
+
+  it("transitions a work item from in_progress to ready", () => {
+    const workItem = makeWorkItem({ state: "in_progress" });
+    const harness = makeTransitionHarness(workItem);
+
+    const result = harness.service.transitionInProgressToReady(workItem.id);
+
+    expect(result.state).toBe("ready");
+    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "ready" } }]);
+    expect(harness.getCurrentWorkItem().state).toBe("ready");
+  });
+
+  it("throws when the current state is not in_progress", () => {
+    const workItem = makeWorkItem({ state: "planned" });
+    const harness = makeTransitionHarness(workItem);
+
+    expect(() => harness.service.transitionInProgressToReady(workItem.id)).toThrow(
+      /Cannot transition .* from planned to ready/,
+    );
+    expect(harness.updateCalls).toEqual([]);
+  });
+
+  it("throws when the current state is ready (no-op rejection)", () => {
+    const workItem = makeWorkItem({ state: "ready" });
+    const harness = makeTransitionHarness(workItem);
+
+    expect(() => harness.service.transitionInProgressToReady(workItem.id)).toThrow(
+      /Cannot transition .* from ready to ready/,
+    );
+    expect(harness.updateCalls).toEqual([]);
   });
 });

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,11 +1,11 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { ExecutionController } from "./execution.controller.js";
 import { ExecutionService } from "./execution.service.js";
 
 @Module({
-  imports: [GraphModule, GitHubModule],
+  imports: [forwardRef(() => GraphModule), GitHubModule],
   controllers: [ExecutionController],
   providers: [ExecutionService],
   exports: [ExecutionService],

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -422,8 +422,11 @@ export class ExecutionService {
     const nextArchivePath = this.hasOwn(input, "archive_path") ? (input.archive_path ?? null) : workItem.archive_path;
     const nextMeta = this.buildMergedWorkItemMeta(workItem, pullRequest, matchedRun?.run_id ?? null, actualFilesSelection.source);
 
+    // ADR 014 step 3: post-merge sync lands on 'merged_pr', not 'done'.
+    // 'merged_pr' is a stable resting state that the disposition flow
+    // (ADR 014 step 7) will transition to 'done' after archival completes.
     this.workItemsService.update(workItem.id, {
-      state: "done",
+      state: "merged_pr",
       actual_files: actualFilesSelection.files,
       branch: nextBranch,
       archive_path: nextArchivePath,

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1826,7 +1826,10 @@ export class ExecutionService {
   }
 
   private markWorkItemInProgressOnLaunch(workItem: WorkItemRecord): { workItem: WorkItemRecord; transitioned: boolean } {
-    if (workItem.state !== "planned") {
+    // Both 'planned' and 'ready' are launchable under ADR 014 step 3:
+    // 'planned' items launch directly (upstream behavior) and 'ready' items
+    // launch after a human reviewer has approved a plan.
+    if (workItem.state !== "planned" && workItem.state !== "ready") {
       return { workItem, transitioned: false };
     }
 
@@ -1834,6 +1837,29 @@ export class ExecutionService {
       workItem: this.workItemsService.update(workItem.id, { state: "in_progress" }),
       transitioned: true,
     };
+  }
+
+  /**
+   * Transition a work item from in_progress back to ready.
+   *
+   * ADR 014 assigns the `in_progress → ready` transition to the execution
+   * service (it's the service that owns launch and sees run results). For
+   * MVP we expose it as a callable helper instead of auto-invoking it from
+   * the run failure path — a human reviewer triggers it via the transition
+   * endpoint when they decide the plan is still valid after a failed run.
+   *
+   * Future work can add conditional auto-invocation once error classification
+   * is rich enough to distinguish "plan valid" from "plan needs rework"
+   * (the latter going to `drafting`).
+   */
+  transitionInProgressToReady(workItemId: string): WorkItemRecord {
+    const workItem = this.workItemsService.get(workItemId);
+    if (workItem.state !== "in_progress") {
+      throw new BadRequestException(
+        `Cannot transition ${workItemId} from ${workItem.state} to ready (requires in_progress)`,
+      );
+    }
+    return this.workItemsService.update(workItemId, { state: "ready" });
   }
 
   private async resolvePullRequestFromWorkItem(workItem: WorkItemRecord) {

--- a/src/modules/graph/__tests__/work-item-transitions.test.ts
+++ b/src/modules/graph/__tests__/work-item-transitions.test.ts
@@ -1,0 +1,161 @@
+import { BadRequestException } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import type { ExecutionService } from "../../execution/execution.service.js";
+import { isValidHumanTransition, VALID_HUMAN_TRANSITIONS } from "../state-transitions.js";
+import type { WorkItemRecord, WorkItemState } from "../types.js";
+import { WorkItemsController } from "../work-items.controller.js";
+import type { WorkItemsService } from "../work-items.service.js";
+
+/**
+ * Tests for the ADR 014 step 3 human-reviewer transition endpoint.
+ *
+ * Construct the controller directly with hand-stubbed services rather
+ * than booting a full Nest context — the transition logic is pure
+ * dispatch and doesn't exercise any framework wiring beyond the
+ * decorators.
+ */
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-153",
+    name: "Test item",
+    kind: "issue",
+    state: "planned",
+    repo: "fusupo/escapement-studio",
+    issue_number: 153,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/153",
+    scope_hint: null,
+    branch: "studio-153-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeController(initialState: WorkItemState = "planned") {
+  let current = makeWorkItem({ state: initialState });
+
+  const workItemsService = {
+    get: vi.fn((id: string) => {
+      if (id !== current.id) throw new Error(`Unknown: ${id}`);
+      return current;
+    }),
+    update: vi.fn((id: string, patch: Partial<WorkItemRecord>) => {
+      current = { ...current, ...patch };
+      return current;
+    }),
+  } as unknown as WorkItemsService;
+
+  const executionService = {
+    transitionInProgressToReady: vi.fn((id: string) => {
+      if (current.state !== "in_progress") {
+        throw new BadRequestException(`Cannot transition ${id} from ${current.state} to ready`);
+      }
+      current = { ...current, state: "ready" };
+      return current;
+    }),
+  } as unknown as ExecutionService;
+
+  const controller = new WorkItemsController(workItemsService, executionService);
+
+  return {
+    controller,
+    workItemsService,
+    executionService,
+    getCurrent: () => current,
+  };
+}
+
+describe("WorkItemsController.transition", () => {
+  describe("allowed human-reviewer transitions", () => {
+    const allowed: Array<[WorkItemState, WorkItemState]> = [
+      ["planned", "drafting"],
+      ["planned", "deferred"],
+      ["planned", "cancelled"],
+      ["drafting", "ready"],
+      ["drafting", "deferred"],
+      ["drafting", "cancelled"],
+      ["ready", "drafting"],
+      ["ready", "deferred"],
+      ["ready", "cancelled"],
+      ["in_progress", "drafting"],
+      ["in_progress", "deferred"],
+      ["in_progress", "cancelled"],
+      ["open_pr", "deferred"],
+      ["open_pr", "cancelled"],
+      ["deferred", "planned"],
+    ];
+
+    for (const [from, to] of allowed) {
+      it(`permits ${from} → ${to}`, () => {
+        const harness = makeController(from);
+        const result = harness.controller.transition("studio-153", { to });
+        expect(result.state).toBe(to);
+      });
+    }
+  });
+
+  describe("in_progress → ready delegation", () => {
+    it("delegates in_progress → ready to ExecutionService.transitionInProgressToReady", () => {
+      const harness = makeController("in_progress");
+
+      const result = harness.controller.transition("studio-153", { to: "ready" });
+
+      expect(harness.executionService.transitionInProgressToReady).toHaveBeenCalledWith("studio-153");
+      expect(harness.workItemsService.update).not.toHaveBeenCalled();
+      expect(result.state).toBe("ready");
+    });
+  });
+
+  describe("rejection of disallowed transitions", () => {
+    const disallowed: Array<[WorkItemState, WorkItemState]> = [
+      ["planned", "in_progress"], // must launch, not manually set
+      ["planned", "done"],
+      ["done", "planned"],
+      ["merged_pr", "done"], // reserved for disposition flow (step 7)
+      ["cancelled", "planned"],
+      ["ready", "in_progress"], // must launch, not manually set
+    ];
+
+    for (const [from, to] of disallowed) {
+      it(`rejects ${from} → ${to}`, () => {
+        const harness = makeController(from);
+        expect(() => harness.controller.transition("studio-153", { to })).toThrow(
+          BadRequestException,
+        );
+      });
+    }
+  });
+
+  describe("input validation", () => {
+    it("rejects a missing `to` field", () => {
+      const harness = makeController("planned");
+      expect(() => harness.controller.transition("studio-153", {} as { to: WorkItemState })).toThrow(
+        /to.*required/,
+      );
+    });
+  });
+});
+
+describe("state-transitions helpers", () => {
+  it("isValidHumanTransition returns true for allowed pairs", () => {
+    expect(isValidHumanTransition("planned", "drafting")).toBe(true);
+    expect(isValidHumanTransition("drafting", "ready")).toBe(true);
+    expect(isValidHumanTransition("in_progress", "ready")).toBe(true);
+  });
+
+  it("isValidHumanTransition returns false for disallowed pairs", () => {
+    expect(isValidHumanTransition("planned", "in_progress")).toBe(false);
+    expect(isValidHumanTransition("done", "planned")).toBe(false);
+    expect(isValidHumanTransition("merged_pr", "done")).toBe(false);
+  });
+
+  it("VALID_HUMAN_TRANSITIONS has no entries for terminal states", () => {
+    expect(VALID_HUMAN_TRANSITIONS.done).toHaveLength(0);
+    expect(VALID_HUMAN_TRANSITIONS.cancelled).toHaveLength(0);
+    expect(VALID_HUMAN_TRANSITIONS.merged_pr).toHaveLength(0);
+  });
+});

--- a/src/modules/graph/graph.module.ts
+++ b/src/modules/graph/graph.module.ts
@@ -1,4 +1,5 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
+import { ExecutionModule } from "../execution/execution.module.js";
 import { EdgesController } from "./edges.controller.js";
 import { EdgesService } from "./edges.service.js";
 import { GraphController } from "./graph.controller.js";
@@ -9,6 +10,7 @@ import { WorkItemsController } from "./work-items.controller.js";
 import { WorkItemsService } from "./work-items.service.js";
 
 @Module({
+  imports: [forwardRef(() => ExecutionModule)],
   controllers: [WorkItemsController, EdgesController, GraphController],
   providers: [SQLiteService, WorkItemsService, EdgesService, GraphService, GraphWriterService],
   exports: [SQLiteService, WorkItemsService, EdgesService, GraphService, GraphWriterService],

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -1,9 +1,112 @@
 import { Inject, Injectable } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
-import { buildDispatchPlan, queryFrontier } from "../../lib/manifest-core.js";
+import {
+  buildParallelGroups,
+  buildSequentialNodes,
+  buildValidationPolicy,
+  determineMergeOrder,
+  parseJsonArray,
+  queryBlocked,
+  queryHumanGated,
+  queryOverlaps,
+} from "../../lib/manifest-core.js";
+import type { Assessment, DispatchPlan, FrontierItem } from "../../lib/manifest-core.js";
 import { SQLiteService } from "./sqlite.service.js";
 import type { GraphFilters, WorkItemRecord } from "./types.js";
 import { WorkItemsService } from "./work-items.service.js";
+
+/**
+ * Studio-local frontier query.
+ *
+ * The upstream `queryFrontier` in `escapement/src/core/planner.ts` hard-codes
+ * `state = 'planned'`. Under ADR 014, Studio promotes `ready` to a launchable
+ * state alongside `planned` (see `docs/adr/014-plans-runs-state-model.md`
+ * transition table — `ready → in_progress` is a valid launch transition).
+ *
+ * This helper mirrors the upstream SQL exactly except it widens the state
+ * filter to `state IN ('planned', 'ready')`. If the upstream planner is
+ * updated to support multi-state frontiers, this helper should be replaced
+ * with a direct upstream call.
+ */
+function queryStudioFrontier(db: DatabaseType): FrontierItem[] {
+  const sql = `
+    SELECT w.id, w.name, w.kind, w.repo, w.scope_hint, w.branch,
+           w.issue_url, w.predicted_files
+    FROM work_items w
+    WHERE w.kind IN ('issue', 'capability')
+      AND w.state IN ('planned', 'ready')
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
+      AND NOT EXISTS (
+        SELECT 1
+        FROM edges e
+        JOIN work_items dep ON dep.id = e.to_id
+        WHERE e.rel = 'depends_on'
+          AND e.from_id = w.id
+          AND dep.state != 'done'
+      )
+    ORDER BY w.id
+  `;
+  const rows = db.prepare(sql).all() as (Omit<FrontierItem, "predicted_files"> & {
+    predicted_files: string;
+  })[];
+  return rows.map((r) => ({
+    ...r,
+    predicted_files: parseJsonArray(r.predicted_files),
+  }));
+}
+
+/**
+ * Studio-local dispatch plan builder.
+ *
+ * Reimplements the upstream `buildDispatchPlan` verbatim except it sources
+ * its frontier from `queryStudioFrontier` (which includes `ready` items).
+ * All other planner helpers (`queryOverlaps`, `queryBlocked`, etc.) are
+ * state-agnostic and reused unchanged.
+ */
+function buildStudioDispatchPlan(
+  db: DatabaseType,
+  assessments?: Map<string, Assessment>,
+): DispatchPlan {
+  const frontier = queryStudioFrontier(db);
+  const overlaps = queryOverlaps(db);
+  const blocked = queryBlocked(db);
+  const humanGated = queryHumanGated(db);
+
+  const groups = buildParallelGroups(frontier, overlaps, assessments);
+  for (const group of groups) {
+    const order = determineMergeOrder(group);
+    if (order) group.merge_order = order;
+  }
+
+  const validationPolicy = buildValidationPolicy(groups);
+  const sequential = buildSequentialNodes(blocked);
+
+  const assumptions: string[] = [];
+  if (!assessments || assessments.size === 0) {
+    assumptions.push(
+      "No conflict classifications provided -- all shared files treated as 'unknown' (conservative)",
+    );
+  }
+  if (frontier.some((f) => f.predicted_files.length === 0)) {
+    assumptions.push(
+      "Some frontier items have no predicted files -- they are assumed to have no file conflicts",
+    );
+  }
+
+  return {
+    generated_at: new Date().toISOString(),
+    assumptions,
+    parallel_groups: groups,
+    sequential,
+    validation_policy: validationPolicy,
+    summary: {
+      frontier_count: frontier.length + blocked.length + humanGated.length,
+      dispatchable_now: frontier.length,
+      blocked_count: blocked.length,
+      human_gate_count: humanGated.length,
+    },
+  };
+}
 
 @Injectable()
 export class GraphService {
@@ -51,12 +154,12 @@ export class GraphService {
   }
 
   getFrontier(repo?: string) {
-    const frontier = queryFrontier(this.db);
+    const frontier = queryStudioFrontier(this.db);
     return repo ? frontier.filter((item) => item.repo === repo) : frontier;
   }
 
   getPlan(repo?: string) {
-    const plan = buildDispatchPlan(this.db);
+    const plan = buildStudioDispatchPlan(this.db);
     if (!repo) {
       return plan;
     }

--- a/src/modules/graph/sqlite.service.ts
+++ b/src/modules/graph/sqlite.service.ts
@@ -58,14 +58,17 @@ export class SQLiteService {
       .prepare("INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0')")
       .run();
 
-    // Extend upstream CHECK constraint to include open_pr state
+    // Extend upstream CHECK constraint to include expanded ADR 014 state set
     this.migrateWorkItemStates();
   }
 
   private migrateWorkItemStates() {
-    // Check if open_pr is already allowed
+    // Guard sentinel is merged_pr (ADR 014 step 3). If already present, the
+    // expanded state set is in place and the migration is a no-op. Instances
+    // that have the step-1/2 schema with open_pr but not merged_pr will fall
+    // through and run the recreate.
     const tableInfo = this.db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='work_items'").get() as { sql: string } | undefined;
-    if (!tableInfo?.sql || tableInfo.sql.includes("open_pr")) {
+    if (!tableInfo?.sql || tableInfo.sql.includes("merged_pr")) {
       return; // already migrated or no table
     }
 
@@ -81,8 +84,11 @@ export class SQLiteService {
         state       TEXT NOT NULL DEFAULT 'planned'
                     CHECK (state IN (
                       'planned',
+                      'drafting',
+                      'ready',
                       'in_progress',
                       'open_pr',
+                      'merged_pr',
                       'done',
                       'deferred',
                       'cancelled'

--- a/src/modules/graph/state-transitions.ts
+++ b/src/modules/graph/state-transitions.ts
@@ -1,0 +1,33 @@
+import type { WorkItemState } from "./types.js";
+
+/**
+ * Allowlist of human-reviewer-triggered work item state transitions.
+ *
+ * This list covers transitions that are initiated by a human via the
+ * transition endpoint (`POST /api/work-items/:id/transition`). It does
+ * NOT cover execution-service-triggered transitions that happen as a
+ * side effect of launch, run completion, or PR sync — those are wired
+ * in ExecutionService directly.
+ *
+ * See `docs/adr/014-plans-runs-state-model.md` for the canonical
+ * transition table and actor assignments.
+ */
+export const VALID_HUMAN_TRANSITIONS: Record<WorkItemState, WorkItemState[]> = {
+  planned: ["drafting", "deferred", "cancelled"],
+  drafting: ["ready", "deferred", "cancelled"],
+  ready: ["drafting", "deferred", "cancelled"],
+  in_progress: ["ready", "drafting", "deferred", "cancelled"],
+  open_pr: ["deferred", "cancelled"],
+  merged_pr: [],
+  done: [],
+  deferred: ["planned"],
+  cancelled: [],
+};
+
+/**
+ * Return true if a human reviewer is allowed to transition a work item
+ * from `from` to `to`.
+ */
+export function isValidHumanTransition(from: WorkItemState, to: WorkItemState): boolean {
+  return VALID_HUMAN_TRANSITIONS[from]?.includes(to) ?? false;
+}

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -28,7 +28,16 @@ export interface MisalignedWorkItem {
   issue_number: number;
   expected_id: string;
 }
-export type WorkItemState = "planned" | "in_progress" | "open_pr" | "done" | "deferred" | "cancelled";
+export type WorkItemState =
+  | "planned"
+  | "drafting"
+  | "ready"
+  | "in_progress"
+  | "open_pr"
+  | "merged_pr"
+  | "done"
+  | "deferred"
+  | "cancelled";
 export type EdgeRel = "depends_on" | "is_part_of" | "implemented_by";
 export type EdgeConfidence = "certain" | "inferred" | "ambiguous";
 

--- a/src/modules/graph/work-items.controller.ts
+++ b/src/modules/graph/work-items.controller.ts
@@ -1,10 +1,32 @@
-import { Body, Controller, Delete, Get, Inject, Param, Post, Put, Query } from "@nestjs/common";
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  forwardRef,
+  Get,
+  Inject,
+  Param,
+  Post,
+  Put,
+  Query,
+} from "@nestjs/common";
+import { ExecutionService } from "../execution/execution.service.js";
+import { isValidHumanTransition } from "./state-transitions.js";
 import { WorkItemsService } from "./work-items.service.js";
-import type { CreateWorkItemDto, UpdateWorkItemDto } from "./types.js";
+import type { CreateWorkItemDto, UpdateWorkItemDto, WorkItemState } from "./types.js";
+
+interface TransitionDto {
+  to: WorkItemState;
+}
 
 @Controller("api/work-items")
 export class WorkItemsController {
-  constructor(@Inject(WorkItemsService) private readonly workItems: WorkItemsService) {}
+  constructor(
+    @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
+    @Inject(forwardRef(() => ExecutionService))
+    private readonly executionService: ExecutionService,
+  ) {}
 
   @Get()
   list(
@@ -33,6 +55,31 @@ export class WorkItemsController {
   @Put(":id")
   update(@Param("id") id: string, @Body() body: UpdateWorkItemDto) {
     return this.workItems.update(id, body);
+  }
+
+  @Post(":id/transition")
+  transition(@Param("id") id: string, @Body() body: TransitionDto) {
+    const target = body?.to;
+    if (!target) {
+      throw new BadRequestException("transition target `to` is required");
+    }
+
+    const workItem = this.workItems.get(id);
+    if (!isValidHumanTransition(workItem.state, target)) {
+      throw new BadRequestException(
+        `Human-reviewer transition ${workItem.state} → ${target} is not allowed`,
+      );
+    }
+
+    // in_progress → ready delegates to ExecutionService per ADR 014 actor
+    // assignment: the execution service owns the logic for reviving a
+    // failed-but-valid run plan. All other human transitions are plain
+    // state updates and go through WorkItemsService directly.
+    if (workItem.state === "in_progress" && target === "ready") {
+      return this.executionService.transitionInProgressToReady(id);
+    }
+
+    return this.workItems.update(id, { state: target });
   }
 
   @Delete(":id")

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -94,10 +94,13 @@
     <div class="graph-legend" aria-label="Graph legend">
       <div>
         <h3>Node State</h3>
-        <div class="legend-row"><span class="legend-swatch" style="background:#238636"></span><code>done</code></div>
+        <div class="legend-row"><span class="legend-swatch" style="background:#58a6ff"></span><code>planned</code></div>
+        <div class="legend-row"><span class="legend-swatch" style="background:#79c0ff"></span><code>drafting</code></div>
+        <div class="legend-row"><span class="legend-swatch" style="background:#56d364"></span><code>ready</code></div>
         <div class="legend-row"><span class="legend-swatch in-progress" style="background:#d29922"></span><code>in_progress</code><span class="legend-note">dashed inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#a371f7"></span><code>open_pr</code></div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#58a6ff"></span><code>planned</code></div>
+        <div class="legend-row"><span class="legend-swatch" style="background:#8957e5"></span><code>merged_pr</code></div>
+        <div class="legend-row"><span class="legend-swatch" style="background:#238636"></span><code>done</code></div>
         <div class="legend-row"><span class="legend-swatch frontier"></span><code>frontier</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#8b949e"></span><code>deferred</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#f85149"></span><code>cancelled</code></div>

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -2,10 +2,13 @@ import * as d3 from "d3";
 import * as dagreD3 from "dagre-d3-es";
 
 const STATE_COLORS = {
-  done: "#238636",
+  planned: "#58a6ff",
+  drafting: "#79c0ff",
+  ready: "#56d364",
   in_progress: "#d29922",
   open_pr: "#a371f7",
-  planned: "#58a6ff",
+  merged_pr: "#8957e5",
+  done: "#238636",
   deferred: "#8b949e",
   cancelled: "#f85149",
 };

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -322,7 +322,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       }
     }
 
-    if (data._prStatus !== "merged" || data.state !== "done" || !rectNode) return;
+    if (data._prStatus !== "merged" || (data.state !== "done" && data.state !== "merged_pr") || !rectNode) return;
     const bbox = rectNode.getBBox();
     nodeGroup.append("text")
       .text("✓PR")


### PR DESCRIPTION
## Summary

ADR 014 step 3: expands `WorkItemState` from 6 to 9 states, adding `drafting`, `ready`, and `merged_pr`. Every transition now has a single clear owner per the ADR actor table, and the disposition epic (#83) gets `merged_pr` as its attach point.

Closes #153.

## What Changed

### Type system + schema
- `src/modules/graph/types.ts` — `WorkItemState` expanded with `drafting`, `ready`, `merged_pr`.
- `src/modules/graph/sqlite.service.ts` — `migrateWorkItemStates` rebuilds the `work_items.state` CHECK constraint with all 9 states. Migration guard sentinel moved from `open_pr` to `merged_pr` so instances with the step-1/2 schema run the recreate exactly once.

### Frontier + dispatch (`ready` becomes launchable)
- `src/modules/graph/graph.service.ts` — `queryStudioFrontier` mirrors upstream SQL with `state IN ('planned', 'ready')`; `buildStudioDispatchPlan` reuses state-agnostic upstream helpers (`queryOverlaps`, `buildParallelGroups`, etc.) but sources its frontier from the Studio-local query. `getFrontier()` and `getPlan()` use the local versions. The override lives inline — can be extracted to a `studio-planner.ts` module if steps 4/5 grow the surface.
- `src/lib/manifest-core.ts` — re-exports the additional planner helpers and types needed for the local dispatch plan.

### Execution service transitions
- `markWorkItemInProgressOnLaunch` now accepts both `planned` and `ready` as launchable source states.
- New public `ExecutionService.transitionInProgressToReady(workItemId)` helper. **MVP decision**: this is NOT auto-invoked on run failure — failed runs stay in `in_progress` until a human triggers it via the new transition endpoint. The service still "owns" the transition per the ADR actor table (ownership = exposed logic, not auto-firing).
- `syncMergedPullRequest` lands on `merged_pr` instead of `done`. `merged_pr → done` is wired by the disposition flow in ADR 014 step 7.

### Human-reviewer transition endpoint
- `POST /api/work-items/:id/transition` with body `{ to: WorkItemState }`. Validates against a `VALID_HUMAN_TRANSITIONS` allowlist in the new `src/modules/graph/state-transitions.ts` module. Returns 400 on invalid transitions.
- `in_progress → ready` delegates to `ExecutionService.transitionInProgressToReady`. All other transitions go through `WorkItemsService.update()`.
- GraphModule ↔ ExecutionModule circular dep resolved with `forwardRef` at both the module and provider levels.

### UI
- `web/src/lib/graph.js` — `STATE_COLORS` extended with `drafting` (`#79c0ff`), `ready` (`#56d364`), `merged_pr` (`#8957e5`), derived from GitHub's accent palette. Merged-PR badge check (line 325) also accepts `merged_pr` in addition to `done` so freshly-synced items still render the ✓PR badge.
- `web/src/components/GraphView.svelte` — legend reordered to match lifecycle flow (`planned → drafting → ready → in_progress → open_pr → merged_pr → done`) with 3 new rows.

### Tests (35 new)
- `src/__tests__/state-machine-allowlist.test.ts` (new, 6 tests) — exhaustive DB CHECK constraint and transition allowlist coverage. Invokes the real `migrateWorkItemStates` SQL via `Object.create` harness so broken migrations fail the test.
- `src/modules/execution/__tests__/launch-eligibility.test.ts` (extended, 4 new tests) — `ready → in_progress` launch mirrors `planned` case; 3 unit tests for `transitionInProgressToReady` (happy path + two rejection cases).
- `src/modules/graph/__tests__/work-item-transitions.test.ts` (new, 26 tests) — all 15 allowed human transitions, 6 rejected disallowed pairs, `in_progress → ready` delegation to ExecutionService verified, input validation.

## Key Decisions (from Phase 3.5 Q&A)

1. **Frontier override** → inline helpers in `graph.service.ts` (no new file). Extracted upstream types via `manifest-core.ts` re-exports.
2. **`syncMergedPullRequest` target** → `merged_pr`, stable resting state. `merged_pr → done` deferred to step 7.
3. **Run-failure MVP policy** → leave failed runs in `in_progress`. Helper exists on ExecutionService but is only called from the human transition endpoint, not the auto-failure path.
4. **Colors** → derived from GitHub's accent palette. Legend reordered to match lifecycle flow.

## Out of Scope

- Close/archive flow (`merged_pr → done`) — ADR 014 step 7.
- Auto error classification (`in_progress → ready` vs `in_progress → drafting` on failure) — needs richer error taxonomy.
- `frontier` and `blocked` as derived views — stays the same, no state promotion.

## Test Plan

Automated (all green locally):
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 171/171 tests across 18 files
- [x] `npx vite build --config web/vite.config.ts` — 1.37s, only pre-existing CSS unused-selector warnings

Manual verification:
- [ ] Launch the app, open the graph view, confirm the new legend rows (`drafting`, `ready`, `merged_pr`) render with distinct colors
- [ ] Exercise `POST /api/work-items/:id/transition` end-to-end (e.g., `planned → drafting → ready`, then launch, verify work item lands on `in_progress`)
- [ ] Sync a merged PR via the existing flow and confirm the work item lands on `merged_pr` (not `done`), badge still renders
- [ ] Confirm a `ready`-state work item appears in the frontier / dispatch plan