### PR TITLE
feat: extract prepare-plan from execution launch (ADR 014 step 4)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,11 @@ import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
 import { HealthModule } from "./modules/health/health.module.js";
 import { PlanningModule } from "./modules/planning/planning.module.js";
+import { PlansModule } from "./modules/plans/plans.module.js";
 import { ReconciliationModule } from "./modules/reconciliation/reconciliation.module.js";
 import { SettingsModule } from "./modules/settings/settings.module.js";
 
 @Module({
-  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, ReconciliationModule, SettingsModule],
+  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, PlansModule, ReconciliationModule, SettingsModule],
 })
 export class AppModule {}

--- a/src/lib/__tests__/context-layout.test.ts
+++ b/src/lib/__tests__/context-layout.test.ts
@@ -13,12 +13,16 @@ import {
   canonicalScratchpadPath,
   ensurePlanDir,
   planDir,
+  planMetadataPath,
   plansRoot,
+  readPlanMetadata,
   runDir,
   runsRoot,
   workItemSlug,
   worktreeDir,
   worktreesRoot,
+  writePlanMetadata,
+  type PlanMetadata,
 } from "../context-layout.js";
 
 describe("workItemSlug", () => {
@@ -121,7 +125,7 @@ describe("ensurePlanDir", () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it("creates the plan dir and writes a metadata marker on first call", () => {
+  it("creates the plan dir and writes the full metadata shape on first call", () => {
     const dir = ensurePlanDir(tmpRoot, "studio-1234");
 
     expect(dir).toBe(join(tmpRoot, PLANS_DIR, "studio_1234"));
@@ -134,6 +138,15 @@ describe("ensurePlanDir", () => {
     expect(marker.plan_id).toBe("studio_1234");
     expect(marker.work_item_id).toBe("studio-1234");
     expect(typeof marker.created_at).toBe("string");
+    // ADR 014 step 4: full PlanMetadata shape on first creation
+    expect(marker.updated_at).toBe(marker.created_at);
+    expect(marker.state).toBeNull();
+    expect(marker.scratchpad_path).toBe(
+      canonicalScratchpadPath(tmpRoot, "studio-1234"),
+    );
+    expect(marker.approved_at).toBeNull();
+    expect(marker.approved_by).toBeNull();
+    expect(marker.run_ids).toEqual([]);
   });
 
   it("is idempotent when called twice for the same work item id", () => {
@@ -169,5 +182,95 @@ describe("ensurePlanDir", () => {
 
   it("throws when the work item id would produce an empty slug", () => {
     expect(() => ensurePlanDir(tmpRoot, "!!!")).toThrow(/empty slug/);
+  });
+});
+
+describe("plan metadata helpers (ADR 014 step 4)", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-154-metadata-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("planMetadataPath points at metadata.json inside the plan dir", () => {
+    expect(planMetadataPath(tmpRoot, "studio-1234")).toBe(
+      join(tmpRoot, PLANS_DIR, "studio_1234", PLAN_METADATA_FILE),
+    );
+  });
+
+  it("readPlanMetadata returns null when metadata does not exist", () => {
+    expect(readPlanMetadata(tmpRoot, "studio-1234")).toBeNull();
+  });
+
+  it("readPlanMetadata returns the full shape after ensurePlanDir", () => {
+    ensurePlanDir(tmpRoot, "studio-1234");
+    const metadata = readPlanMetadata(tmpRoot, "studio-1234");
+
+    expect(metadata).not.toBeNull();
+    expect(metadata!.plan_id).toBe("studio_1234");
+    expect(metadata!.work_item_id).toBe("studio-1234");
+    expect(metadata!.state).toBeNull();
+    expect(metadata!.scratchpad_path).toBe(
+      canonicalScratchpadPath(tmpRoot, "studio-1234"),
+    );
+    expect(metadata!.run_ids).toEqual([]);
+  });
+
+  it("readPlanMetadata tolerates the legacy 3-field marker shape", () => {
+    // Simulate a plan dir created by an earlier step that only wrote the
+    // legacy marker shape (plan_id / work_item_id / created_at).
+    const slug = "studio_1234";
+    const dir = join(tmpRoot, PLANS_DIR, slug);
+    mkdirSync(dir, { recursive: true });
+    const legacy = {
+      plan_id: slug,
+      work_item_id: "studio-1234",
+      created_at: "2026-01-01T00:00:00.000Z",
+    };
+    writeFileSync(join(dir, PLAN_METADATA_FILE), JSON.stringify(legacy), "utf8");
+
+    const metadata = readPlanMetadata(tmpRoot, "studio-1234");
+
+    expect(metadata).not.toBeNull();
+    // Legacy fields preserved
+    expect(metadata!.created_at).toBe("2026-01-01T00:00:00.000Z");
+    expect(metadata!.plan_id).toBe(slug);
+    // Missing fields defaulted
+    expect(metadata!.updated_at).toBe("2026-01-01T00:00:00.000Z");
+    expect(metadata!.state).toBeNull();
+    expect(metadata!.scratchpad_path).toBe(canonicalScratchpadPath(tmpRoot, "studio-1234"));
+    expect(metadata!.approved_at).toBeNull();
+    expect(metadata!.approved_by).toBeNull();
+    expect(metadata!.run_ids).toEqual([]);
+  });
+
+  it("writePlanMetadata persists changes that readPlanMetadata can round-trip", () => {
+    ensurePlanDir(tmpRoot, "studio-1234");
+    const before = readPlanMetadata(tmpRoot, "studio-1234")!;
+
+    const updated: PlanMetadata = {
+      ...before,
+      state: "drafting",
+      updated_at: "2026-04-09T12:00:00.000Z",
+    };
+    writePlanMetadata(tmpRoot, "studio-1234", updated);
+
+    const after = readPlanMetadata(tmpRoot, "studio-1234");
+    expect(after!.state).toBe("drafting");
+    expect(after!.updated_at).toBe("2026-04-09T12:00:00.000Z");
+    expect(after!.plan_id).toBe(before.plan_id);
+  });
+
+  it("readPlanMetadata throws when metadata is corrupt JSON", () => {
+    const slug = "studio_1234";
+    const dir = join(tmpRoot, PLANS_DIR, slug);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, PLAN_METADATA_FILE), "{ bad json", "utf8");
+
+    expect(() => readPlanMetadata(tmpRoot, "studio-1234")).toThrow(/failed to parse/);
   });
 });

--- a/src/lib/context-layout.ts
+++ b/src/lib/context-layout.ts
@@ -111,22 +111,122 @@ export function canonicalScratchpadPath(artifactRoot: string, workItemId: string
   return join(planDir(artifactRoot, workItemId), `SCRATCHPAD_${slug}.md`);
 }
 
-/* ── Plan dir creation with collision detection ──────────────────────────── */
+/* ── Plan metadata schema ────────────────────────────────────────────────── */
 
-interface PlanMetadataMarker {
+/**
+ * ADR 014 plan state. Mirrors the prepared-plan phase of the work item
+ * lifecycle.
+ *
+ * - `null` — legacy or execution-launched plan dir that was created without
+ *   going through the prepare-plan flow. Step 4 introduces prepare/approve
+ *   as an explicit path; existing callers (ExecutionService) still create
+ *   plan dirs directly at launch time with a null state.
+ * - `"drafting"` — written by PlansService.prepare
+ * - `"ready"` — written by PlansService.approve
+ */
+export type PlanState = "drafting" | "ready" | null;
+
+/**
+ * Full plan metadata shape written to `plans/<slug>/metadata.json`.
+ *
+ * Introduced in ADR 014 step 4 (issue #154). Earlier steps wrote only a
+ * 3-field marker (`plan_id`, `work_item_id`, `created_at`); `readPlanMetadata`
+ * tolerates that legacy shape by filling in missing fields with defaults.
+ */
+export interface PlanMetadata {
   plan_id: string;
   work_item_id: string;
   created_at: string;
+  updated_at: string;
+  state: PlanState;
+  scratchpad_path: string;
+  approved_at: string | null;
+  approved_by: string | null;
+  run_ids: string[];
+}
+
+/** Path to the metadata.json sidecar for a work item's plan. */
+export function planMetadataPath(artifactRoot: string, workItemId: string): string {
+  return join(planDir(artifactRoot, workItemId), PLAN_METADATA_FILE);
 }
 
 /**
- * Ensure the plan directory for a work item exists, creating it (and a
- * minimal metadata sidecar) on first call. Idempotent when called repeatedly
- * for the same work item id.
+ * Read plan metadata from disk, tolerating the legacy 3-field marker shape.
+ * Returns `null` if the metadata file does not exist.
+ *
+ * Missing fields are filled with safe defaults: `state` is `null`,
+ * `updated_at` falls back to `created_at`, `scratchpad_path` is recomputed,
+ * approver fields are null, `run_ids` is empty. This lets new code assume the
+ * full shape without breaking plan dirs created by earlier steps.
+ *
+ * @throws if the file exists but cannot be parsed as JSON
+ */
+export function readPlanMetadata(artifactRoot: string, workItemId: string): PlanMetadata | null {
+  const path = planMetadataPath(artifactRoot, workItemId);
+  if (!existsSync(path)) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `readPlanMetadata: failed to parse ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`readPlanMetadata: ${path} did not contain a JSON object`);
+  }
+
+  const partial = raw as Partial<PlanMetadata>;
+  const slug = workItemSlug(workItemId);
+  const createdAt = typeof partial.created_at === "string" ? partial.created_at : new Date(0).toISOString();
+
+  return {
+    plan_id: typeof partial.plan_id === "string" ? partial.plan_id : slug,
+    work_item_id: typeof partial.work_item_id === "string" ? partial.work_item_id : workItemId,
+    created_at: createdAt,
+    updated_at: typeof partial.updated_at === "string" ? partial.updated_at : createdAt,
+    state: partial.state === "drafting" || partial.state === "ready" ? partial.state : null,
+    scratchpad_path:
+      typeof partial.scratchpad_path === "string"
+        ? partial.scratchpad_path
+        : canonicalScratchpadPath(artifactRoot, workItemId),
+    approved_at: typeof partial.approved_at === "string" ? partial.approved_at : null,
+    approved_by: typeof partial.approved_by === "string" ? partial.approved_by : null,
+    run_ids: Array.isArray(partial.run_ids)
+      ? partial.run_ids.filter((id): id is string => typeof id === "string")
+      : [],
+  };
+}
+
+/**
+ * Write plan metadata to disk. Caller is responsible for ensuring the plan
+ * dir exists (use `ensurePlanDir` first).
+ */
+export function writePlanMetadata(
+  artifactRoot: string,
+  workItemId: string,
+  metadata: PlanMetadata,
+): void {
+  const path = planMetadataPath(artifactRoot, workItemId);
+  writeFileSync(path, JSON.stringify(metadata, null, 2), "utf8");
+}
+
+/* ── Plan dir creation with collision detection ──────────────────────────── */
+
+/**
+ * Ensure the plan directory for a work item exists, creating it (and a full
+ * metadata sidecar) on first call. Idempotent when called repeatedly for the
+ * same work item id.
  *
  * Detects slug collisions: if another work item id already owns a plan dir at
  * the same slug path, throws with a clear error. This matches the collision
  * detection requirement in ADR 014 step 1.
+ *
+ * On first creation, writes the full `PlanMetadata` shape with `state: null`,
+ * `updated_at = created_at`, empty approver fields, and empty `run_ids`.
+ * PlansService.prepare overwrites with `state: "drafting"` afterwards.
  *
  * Returns the absolute path to the plan directory.
  *
@@ -138,9 +238,9 @@ export function ensurePlanDir(artifactRoot: string, workItemId: string): string 
   const metadataPath = join(dir, PLAN_METADATA_FILE);
 
   if (existsSync(metadataPath)) {
-    let existing: PlanMetadataMarker | null = null;
+    let existing: Partial<PlanMetadata> | null = null;
     try {
-      existing = JSON.parse(readFileSync(metadataPath, "utf8")) as PlanMetadataMarker;
+      existing = JSON.parse(readFileSync(metadataPath, "utf8")) as Partial<PlanMetadata>;
     } catch {
       // Corrupt marker — treat as a collision the caller must resolve manually.
       throw new Error(
@@ -161,12 +261,19 @@ export function ensurePlanDir(artifactRoot: string, workItemId: string): string 
 
   mkdirSync(dir, { recursive: true });
 
-  const marker: PlanMetadataMarker = {
+  const now = new Date().toISOString();
+  const metadata: PlanMetadata = {
     plan_id: slug,
     work_item_id: workItemId,
-    created_at: new Date().toISOString(),
+    created_at: now,
+    updated_at: now,
+    state: null,
+    scratchpad_path: canonicalScratchpadPath(artifactRoot, workItemId),
+    approved_at: null,
+    approved_by: null,
+    run_ids: [],
   };
-  writeFileSync(metadataPath, JSON.stringify(marker, null, 2), "utf8");
+  writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), "utf8");
 
   return dir;
 }

--- a/src/lib/github-cli.ts
+++ b/src/lib/github-cli.ts
@@ -1,0 +1,32 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Thin wrappers around the `gh` CLI. Extracted in ADR 014 step 4 (#154) so
+ * that both `ExecutionService` and `PlansService` can reach for the same
+ * issue-fetching helper without duplicating the `gh` invocation or creating
+ * an inter-module dependency for a simple utility.
+ *
+ * All helpers here are synchronous and swallow `gh` failures by returning
+ * `null` — the caller decides how to surface missing issue data.
+ */
+
+/**
+ * Fetch the body of a GitHub issue via `gh issue view`. Returns the body
+ * text, or `null` if inputs are missing, the CLI fails, or the body is empty.
+ *
+ * Uses a 15s timeout to avoid hanging the calling request on flaky network
+ * conditions.
+ */
+export function fetchIssueBody(repo: string | null, issueNumber: number | null): string | null {
+  if (!repo || !issueNumber) return null;
+  try {
+    const raw = execFileSync(
+      "gh",
+      ["issue", "view", String(issueNumber), "--repo", repo, "--json", "body", "--jq", ".body"],
+      { encoding: "utf8", timeout: 15000 },
+    ).trim();
+    return raw || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -12,6 +12,7 @@ import {
   workItemSlug,
   worktreesRoot,
 } from "../../lib/context-layout.js";
+import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -600,20 +601,6 @@ export class ExecutionService {
     return { resolved: true, run_id: runId };
   }
 
-  /** Fetch issue body via gh CLI. Returns body text or null. */
-  private fetchIssueBody(repo: string | null, issueNumber: number | null): string | null {
-    if (!repo || !issueNumber) return null;
-    try {
-      const raw = execFileSync("gh", ["issue", "view", String(issueNumber), "--repo", repo, "--json", "body", "--jq", ".body"], {
-        encoding: "utf8",
-        timeout: 15000,
-      }).trim();
-      return raw || null;
-    } catch {
-      return null;
-    }
-  }
-
   /** Read AGENTS.md or CLAUDE.md from a directory if it exists. */
   private readProjectContext(dir: string): string | null {
     for (const name of ["AGENTS.md", "CLAUDE.md"]) {
@@ -661,7 +648,7 @@ export class ExecutionService {
 
     // --- Gather context ---
     const workItem = this.workItemsService.get(run.work_item_id);
-    const issueBody = this.fetchIssueBody(workItem.repo, workItem.issue_number);
+    const issueBody = fetchIssueBody(workItem.repo, workItem.issue_number);
     const projectContext = this.readProjectContext(run.worktree_path);
     this.pushActivity(run.run_id, "status_change", `Context gathered: issue body ${issueBody ? "found" : "not found"}, project conventions ${projectContext ? "found" : "not found"}`);
 

--- a/src/modules/plans/__tests__/plans.service.test.ts
+++ b/src/modules/plans/__tests__/plans.service.test.ts
@@ -1,0 +1,564 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { PlansService } from "../plans.service.js";
+import type { PlanResponse } from "../types.js";
+import {
+  canonicalScratchpadPath,
+  ensurePlanDir,
+  readPlanMetadata,
+  type PlanMetadata,
+} from "../../../lib/context-layout.js";
+import type { StudioIssueTemplate } from "../../github/studio-issue-template.service.js";
+import type { WorkItemRecord, WorkItemState } from "../../graph/types.js";
+
+/**
+ * ADR 014 step 4 — PlansService lifecycle tests.
+ *
+ * Uses the Object.create harness pattern from the execution test suite to
+ * bypass NestJS DI. fetchIssueBody (from src/lib/github-cli.ts) is mocked so
+ * prepare runs synchronously without shelling out to `gh`.
+ */
+
+vi.mock("../../../lib/github-cli.js", () => ({
+  fetchIssueBody: vi.fn(() => "Mocked issue body from fixture."),
+}));
+
+interface HarnessWorkItemsService {
+  get(id: string): WorkItemRecord;
+  update(id: string, patch: Partial<WorkItemRecord>): WorkItemRecord;
+}
+
+interface HarnessTemplateService {
+  listTemplates(): StudioIssueTemplate[];
+}
+
+interface Harness {
+  service: PlansService;
+  workItems: Map<string, WorkItemRecord>;
+  updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }>;
+  templates: StudioIssueTemplate[];
+  artifactRoot: string;
+}
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-154",
+    name: "Extract prepare-plan from execution launch",
+    kind: "issue",
+    state: "planned",
+    repo: "fusupo/escapement-studio",
+    issue_number: 154,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/154",
+    scope_hint: "Split plan preparation from execution launch.",
+    branch: "154-extract-prepare-plan-from-execution-launch",
+    archive_path: null,
+    predicted_files: ["src/modules/plans/plans.service.ts"],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeTemplate(kind: "feature" | "bug" | "task", name: string): StudioIssueTemplate {
+  return {
+    kind,
+    path: `.github/ISSUE_TEMPLATE/${kind}.md`,
+    name,
+    labels: [kind],
+    body: `# ${name}\n\n## Summary\n\n## Acceptance Criteria\n`,
+  };
+}
+
+function makeHarness(initial: WorkItemRecord): Harness {
+  const workItems = new Map<string, WorkItemRecord>([[initial.id, initial]]);
+  const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+  const templates: StudioIssueTemplate[] = [makeTemplate("feature", "Feature Request")];
+  const artifactRoot = mkdtempSync(join(tmpdir(), "studio-154-"));
+
+  const workItemsService: HarnessWorkItemsService = {
+    get(id: string): WorkItemRecord {
+      const item = workItems.get(id);
+      if (!item) throw new NotFoundException(`Work item not found: ${id}`);
+      return item;
+    },
+    update(id: string, patch: Partial<WorkItemRecord>): WorkItemRecord {
+      updateCalls.push({ id, patch });
+      const current = workItems.get(id);
+      if (!current) throw new NotFoundException(`Work item not found: ${id}`);
+      const next: WorkItemRecord = {
+        ...current,
+        ...patch,
+        updated_at: new Date("2026-04-09T00:00:05.000Z").toISOString(),
+      };
+      workItems.set(id, next);
+      return next;
+    },
+  };
+  const templateService: HarnessTemplateService = {
+    listTemplates: () => templates,
+  };
+
+  const service = Object.create(PlansService.prototype) as PlansService;
+  (service as unknown as { workItemsService: HarnessWorkItemsService }).workItemsService = workItemsService;
+  (service as unknown as { templateService: HarnessTemplateService }).templateService = templateService;
+  (service as unknown as { artifactRoot: string }).artifactRoot = artifactRoot;
+  (service as unknown as { logger: { log: (m: string) => void } }).logger = { log: () => {} };
+
+  return { service, workItems, updateCalls, templates, artifactRoot };
+}
+
+function cleanup(h: Harness) {
+  rmSync(h.artifactRoot, { recursive: true, force: true });
+}
+
+describe("PlansService.prepare", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("transitions planned → drafting and writes canonical scratchpad", () => {
+    harness = makeHarness(makeWorkItem());
+
+    const result = harness.service.prepare("studio-154");
+
+    expect(result.work_item_id).toBe("studio-154");
+    expect(result.metadata.state).toBe("drafting");
+    // The update call from prepare
+    expect(harness.updateCalls).toEqual([{ id: "studio-154", patch: { state: "drafting" } }]);
+
+    // Scratchpad exists with the skeleton content
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
+    expect(existsSync(canonical)).toBe(true);
+    const content = readFileSync(canonical, "utf8");
+    expect(content).toContain("# Plan: studio-154");
+    expect(content).toContain("## Affected Files");
+    expect(content).toContain("## Acceptance Criteria");
+    expect(content).toContain("Mocked issue body from fixture.");
+  });
+
+  it("is idempotent on drafting → drafting and carries existing scratchpad forward", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
+    writeFileSync(canonical, "# Human edit — do not stomp\n", "utf8");
+
+    const result = harness.service.prepare("studio-154");
+
+    // No transition update — already drafting
+    expect(harness.updateCalls).toEqual([]);
+    // Scratchpad content preserved verbatim
+    expect(result.scratchpad_content).toBe("# Human edit — do not stomp\n");
+    expect(readFileSync(canonical, "utf8")).toBe("# Human edit — do not stomp\n");
+    // But metadata is still written (updated_at bumped, state stays drafting)
+    expect(result.metadata.state).toBe("drafting");
+  });
+
+  it("regenerates skeleton if canonical scratchpad exists but is empty", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
+    writeFileSync(canonical, "   \n  \n", "utf8");
+
+    const result = harness.service.prepare("studio-154");
+
+    expect(result.scratchpad_content).toContain("# Plan: studio-154");
+  });
+
+  const rejectedStates: WorkItemState[] = ["in_progress", "open_pr", "merged_pr", "done", "ready", "deferred", "cancelled"];
+  for (const state of rejectedStates) {
+    it(`rejects prepare when work item is in ${state}`, () => {
+      harness = makeHarness(makeWorkItem({ state }));
+      expect(() => harness.service.prepare("studio-154")).toThrow(BadRequestException);
+      // No state mutation on failure
+      expect(harness.updateCalls).toEqual([]);
+    });
+  }
+
+  it("throws NotFoundException when work item does not exist", () => {
+    harness = makeHarness(makeWorkItem());
+    expect(() => harness.service.prepare("studio-missing")).toThrow(NotFoundException);
+  });
+});
+
+describe("PlansService.buildPlanScratchpad / renderPlanScratchpad", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("includes all required canonical sections", () => {
+    harness = makeHarness(makeWorkItem());
+    const content = harness.service.renderPlanScratchpad(
+      makeWorkItem(),
+      "Issue body goes here.",
+      [makeTemplate("feature", "Feature Request")],
+    );
+
+    expect(content).toContain("## Context");
+    expect(content).toContain("## Issue Body");
+    expect(content).toContain("## Summary");
+    expect(content).toContain("## Acceptance Criteria");
+    expect(content).toContain("## Implementation Plan");
+    expect(content).toContain("## Affected Files");
+    expect(content).toContain("## Quality Checks");
+    expect(content).toContain("## Questions / Concerns");
+    expect(content).toContain("## Studio Issue Templates Available");
+    expect(content).toContain("## Work Log");
+    expect(content).toContain("## Blockers");
+  });
+
+  it("seeds the ## Affected Files section from predicted_files", () => {
+    harness = makeHarness(makeWorkItem());
+    const content = harness.service.renderPlanScratchpad(
+      makeWorkItem({ predicted_files: ["a.ts", "b.ts"] }),
+      null,
+      [],
+    );
+    expect(content).toContain("- a.ts");
+    expect(content).toContain("- b.ts");
+  });
+
+  it("handles missing issue body gracefully", () => {
+    harness = makeHarness(makeWorkItem());
+    const content = harness.service.renderPlanScratchpad(makeWorkItem(), null, []);
+    expect(content).toContain("issue body unavailable");
+  });
+});
+
+describe("PlansService.extractAffectedFiles", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("extracts bare file paths from a well-formed section", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = [
+      "# Plan",
+      "## Affected Files",
+      "",
+      "- src/foo.ts",
+      "- src/bar.ts",
+      "- src/baz.ts",
+      "",
+      "## Quality Checks",
+      "- [ ] tsc",
+    ].join("\n");
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual([
+      "src/foo.ts",
+      "src/bar.ts",
+      "src/baz.ts",
+    ]);
+  });
+
+  it("strips inline notes separated by — and (", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = [
+      "## Affected Files",
+      "- src/foo.ts — new helper",
+      "- src/bar.ts (modify)",
+      "- `src/baz.ts`",
+      "",
+      "## Next",
+    ].join("\n");
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual([
+      "src/foo.ts",
+      "src/bar.ts",
+      "src/baz.ts",
+    ]);
+  });
+
+  it("skips placeholder parenthetical items", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = [
+      "## Affected Files",
+      "- (none predicted yet — populate during plan review)",
+      "- src/real.ts",
+      "## End",
+    ].join("\n");
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual(["src/real.ts"]);
+  });
+
+  it("dedupes repeated entries", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = [
+      "## Affected Files",
+      "- src/a.ts",
+      "- src/a.ts",
+      "- src/b.ts",
+      "## End",
+    ].join("\n");
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("returns empty array when section is missing", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = "# Plan\n\n## Summary\n\n- not affected files";
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual([]);
+  });
+
+  it("returns empty array when section is empty", () => {
+    harness = makeHarness(makeWorkItem());
+    const scratchpad = "## Affected Files\n\n<!-- nothing here yet -->\n\n## Next";
+    expect(harness.service.extractAffectedFiles(scratchpad)).toEqual([]);
+  });
+});
+
+describe("PlansService.diffPredictedFiles", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("computes added/removed/unchanged correctly", () => {
+    harness = makeHarness(makeWorkItem());
+    const diff = harness.service.diffPredictedFiles(["a.ts", "b.ts"], ["b.ts", "c.ts"]);
+    expect(diff).toEqual({ added: ["c.ts"], removed: ["a.ts"], unchanged: ["b.ts"] });
+  });
+
+  it("returns empty diff for matching lists", () => {
+    harness = makeHarness(makeWorkItem());
+    const diff = harness.service.diffPredictedFiles(["a.ts"], ["a.ts"]);
+    expect(diff).toEqual({ added: [], removed: [], unchanged: ["a.ts"] });
+  });
+});
+
+describe("PlansService.approve", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  function primeDraft(workItem: WorkItemRecord, affectedFiles: string[]): void {
+    // Simulate a prior prepare: ensure plan dir + canonical scratchpad exist
+    // and the work item is in drafting state.
+    ensurePlanDir(harness.artifactRoot, workItem.id);
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, workItem.id);
+    const content = [
+      "# Plan",
+      "## Affected Files",
+      ...affectedFiles.map((f) => `- ${f}`),
+      "## End",
+    ].join("\n");
+    writeFileSync(canonical, content, "utf8");
+    // Manually mark drafting so approve's precondition passes
+    harness.workItems.set(workItem.id, { ...workItem, state: "drafting" });
+  }
+
+  it("transitions drafting → ready and records approver metadata", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    primeDraft(harness.workItems.get("studio-154")!, ["src/foo.ts"]);
+    harness.updateCalls.length = 0; // clear the primeDraft set() noise
+
+    const result = harness.service.approve("studio-154", { approved_by: "alice" });
+
+    expect(result.metadata.state).toBe("ready");
+    expect(result.metadata.approved_by).toBe("alice");
+    expect(typeof result.metadata.approved_at).toBe("string");
+    // The last update call should be the state transition to ready
+    const stateUpdate = harness.updateCalls.find((c) => c.patch.state === "ready");
+    expect(stateUpdate).toBeDefined();
+  });
+
+  it("defaults approved_by to 'local' when dto omits it", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    primeDraft(harness.workItems.get("studio-154")!, ["src/foo.ts"]);
+
+    const result = harness.service.approve("studio-154");
+
+    expect(result.metadata.approved_by).toBe("local");
+  });
+
+  it("refines predicted_files from ## Affected Files and returns diff", () => {
+    const workItem = makeWorkItem({ state: "drafting", predicted_files: ["old.ts", "shared.ts"] });
+    harness = makeHarness(workItem);
+    primeDraft(workItem, ["shared.ts", "new.ts"]);
+    harness.updateCalls.length = 0;
+
+    const result = harness.service.approve("studio-154");
+
+    expect(result.predicted_files_diff).toEqual({
+      added: ["new.ts"],
+      removed: ["old.ts"],
+      unchanged: ["shared.ts"],
+    });
+    // predicted_files update call came first, then state transition to ready
+    const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
+    expect(predictedUpdate?.patch.predicted_files).toEqual(["shared.ts", "new.ts"]);
+  });
+
+  it("leaves predicted_files unchanged when ## Affected Files is empty", () => {
+    const workItem = makeWorkItem({ state: "drafting", predicted_files: ["keep.ts"] });
+    harness = makeHarness(workItem);
+    primeDraft(workItem, []); // empty Affected Files
+    harness.updateCalls.length = 0;
+
+    const result = harness.service.approve("studio-154");
+
+    expect(result.predicted_files_diff).toEqual({
+      added: [],
+      removed: ["keep.ts"],
+      unchanged: [],
+    });
+    // No predicted_files update call — current value preserved
+    const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
+    expect(predictedUpdate).toBeUndefined();
+  });
+
+  const rejectedStates: WorkItemState[] = ["planned", "ready", "in_progress", "open_pr", "merged_pr", "done", "deferred", "cancelled"];
+  for (const state of rejectedStates) {
+    it(`rejects approve when state is ${state}`, () => {
+      harness = makeHarness(makeWorkItem({ state }));
+      expect(() => harness.service.approve("studio-154")).toThrow(BadRequestException);
+    });
+  }
+
+  it("throws NotFoundException when the canonical scratchpad is missing", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    // Ensure plan dir exists but not scratchpad
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    expect(() => harness.service.approve("studio-154")).toThrow(NotFoundException);
+  });
+});
+
+describe("PlansService.reopen", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("transitions ready → drafting and clears approver metadata", () => {
+    harness = makeHarness(makeWorkItem({ state: "ready" }));
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    // Seed metadata with an approved state
+    const metadataPath = join(harness.artifactRoot, "plans", "studio_154", "metadata.json");
+    const approved: PlanMetadata = {
+      plan_id: "studio_154",
+      work_item_id: "studio-154",
+      created_at: "2026-04-09T00:00:00.000Z",
+      updated_at: "2026-04-09T00:00:00.000Z",
+      state: "ready",
+      scratchpad_path: canonicalScratchpadPath(harness.artifactRoot, "studio-154"),
+      approved_at: "2026-04-09T00:00:03.000Z",
+      approved_by: "alice",
+      run_ids: [],
+    };
+    writeFileSync(metadataPath, JSON.stringify(approved), "utf8");
+    writeFileSync(canonicalScratchpadPath(harness.artifactRoot, "studio-154"), "# Plan", "utf8");
+
+    const result = harness.service.reopen("studio-154");
+
+    expect(result.metadata.state).toBe("drafting");
+    expect(result.metadata.approved_at).toBeNull();
+    expect(result.metadata.approved_by).toBeNull();
+    expect(harness.updateCalls).toEqual([{ id: "studio-154", patch: { state: "drafting" } }]);
+  });
+
+  const rejectedStates: WorkItemState[] = ["planned", "drafting", "in_progress", "open_pr", "merged_pr", "done", "deferred", "cancelled"];
+  for (const state of rejectedStates) {
+    it(`rejects reopen when state is ${state}`, () => {
+      harness = makeHarness(makeWorkItem({ state }));
+      expect(() => harness.service.reopen("studio-154")).toThrow(BadRequestException);
+    });
+  }
+});
+
+describe("PlansService.get", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("returns metadata + scratchpad for an existing plan", () => {
+    harness = makeHarness(makeWorkItem({ state: "drafting" }));
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    writeFileSync(
+      canonicalScratchpadPath(harness.artifactRoot, "studio-154"),
+      "# Plan",
+      "utf8",
+    );
+
+    const result = harness.service.get("studio-154");
+
+    expect(result.work_item_id).toBe("studio-154");
+    expect(result.scratchpad_content).toBe("# Plan");
+  });
+
+  it("throws NotFoundException when no plan dir exists", () => {
+    harness = makeHarness(makeWorkItem());
+    expect(() => harness.service.get("studio-154")).toThrow(NotFoundException);
+  });
+
+  it("throws NotFoundException when work item itself does not exist", () => {
+    harness = makeHarness(makeWorkItem());
+    expect(() => harness.service.get("studio-missing")).toThrow(NotFoundException);
+  });
+});
+
+describe("PlansService lifecycle (integration)", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("completes a full planned → drafting → ready → drafting → ready cycle", () => {
+    harness = makeHarness(makeWorkItem({ predicted_files: ["src/foo.ts"] }));
+
+    // 1. prepare
+    const afterPrepare: PlanResponse = harness.service.prepare("studio-154");
+    expect(afterPrepare.metadata.state).toBe("drafting");
+    expect(harness.workItems.get("studio-154")?.state).toBe("drafting");
+
+    // Inject a custom Affected Files section into the scratchpad so approve
+    // can exercise the refinement path.
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
+    writeFileSync(
+      canonical,
+      [
+        "# Plan: studio-154",
+        "## Affected Files",
+        "- src/foo.ts",
+        "- src/new.ts",
+        "## End",
+      ].join("\n"),
+      "utf8",
+    );
+
+    // 2. approve
+    const afterApprove = harness.service.approve("studio-154", { approved_by: "marc" });
+    expect(afterApprove.metadata.state).toBe("ready");
+    expect(afterApprove.metadata.approved_by).toBe("marc");
+    expect(afterApprove.predicted_files_diff?.added).toEqual(["src/new.ts"]);
+    expect(harness.workItems.get("studio-154")?.state).toBe("ready");
+    expect(harness.workItems.get("studio-154")?.predicted_files).toEqual(["src/foo.ts", "src/new.ts"]);
+
+    // Round-trip metadata via disk
+    const diskMetadata = readPlanMetadata(harness.artifactRoot, "studio-154");
+    expect(diskMetadata?.state).toBe("ready");
+    expect(diskMetadata?.approved_by).toBe("marc");
+
+    // 3. reopen
+    const afterReopen = harness.service.reopen("studio-154");
+    expect(afterReopen.metadata.state).toBe("drafting");
+    expect(afterReopen.metadata.approved_at).toBeNull();
+    expect(harness.workItems.get("studio-154")?.state).toBe("drafting");
+
+    // 4. approve again — should succeed on the second pass
+    const afterApprove2 = harness.service.approve("studio-154");
+    expect(afterApprove2.metadata.state).toBe("ready");
+    expect(harness.workItems.get("studio-154")?.state).toBe("ready");
+  });
+});

--- a/src/modules/plans/plans.controller.ts
+++ b/src/modules/plans/plans.controller.ts
@@ -1,0 +1,39 @@
+import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { PlansService } from "./plans.service.js";
+import type { ApprovePlanDto, PlanResponse, ReopenPlanDto } from "./types.js";
+
+/**
+ * ADR 014 step 4 — plan preparation REST endpoints.
+ *
+ * See `src/modules/plans/plans.service.ts` for the lifecycle contract.
+ */
+@Controller("api/plans")
+export class PlansController {
+  constructor(private readonly plansService: PlansService) {}
+
+  @Post(":work_item_id/prepare")
+  prepare(@Param("work_item_id") workItemId: string): PlanResponse {
+    return this.plansService.prepare(workItemId);
+  }
+
+  @Post(":work_item_id/approve")
+  approve(
+    @Param("work_item_id") workItemId: string,
+    @Body() body: ApprovePlanDto = {},
+  ): PlanResponse {
+    return this.plansService.approve(workItemId, body);
+  }
+
+  @Post(":work_item_id/reopen")
+  reopen(
+    @Param("work_item_id") workItemId: string,
+    @Body() body: ReopenPlanDto = {},
+  ): PlanResponse {
+    return this.plansService.reopen(workItemId, body);
+  }
+
+  @Get(":work_item_id")
+  get(@Param("work_item_id") workItemId: string): PlanResponse {
+    return this.plansService.get(workItemId);
+  }
+}

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { GitHubModule } from "../github/github.module.js";
+import { GraphModule } from "../graph/graph.module.js";
+import { PlansController } from "./plans.controller.js";
+import { PlansService } from "./plans.service.js";
+
+/**
+ * ADR 014 step 4 — plan preparation module.
+ *
+ * Depends on GraphModule (for WorkItemsService) and GitHubModule (for
+ * StudioIssueTemplateService). One-directional — nothing else imports
+ * PlansModule, so no forwardRef cycles.
+ */
+@Module({
+  imports: [GraphModule, GitHubModule],
+  controllers: [PlansController],
+  providers: [PlansService],
+  exports: [PlansService],
+})
+export class PlansModule {}

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -1,0 +1,415 @@
+import { BadRequestException, Injectable, Logger, NotFoundException } from "@nestjs/common";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import {
+  canonicalScratchpadPath,
+  ensurePlanDir,
+  readPlanMetadata,
+  writePlanMetadata,
+  type PlanMetadata,
+} from "../../lib/context-layout.js";
+import { fetchIssueBody } from "../../lib/github-cli.js";
+import {
+  StudioIssueTemplateService,
+  type StudioIssueTemplate,
+} from "../github/studio-issue-template.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
+import type {
+  ApprovePlanDto,
+  PlanResponse,
+  PredictedFilesDiff,
+  ReopenPlanDto,
+} from "./types.js";
+
+/**
+ * ADR 014 step 4 — the plan preparation service.
+ *
+ * Splits scratchpad drafting out of the execution launch path so a plan can
+ * be drafted, reviewed, and approved independently of any run. Prepare does
+ * NOT create a worktree; the worktree still lives inside the execution flow
+ * and is created on launch.
+ *
+ * Lifecycle:
+ *   planned → drafting  (prepare)
+ *   drafting → ready    (approve)
+ *   ready → drafting    (reopen)
+ *
+ * See `docs/adr/014-plans-runs-state-model.md` and
+ * `docs/contracts/plan-and-run-lifecycle.md` for the full contract.
+ */
+@Injectable()
+export class PlansService {
+  private readonly logger = new Logger(PlansService.name);
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+
+  constructor(
+    private readonly workItemsService: WorkItemsService,
+    private readonly templateService: StudioIssueTemplateService,
+  ) {}
+
+  /* ── Public API ────────────────────────────────────────────────────────── */
+
+  /**
+   * Draft (or re-draft) the canonical scratchpad for a work item and
+   * transition it to the `drafting` state. No worktree is created.
+   *
+   * - If the canonical scratchpad already exists and is non-empty, its
+   *   contents are carried forward unchanged (so in-progress plan edits are
+   *   not destroyed).
+   * - If it is absent or empty, a fresh skeleton is generated from the issue
+   *   body and Studio issue templates.
+   *
+   * Valid pre-states: `planned`, `drafting`. Everything else throws
+   * `BadRequestException`.
+   */
+  prepare(workItemId: string): PlanResponse {
+    const workItem = this.workItemsService.get(workItemId);
+    this.assertPreparable(workItem);
+
+    // Transition work item state FIRST so concurrent prepare requests for
+    // the same work item fail fast on the state guard (they will observe
+    // `drafting`, not `planned`, if they lose the race). The state guard
+    // allows drafting → drafting (re-prepare) but rejects everything else.
+    const transitioned =
+      workItem.state === "drafting"
+        ? workItem
+        : this.workItemsService.update(workItemId, { state: "drafting" });
+
+    // Ensure the plan dir exists and write initial metadata if we were first.
+    ensurePlanDir(this.artifactRoot, workItemId);
+
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, workItemId);
+    let scratchpadContent: string;
+    if (existsSync(canonicalPath)) {
+      const existing = readFileSync(canonicalPath, "utf8");
+      if (existing.trim().length > 0) {
+        scratchpadContent = existing;
+      } else {
+        scratchpadContent = this.generateSkeleton(transitioned);
+        writeFileSync(canonicalPath, scratchpadContent, "utf8");
+      }
+    } else {
+      scratchpadContent = this.generateSkeleton(transitioned);
+      writeFileSync(canonicalPath, scratchpadContent, "utf8");
+    }
+
+    // Update plan metadata to reflect drafting state.
+    const metadata = this.updatePlanMetadata(workItemId, (current) => ({
+      ...current,
+      state: "drafting",
+      scratchpad_path: canonicalPath,
+    }));
+
+    return {
+      work_item_id: workItemId,
+      metadata,
+      scratchpad_content: scratchpadContent,
+    };
+  }
+
+  /**
+   * Approve a drafted plan: transition `drafting → ready`, auto-refine the
+   * work item's `predicted_files` from the scratchpad's `## Affected Files`
+   * section, and return the diff for review UIs.
+   */
+  approve(workItemId: string, dto: ApprovePlanDto = {}): PlanResponse {
+    const workItem = this.workItemsService.get(workItemId);
+    if (workItem.state !== "drafting") {
+      throw new BadRequestException(
+        `Cannot approve plan for ${workItemId}: expected state 'drafting', got '${workItem.state}'`,
+      );
+    }
+
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, workItemId);
+    if (!existsSync(canonicalPath)) {
+      throw new NotFoundException(
+        `Cannot approve plan for ${workItemId}: canonical scratchpad not found at ${canonicalPath}`,
+      );
+    }
+    const scratchpadContent = readFileSync(canonicalPath, "utf8");
+
+    // Compute the predicted_files diff from the scratchpad.
+    const extracted = this.extractAffectedFiles(scratchpadContent);
+    const diff = this.diffPredictedFiles(workItem.predicted_files, extracted);
+
+    // Apply the refinement only if the scratchpad's Affected Files section
+    // produced something. If it is empty/absent, preserve the current value.
+    if (extracted.length > 0) {
+      this.workItemsService.update(workItemId, { predicted_files: extracted });
+    }
+
+    // Transition drafting → ready.
+    this.workItemsService.update(workItemId, { state: "ready" });
+
+    const now = new Date().toISOString();
+    const approvedBy = dto.approved_by?.trim() || "local";
+    const metadata = this.updatePlanMetadata(workItemId, (current) => ({
+      ...current,
+      state: "ready",
+      approved_at: now,
+      approved_by: approvedBy,
+    }));
+
+    this.logger.log(
+      `Plan approved for ${workItemId} by ${approvedBy}: ` +
+        `${diff.added.length} added, ${diff.removed.length} removed, ${diff.unchanged.length} unchanged`,
+    );
+
+    return {
+      work_item_id: workItemId,
+      metadata,
+      scratchpad_content: scratchpadContent,
+      predicted_files_diff: diff,
+    };
+  }
+
+  /**
+   * Reopen an approved plan for further editing: `ready → drafting`. Clears
+   * approver fields in metadata.
+   */
+  reopen(workItemId: string, _dto: ReopenPlanDto = {}): PlanResponse {
+    const workItem = this.workItemsService.get(workItemId);
+    if (workItem.state !== "ready") {
+      throw new BadRequestException(
+        `Cannot reopen plan for ${workItemId}: expected state 'ready', got '${workItem.state}'`,
+      );
+    }
+
+    this.workItemsService.update(workItemId, { state: "drafting" });
+
+    const metadata = this.updatePlanMetadata(workItemId, (current) => ({
+      ...current,
+      state: "drafting",
+      approved_at: null,
+      approved_by: null,
+    }));
+
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, workItemId);
+    const scratchpadContent = existsSync(canonicalPath) ? readFileSync(canonicalPath, "utf8") : "";
+
+    return {
+      work_item_id: workItemId,
+      metadata,
+      scratchpad_content: scratchpadContent,
+    };
+  }
+
+  /**
+   * Fetch plan metadata + scratchpad content for a work item. Returns 404 if
+   * the plan dir does not exist yet.
+   */
+  get(workItemId: string): PlanResponse {
+    // Validate the work item exists (throws NotFoundException if not).
+    this.workItemsService.get(workItemId);
+
+    const metadata = readPlanMetadata(this.artifactRoot, workItemId);
+    if (!metadata) {
+      throw new NotFoundException(
+        `No plan found for work item ${workItemId}. Call POST /api/plans/${workItemId}/prepare first.`,
+      );
+    }
+
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, workItemId);
+    const scratchpadContent = existsSync(canonicalPath) ? readFileSync(canonicalPath, "utf8") : "";
+
+    return {
+      work_item_id: workItemId,
+      metadata,
+      scratchpad_content: scratchpadContent,
+    };
+  }
+
+  /* ── Private helpers ───────────────────────────────────────────────────── */
+
+  private assertPreparable(workItem: WorkItemRecord): void {
+    const preparable: WorkItemState[] = ["planned", "drafting"];
+    if (!preparable.includes(workItem.state)) {
+      throw new BadRequestException(
+        `Cannot prepare plan for ${workItem.id}: expected state in [${preparable.join(", ")}], got '${workItem.state}'`,
+      );
+    }
+  }
+
+  /**
+   * Generate a skeleton scratchpad for a work item in the plan phase (no run
+   * context yet). Seeded from the issue body and the Studio issue templates.
+   * No sub-agent call — per Q2 decision, prepare writes structure only.
+   */
+  buildPlanScratchpad(workItem: WorkItemRecord): string {
+    const issueBody = fetchIssueBody(workItem.repo, workItem.issue_number);
+    const templates = this.templateService.listTemplates();
+    return this.renderPlanScratchpad(workItem, issueBody, templates);
+  }
+
+  /**
+   * Pure rendering function for the plan scratchpad skeleton. Separated from
+   * `buildPlanScratchpad` so tests can drive it with injected issue bodies
+   * and templates without mocking `gh` or the filesystem.
+   */
+  renderPlanScratchpad(
+    workItem: WorkItemRecord,
+    issueBody: string | null,
+    templates: StudioIssueTemplate[],
+  ): string {
+    const predictedOwned = workItem.predicted_files.length
+      ? workItem.predicted_files.map((path) => `- ${path}`).join("\n")
+      : "- (none predicted yet — populate during plan review)";
+
+    const templateSummary = templates.length
+      ? templates
+          .map((template) => `- ${template.kind}: ${template.name}`)
+          .join("\n")
+      : "- (no Studio issue templates found under .github/ISSUE_TEMPLATE)";
+
+    const issueSection = issueBody
+      ? ["## Issue Body", "", issueBody.trim(), ""]
+      : ["## Issue Body", "", "_(issue body unavailable — link to issue: " + (workItem.issue_url ?? "(not linked)") + ")_", ""];
+
+    return [
+      `# Plan: ${workItem.id} — ${workItem.name}`,
+      "",
+      "> Drafted by PlansService.prepare (ADR 014 step 4). Worktree not yet created.",
+      "",
+      "## Context",
+      `- **Work item:** ${workItem.id}`,
+      `- **Repo:** ${workItem.repo ?? "(not set)"}`,
+      `- **Issue:** ${workItem.issue_url ?? "(not linked)"}`,
+      `- **Scope hint:** ${workItem.scope_hint ?? "(not set)"}`,
+      `- **Branch:** ${workItem.branch ?? "(not set)"}`,
+      "",
+      ...issueSection,
+      "## Summary",
+      "<!-- One-paragraph statement of what this plan proposes. Fill during drafting. -->",
+      "",
+      "## Acceptance Criteria",
+      "<!-- Copy from the issue body if present, refine during drafting. -->",
+      "",
+      "- [ ] (to be filled in)",
+      "",
+      "## Implementation Plan",
+      "<!-- Atomic, committable tasks. Populate during drafting; approver reviews. -->",
+      "",
+      "- [ ] (to be filled in)",
+      "",
+      "## Affected Files",
+      "<!-- Predicted files this plan will touch. Approval refines the work item's predicted_files from this list. -->",
+      "",
+      predictedOwned,
+      "",
+      "## Quality Checks",
+      "- [ ] `npx tsc --noEmit`",
+      "- [ ] `npx vitest run`",
+      "- [ ] `npx vite build --config web/vite.config.ts`",
+      "",
+      "## Questions / Concerns",
+      "<!-- Surface ambiguities here. Resolve before approval. -->",
+      "",
+      "## Studio Issue Templates Available",
+      templateSummary,
+      "",
+      "## Work Log",
+      "",
+      `### ${new Date().toISOString().slice(0, 10)} - Plan drafted`,
+      "- Scratchpad created by PlansService.prepare",
+      "",
+      "## Blockers",
+      "",
+    ].join("\n");
+  }
+
+  /**
+   * Parse the `## Affected Files` section of a scratchpad. Returns a deduped,
+   * stable-ordered list of file paths. List items may include inline notes
+   * separated by `—` or `(` — only the path portion is captured.
+   *
+   * If the section is missing or empty, returns `[]`.
+   */
+  extractAffectedFiles(scratchpadContent: string): string[] {
+    const lines = scratchpadContent.split(/\r?\n/);
+    let inSection = false;
+    const collected: string[] = [];
+    const seen = new Set<string>();
+
+    for (const line of lines) {
+      const headingMatch = /^##\s+(.+?)\s*$/.exec(line);
+      if (headingMatch) {
+        const heading = headingMatch[1].trim().toLowerCase();
+        if (heading === "affected files") {
+          inSection = true;
+          continue;
+        }
+        if (inSection) {
+          // Left the section on the next ## heading
+          break;
+        }
+      }
+
+      if (!inSection) continue;
+
+      // Skip HTML comments, empty lines, and non-list lines
+      const listMatch = /^\s*[-*]\s+(.+?)\s*$/.exec(line);
+      if (!listMatch) continue;
+
+      let item = listMatch[1].trim();
+      if (!item) continue;
+      // Strip inline notes (e.g. `src/foo.ts — add helper` or `src/foo.ts (new)`)
+      const dashIdx = item.indexOf(" —");
+      if (dashIdx !== -1) item = item.slice(0, dashIdx).trim();
+      const parenIdx = item.indexOf(" (");
+      if (parenIdx !== -1) item = item.slice(0, parenIdx).trim();
+      // Strip surrounding backticks that some authors use for monospace
+      item = item.replace(/^`+|`+$/g, "").trim();
+      // Skip bare comments and placeholders
+      if (!item || item.startsWith("(")) continue;
+
+      if (!seen.has(item)) {
+        seen.add(item);
+        collected.push(item);
+      }
+    }
+
+    return collected;
+  }
+
+  /**
+   * Compute the diff between the current `predicted_files` and a new list
+   * extracted from the plan.
+   */
+  diffPredictedFiles(current: string[], next: string[]): PredictedFilesDiff {
+    const currentSet = new Set(current);
+    const nextSet = new Set(next);
+    const added = next.filter((f) => !currentSet.has(f));
+    const removed = current.filter((f) => !nextSet.has(f));
+    const unchanged = next.filter((f) => currentSet.has(f));
+    return { added, removed, unchanged };
+  }
+
+  /**
+   * Read, mutate, and write plan metadata in a single step, bumping
+   * `updated_at` to now.
+   */
+  private updatePlanMetadata(
+    workItemId: string,
+    mutator: (current: PlanMetadata) => PlanMetadata,
+  ): PlanMetadata {
+    const current = readPlanMetadata(this.artifactRoot, workItemId);
+    if (!current) {
+      throw new Error(
+        `updatePlanMetadata: plan dir for ${workItemId} missing — call ensurePlanDir first`,
+      );
+    }
+    const mutated: PlanMetadata = {
+      ...mutator(current),
+      updated_at: new Date().toISOString(),
+    };
+    writePlanMetadata(this.artifactRoot, workItemId, mutated);
+    return mutated;
+  }
+
+  /** Alias used by `prepare` for clarity at the call site. */
+  private generateSkeleton(workItem: WorkItemRecord): string {
+    return this.buildPlanScratchpad(workItem);
+  }
+}

--- a/src/modules/plans/types.ts
+++ b/src/modules/plans/types.ts
@@ -1,0 +1,43 @@
+import type { PlanMetadata } from "../../lib/context-layout.js";
+
+/** POST /api/plans/:work_item_id/prepare — no body required. */
+export interface PreparePlanDto {
+  // intentionally empty — the work item id is a path param
+}
+
+/** POST /api/plans/:work_item_id/approve */
+export interface ApprovePlanDto {
+  /** Opaque identifier of the approver. Defaults to `"local"` (single-user MVP). */
+  approved_by?: string;
+}
+
+/** POST /api/plans/:work_item_id/reopen */
+export interface ReopenPlanDto {
+  /** Optional human-readable reason recorded in plan metadata. Not persisted yet. */
+  reason?: string;
+}
+
+/**
+ * Diff between the current work item's `predicted_files` and the files parsed
+ * out of the plan's `## Affected Files` section at approval time.
+ */
+export interface PredictedFilesDiff {
+  /** Files present in the plan but not in the previous `predicted_files`. */
+  added: string[];
+  /** Files present in the previous `predicted_files` but not in the plan. */
+  removed: string[];
+  /** Files present in both. */
+  unchanged: string[];
+}
+
+/**
+ * Response shape for all plan endpoints. The scratchpad content is always
+ * inlined (matching `getRunScratchpad` in the execution controller).
+ */
+export interface PlanResponse {
+  work_item_id: string;
+  metadata: PlanMetadata;
+  scratchpad_content: string;
+  /** Set on approve responses so the caller can surface the diff in review UIs. */
+  predicted_files_diff?: PredictedFilesDiff;
+}


### PR DESCRIPTION
## Summary

- Splits plan preparation from execution launch per ADR 014 step 4.
  Introduces a standalone `PlansService` that drafts the canonical
  scratchpad for a work item **without** creating a worktree, and owns
  the `planned → drafting → ready → drafting` transitions alongside
  approver metadata.
- Exposes four REST endpoints under `/api/plans/:work_item_id`:
  `prepare`, `approve`, `reopen`, and `GET`. Scratchpad content is
  returned inline in every response (matching the run-scratchpad
  pattern in the execution controller).
- At approval, parses the scratchpad's `## Affected Files` section and
  auto-refines the work item's `predicted_files`. Returns the
  `added/removed/unchanged` diff so review UIs can surface it.

Closes #154.

## What Changed

**Metadata schema (`src/lib/context-layout.ts`)**
- Exports new `PlanMetadata` interface and `PlanState` type
  (`"drafting" | "ready" | null`)
- Adds `planMetadataPath`, `readPlanMetadata`, `writePlanMetadata` helpers
- `ensurePlanDir` now writes the full shape with `state: null`
  (execution-launched plan dirs) on first creation
- `readPlanMetadata` tolerates the legacy 3-field marker shape from
  earlier steps by defaulting missing fields

**Shared `gh` helper (`src/lib/github-cli.ts`, new)**
- Extracts `fetchIssueBody(repo, issueNumber)` out of
  `ExecutionService` so both services can reach for the same
  implementation without duplication or inter-module coupling
- `ExecutionService` updated to import from the new helper

**Plans module (`src/modules/plans/`, new)**
- `PlansService` with `prepare` / `approve` / `reopen` / `get`
- `PlansController` exposing the four REST endpoints
- `PlansModule` depends on `GraphModule` + `GitHubModule` —
  one-directional, no new `forwardRef` cycles
- Registered in `AppModule`

**Tests (54 new)**
- `context-layout.test.ts`: +6 tests covering the expanded metadata
  schema, legacy shape tolerance, and the read/write helpers
- `plans.service.test.ts`: 48 tests covering prepare (state
  transitions, idempotency, scratchpad preservation, rejection from
  all invalid states), buildPlanScratchpad (section structure),
  extractAffectedFiles (path parsing, note stripping, dedup,
  placeholder handling), diffPredictedFiles, approve (transition,
  metadata, diff surfacing, rejection), reopen, get, and a full
  end-to-end lifecycle integration test

## Key Decisions (from SCRATCHPAD_154 Phase 3.5 Q&A)

1. **`fetchIssueBody` extracted to `src/lib/github-cli.ts`** rather
   than duplicated in `PlansService`. Cleaner long-term; avoids a
   second home for the same `gh` CLI pattern.
2. **`prepare` writes a skeleton only** — no sub-agent involvement.
   Structured template seeded from issue body + Studio issue
   template. Human or the Planner skill fills in the implementation
   plan externally before approval. Keeps the endpoint synchronous.
3. **`GET /api/plans/:id` returns scratchpad inline** matching the
   existing `getRunScratchpad` pattern in `ExecutionController`.

## Out of Scope

- Launch-time guard that *requires* a `ready` plan before execution
  can start. That is ADR 014 step 5 (deferred). Today launch still
  accepts both `planned` and `ready`.
- The `merged_pr → done` disposition flow — ADR 014 step 7 (deferred,
  tracked by #83).
- UI integration. This PR lands the service + REST surface; the
  Studio frontend continues to drive execution via the launch flow
  until a follow-up wires the prepare/approve actions into the graph
  view.

## Test Plan

Automated (all green locally):
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — **225/225** tests across 19 files
      (54 new tests for this issue)
- [x] `npx vite build --config web/vite.config.ts` — 1.25s clean
      (only pre-existing a11y warning in PlannerChatAdapter.svelte)

Manual verification (for the reviewer):
- [ ] `POST /api/plans/studio-154/prepare` on a `planned` work item
      transitions to `drafting`, writes the canonical scratchpad, and
      returns metadata + content inline
- [ ] Edit the scratchpad to add items under `## Affected Files`, then
      `POST /api/plans/studio-154/approve` — verify the work item's
      `predicted_files` is refined and `predicted_files_diff` is
      populated
- [ ] `POST /api/plans/studio-154/reopen` transitions back to
      `drafting` and clears `approved_by` in metadata
- [ ] `GET /api/plans/studio-154` returns the current metadata +
      scratchpad content