### PR TITLE
feat: replace scratchpad .gitignore trick with hard commit guards (ADR 014 step 6)

### DIFF
--- a/src/modules/execution/__tests__/scratchpad-commit-guards.test.ts
+++ b/src/modules/execution/__tests__/scratchpad-commit-guards.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BadRequestException } from "@nestjs/common";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionRunRecord } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+/**
+ * ADR 014 step 6: scratchpad commit guards.
+ *
+ * These tests run against real `git init` worktrees in tmp directories so
+ * that the `git diff --cached --name-only` and `git diff --name-only $base...HEAD`
+ * calls exercise actual git index / history semantics. Mocking git would
+ * defeat the purpose of the guards.
+ *
+ * Harness pattern matches launch-eligibility.test.ts: Object.create the
+ * ExecutionService prototype and wire up only the collaborators the code
+ * under test touches.
+ */
+
+interface HarnessService {
+  artifactRoot: string;
+  logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+  workItemsService: { get: (id: string) => WorkItemRecord; update: ReturnType<typeof vi.fn> };
+  appendEvent: ReturnType<typeof vi.fn>;
+  updateRun: ReturnType<typeof vi.fn>;
+  getRun: (runId: string) => ExecutionRunRecord | undefined;
+  runGhIn: ReturnType<typeof vi.fn>;
+  writeSummary: ReturnType<typeof vi.fn>;
+  buildPullRequestTitle: (workItem: WorkItemRecord) => string;
+  buildPullRequestBody: (run: ExecutionRunRecord, workItem: WorkItemRecord, baseRef: string) => string;
+
+  // Methods under test (prototype — available via Object.create)
+  findStagedScratchpadViolations: ExecutionService["findStagedScratchpadViolations"];
+  findCommittedScratchpadViolations: ExecutionService["findCommittedScratchpadViolations"];
+  isScratchpadPath: ExecutionService["isScratchpadPath"];
+  autoStageAndCommit: (run: ExecutionRunRecord, workItem: WorkItemRecord, commitMessage?: string) => void;
+  createPullRequest: ExecutionService["createPullRequest"];
+}
+
+function initGitRepo(worktreePath: string, baseBranch = "main"): void {
+  mkdirSync(worktreePath, { recursive: true });
+  execFileSync("git", ["init", "-q", "-b", baseBranch], { cwd: worktreePath });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: worktreePath });
+  execFileSync("git", ["config", "user.name", "Test User"], { cwd: worktreePath });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: worktreePath });
+  // Seed an initial commit so `$base...HEAD` has a valid merge-base
+  writeFileSync(join(worktreePath, "README.md"), "# base\n", "utf8");
+  execFileSync("git", ["add", "README.md"], { cwd: worktreePath });
+  execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: worktreePath });
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_test",
+    run_type: "execution",
+    work_item_id: "studio-156",
+    work_item_name: "Scratchpad commit guards test",
+    status: "completed",
+    created_at: "2026-04-09T00:00:00.000Z",
+    updated_at: "2026-04-09T00:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "156-scratchpad-commit-guards",
+    base_ref: "main",
+    worktree_path: "",
+    artifact_dir: "",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-156",
+    name: "Scratchpad commit guards",
+    kind: "issue",
+    state: "in_progress",
+    repo: "fusupo/escapement-studio",
+    issue_number: 156,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/156",
+    scope_hint: null,
+    branch: "156-scratchpad-commit-guards",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-09T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeService(params: { run?: ExecutionRunRecord; workItem?: WorkItemRecord } = {}): HarnessService {
+  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  const workItem = params.workItem ?? makeWorkItem();
+  service.artifactRoot = "/tmp/studio-artifact-test";
+  service.logger = { log: vi.fn(), warn: vi.fn() };
+  service.workItemsService = {
+    get: (_id: string) => workItem,
+    update: vi.fn((_id: string, patch: Partial<WorkItemRecord>) => ({ ...workItem, ...patch })),
+  };
+  service.appendEvent = vi.fn();
+  service.updateRun = vi.fn((_runId: string, patch: Partial<ExecutionRunRecord>) => ({
+    ...(params.run ?? makeRun()),
+    ...patch,
+  }));
+  service.getRun = (runId: string) => (params.run && params.run.run_id === runId ? params.run : undefined);
+  // Fail the test if the code under test attempts a gh call or push —
+  // the guards must throw BEFORE any side effect.
+  service.runGhIn = vi.fn(() => {
+    throw new Error("runGhIn should not be called when guard rejects");
+  });
+  service.writeSummary = vi.fn();
+  service.buildPullRequestTitle = () => "title";
+  service.buildPullRequestBody = () => "body";
+  return service;
+}
+
+describe("ADR 014 step 6: scratchpad commit guards", () => {
+  let tmpRoot: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-156-"));
+    worktree = join(tmpRoot, "wt");
+    initGitRepo(worktree);
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("isScratchpadPath", () => {
+    const service = Object.create(ExecutionService.prototype) as HarnessService;
+
+    it("matches SCRATCHPAD_<slug>.md at worktree root", () => {
+      expect(service.isScratchpadPath("SCRATCHPAD_studio_156.md")).toBe(true);
+    });
+
+    it("matches SCRATCHPAD_<slug>.md at any path depth", () => {
+      expect(service.isScratchpadPath("nested/dir/SCRATCHPAD_anything.md")).toBe(true);
+      expect(service.isScratchpadPath("deeply/nested/path/SCRATCHPAD_x.md")).toBe(true);
+    });
+
+    it("does not match unrelated files", () => {
+      expect(service.isScratchpadPath("README.md")).toBe(false);
+      expect(service.isScratchpadPath("src/scratchpad.md")).toBe(false); // lowercase
+      expect(service.isScratchpadPath("SCRATCHPAD.md")).toBe(false); // no underscore+slug
+      expect(service.isScratchpadPath("SCRATCHPAD_foo.txt")).toBe(false); // wrong extension
+    });
+  });
+
+  describe("findStagedScratchpadViolations", () => {
+    it("returns [] when the index is clean", () => {
+      const service = makeService();
+      expect(service.findStagedScratchpadViolations(worktree)).toEqual([]);
+    });
+
+    it("returns [] when only non-scratchpad files are staged", () => {
+      writeFileSync(join(worktree, "src.ts"), "export {};\n", "utf8");
+      execFileSync("git", ["add", "src.ts"], { cwd: worktree });
+      const service = makeService();
+      expect(service.findStagedScratchpadViolations(worktree)).toEqual([]);
+    });
+
+    it("detects a staged SCRATCHPAD_*.md at the root", () => {
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_156.md"), "secret plan\n", "utf8");
+      execFileSync("git", ["add", "SCRATCHPAD_studio_156.md"], { cwd: worktree });
+      const service = makeService();
+      expect(service.findStagedScratchpadViolations(worktree)).toEqual(["SCRATCHPAD_studio_156.md"]);
+    });
+
+    it("detects a staged SCRATCHPAD_*.md at a nested path", () => {
+      mkdirSync(join(worktree, "docs", "plans"), { recursive: true });
+      writeFileSync(join(worktree, "docs", "plans", "SCRATCHPAD_x.md"), "nested\n", "utf8");
+      execFileSync("git", ["add", "docs/plans/SCRATCHPAD_x.md"], { cwd: worktree });
+      const service = makeService();
+      expect(service.findStagedScratchpadViolations(worktree)).toEqual(["docs/plans/SCRATCHPAD_x.md"]);
+    });
+  });
+
+  describe("findCommittedScratchpadViolations", () => {
+    it("returns [] when the branch is clean relative to base", () => {
+      const service = makeService();
+      expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual([]);
+    });
+
+    it("returns [] when only non-scratchpad files were committed", () => {
+      execFileSync("git", ["checkout", "-q", "-b", "feature"], { cwd: worktree });
+      writeFileSync(join(worktree, "src.ts"), "export {};\n", "utf8");
+      execFileSync("git", ["add", "src.ts"], { cwd: worktree });
+      execFileSync("git", ["commit", "-q", "-m", "feat"], { cwd: worktree });
+      const service = makeService();
+      expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual([]);
+    });
+
+    it("detects a scratchpad committed to the branch", () => {
+      execFileSync("git", ["checkout", "-q", "-b", "feature"], { cwd: worktree });
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_156.md"), "leaked\n", "utf8");
+      execFileSync("git", ["add", "SCRATCHPAD_studio_156.md"], { cwd: worktree });
+      execFileSync("git", ["commit", "-q", "-m", "oops"], { cwd: worktree });
+      const service = makeService();
+      expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual(["SCRATCHPAD_studio_156.md"]);
+    });
+  });
+
+  describe("autoStageAndCommit", () => {
+    it("commits normally when no scratchpad is staged", () => {
+      writeFileSync(join(worktree, "src.ts"), "export {};\n", "utf8");
+      const run = makeRun({ worktree_path: worktree });
+      const workItem = makeWorkItem();
+      const service = makeService({ run, workItem });
+
+      expect(() => service.autoStageAndCommit(run, workItem)).not.toThrow();
+
+      // A new commit should exist
+      const log = execFileSync("git", ["log", "--oneline"], { cwd: worktree, encoding: "utf8" });
+      expect(log.split("\n").filter((l) => l.trim()).length).toBe(2); // initial + feat
+      // No block event should have been emitted
+      expect(service.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the worktree is clean", () => {
+      const run = makeRun({ worktree_path: worktree });
+      const workItem = makeWorkItem();
+      const service = makeService({ run, workItem });
+
+      expect(() => service.autoStageAndCommit(run, workItem)).not.toThrow();
+      expect(service.appendEvent).not.toHaveBeenCalled();
+
+      // Still only the initial commit
+      const log = execFileSync("git", ["log", "--oneline"], { cwd: worktree, encoding: "utf8" });
+      expect(log.split("\n").filter((l) => l.trim()).length).toBe(1);
+    });
+
+    it("throws and emits an event when a scratchpad is staged (does not create a commit)", () => {
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_156.md"), "plan content\n", "utf8");
+      const run = makeRun({ worktree_path: worktree });
+      const workItem = makeWorkItem();
+      const service = makeService({ run, workItem });
+
+      expect(() => service.autoStageAndCommit(run, workItem)).toThrow(BadRequestException);
+      expect(() => service.autoStageAndCommit(run, workItem)).toThrow(/auto_commit_blocked_by_scratchpad/);
+
+      // Called twice because of the two expect().toThrow calls above;
+      // assert the payload on one of them.
+      expect(service.appendEvent).toHaveBeenCalledWith(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "auto_commit",
+        paths: ["SCRATCHPAD_studio_156.md"],
+      });
+
+      // Critically: NO new commit was created
+      const log = execFileSync("git", ["log", "--oneline"], { cwd: worktree, encoding: "utf8" });
+      expect(log.split("\n").filter((l) => l.trim()).length).toBe(1);
+    });
+  });
+
+  describe("createPullRequest guards", () => {
+    it("rejects with phase=pull_request when the index contains a scratchpad (auto_commit: false)", async () => {
+      // Seed: branch off main, staged scratchpad, NO commit yet
+      execFileSync("git", ["checkout", "-q", "-b", "156-scratchpad-commit-guards"], { cwd: worktree });
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_156.md"), "plan\n", "utf8");
+      execFileSync("git", ["add", "SCRATCHPAD_studio_156.md"], { cwd: worktree });
+
+      const run = makeRun({ worktree_path: worktree });
+      const workItem = makeWorkItem();
+      const service = makeService({ run, workItem });
+
+      await expect(
+        service.createPullRequest({
+          run_id: run.run_id,
+          auto_commit: false,
+          base_ref: "main",
+        }),
+      ).rejects.toThrow(/pull_request_blocked_by_scratchpad/);
+
+      expect(service.appendEvent).toHaveBeenCalledWith(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "pull_request",
+        paths: ["SCRATCHPAD_studio_156.md"],
+      });
+      // No push, no gh call
+      expect(service.runGhIn).not.toHaveBeenCalled();
+      // No remote created
+      const remotes = execFileSync("git", ["remote"], { cwd: worktree, encoding: "utf8" }).trim();
+      expect(remotes).toBe("");
+    });
+
+    it("rejects with phase=pull_request_history when the branch has a committed scratchpad", async () => {
+      // Seed: branch off main, commit a scratchpad, worktree clean after commit
+      execFileSync("git", ["checkout", "-q", "-b", "156-scratchpad-commit-guards"], { cwd: worktree });
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_156.md"), "leaked\n", "utf8");
+      execFileSync("git", ["add", "SCRATCHPAD_studio_156.md"], { cwd: worktree });
+      execFileSync("git", ["commit", "-q", "-m", "oops"], { cwd: worktree });
+
+      // Also add an innocuous committed file so the branch has "real" work
+      writeFileSync(join(worktree, "src.ts"), "export {};\n", "utf8");
+      execFileSync("git", ["add", "src.ts"], { cwd: worktree });
+      execFileSync("git", ["commit", "-q", "-m", "feat"], { cwd: worktree });
+
+      const run = makeRun({ worktree_path: worktree });
+      const workItem = makeWorkItem();
+      const service = makeService({ run, workItem });
+
+      await expect(
+        service.createPullRequest({
+          run_id: run.run_id,
+          auto_commit: false,
+          base_ref: "main",
+        }),
+      ).rejects.toThrow(/pull_request_blocked_by_committed_scratchpad/);
+
+      expect(service.appendEvent).toHaveBeenCalledWith(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "pull_request_history",
+        paths: ["SCRATCHPAD_studio_156.md"],
+      });
+      expect(service.runGhIn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("no leftover gitignore mutation", () => {
+    it("executeRun no longer writes SCRATCHPAD_*.md to the worktree .gitignore", () => {
+      // Just a sanity check that the method is gone — the absence is
+      // enforced by the type system and the tsc build, but this test
+      // documents the ADR 014 step 6 contract directly.
+      const service = Object.create(ExecutionService.prototype) as Record<string, unknown>;
+      expect(service.ensureScratchpadIgnored).toBeUndefined();
+      expect(existsSync(join(worktree, ".gitignore"))).toBe(false);
+    });
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -348,6 +348,36 @@ export class ExecutionService {
       this.autoStageAndCommit(run, workItem, input.commit_message);
     }
 
+    // ADR 014 step 6: hard guards at PR creation. These run even when
+    // auto_commit: false (the auto-commit guard is inside an optional
+    // branch) and they cover both the current staged state and the
+    // branch's full committed history relative to the base ref.
+    const prStagedViolations = this.findStagedScratchpadViolations(run.worktree_path);
+    if (prStagedViolations.length > 0) {
+      this.appendEvent(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "pull_request",
+        paths: prStagedViolations,
+      });
+      throw new BadRequestException(
+        `pull_request_blocked_by_scratchpad: the following scratchpad files are staged and must not be committed before opening a pull request: ${prStagedViolations.join(", ")}. ` +
+          `Unstage them (git reset HEAD -- <path>) before retrying.`,
+      );
+    }
+
+    const committedViolations = this.findCommittedScratchpadViolations(run.worktree_path, baseRef);
+    if (committedViolations.length > 0) {
+      this.appendEvent(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "pull_request_history",
+        paths: committedViolations,
+      });
+      throw new BadRequestException(
+        `pull_request_blocked_by_committed_scratchpad: the following scratchpad files were committed to branch ${run.branch}: ${committedViolations.join(", ")}. ` +
+          `Inspect the history with \`git log ${baseRef}...HEAD -- '${committedViolations[0]}'\` and remove the files from the branch (e.g. \`git rm\` + rewrite) before opening a pull request.`,
+      );
+    }
+
     const title = input.title?.trim() || this.buildPullRequestTitle(workItem);
     const body = input.body?.trim() || this.buildPullRequestBody(run, workItem, baseRef);
     const aheadCount = this.countCommitsAhead(run.worktree_path, baseRef, run.branch);
@@ -674,9 +704,6 @@ export class ExecutionService {
     );
     this.appendEvent(run, { type: "scratchpad_written", path: scratchpadPath });
     this.emitChecklistIfChanged(run);
-
-    // Ensure SCRATCHPAD_*.md is gitignored so the agent can't accidentally commit it
-    this.ensureScratchpadIgnored(run.worktree_path);
 
     // --- Create agent session ---
     const { session, modelFallbackMessage } = await createAgentSession({
@@ -1495,25 +1522,6 @@ export class ExecutionService {
     ].join("\n");
   }
 
-  /** Ensure `SCRATCHPAD_*.md` is in the worktree's .gitignore so canonical scratchpads can't be committed. */
-  private ensureScratchpadIgnored(worktreePath: string): void {
-    const gitignorePath = join(worktreePath, ".gitignore");
-    const entry = "SCRATCHPAD_*.md";
-    try {
-      if (existsSync(gitignorePath)) {
-        const content = readFileSync(gitignorePath, "utf8");
-        if (content.includes(entry)) return;
-        writeFileSync(gitignorePath, content.trimEnd() + "\n" + entry + "\n", "utf8");
-      } else {
-        writeFileSync(gitignorePath, entry + "\n", "utf8");
-      }
-      // Stage the .gitignore change immediately so it's not left untracked
-      this.runGitIn(worktreePath, ["add", ".gitignore"]);
-    } catch {
-      // Non-fatal — the prompt still tells the agent not to commit it
-    }
-  }
-
   /**
    * Sync the agent's worktree scratchpad back to the canonical plan file.
    *
@@ -1917,6 +1925,21 @@ export class ExecutionService {
     this.logger.log(`Auto-staging and committing changes in ${run.worktree_path}`);
     this.runGitIn(run.worktree_path, ["add", "-A"]);
 
+    // ADR 014 step 6: hard guard against committing `SCRATCHPAD_*.md`.
+    // Replaces the silent `.gitignore` trick — disobedience is now visible.
+    const stagedViolations = this.findStagedScratchpadViolations(run.worktree_path);
+    if (stagedViolations.length > 0) {
+      this.appendEvent(run, {
+        type: "scratchpad_commit_blocked",
+        phase: "auto_commit",
+        paths: stagedViolations,
+      });
+      throw new BadRequestException(
+        `auto_commit_blocked_by_scratchpad: the following scratchpad files are staged and must not be committed: ${stagedViolations.join(", ")}. ` +
+          `Unstage them (git reset HEAD -- <path>) and retry. The canonical scratchpad lives at plans/<slug>/ and should not enter the worktree's git history.`,
+      );
+    }
+
     const message = commitMessage?.trim() || this.buildCommitMessage(workItem);
     this.runGitIn(run.worktree_path, ["commit", "-m", message]);
 
@@ -1925,6 +1948,42 @@ export class ExecutionService {
     if (changedFiles.length > 0) {
       this.updateRun(run.run_id, { changed_files: changedFiles });
     }
+  }
+
+  /**
+   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files in the git index.
+   *
+   * Basename match at any path depth. Returns an empty array when the
+   * index is clean. Callers use the list both for the rejection error
+   * message and for the `scratchpad_commit_blocked` event payload.
+   */
+  private findStagedScratchpadViolations(worktreePath: string): string[] {
+    const output = this.runGitIn(worktreePath, ["diff", "--cached", "--name-only"], { allowFailure: true });
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
+  }
+
+  /**
+   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files introduced by this
+   * branch relative to its base ref.
+   *
+   * Uses three-dot `$base...HEAD` (merge-base relative) so files that
+   * changed on the base branch are not spuriously flagged. This matches
+   * what GitHub shows in a pull-request diff.
+   */
+  private findCommittedScratchpadViolations(worktreePath: string, baseRef: string): string[] {
+    const output = this.runGitIn(worktreePath, ["diff", "--name-only", `${baseRef}...HEAD`], { allowFailure: true });
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
+  }
+
+  /** Basename match for `SCRATCHPAD_*.md` at any path depth. */
+  private isScratchpadPath(path: string): boolean {
+    return /(?:^|\/)SCRATCHPAD_[^/]*\.md$/.test(path);
   }
 
   private buildCommitMessage(workItem: WorkItemRecord): string {


### PR DESCRIPTION
## Summary

Step 6 of the ADR 014 plan/run lifecycle rollout. Replaces the silent `.gitignore` trick that hid scratchpad-staging disobedience with **hard validation guards** at the two points where scratchpads could leak into git history.

Closes #156

## Why

The old `ensureScratchpadIgnored` method appended `SCRATCHPAD_*.md` to the worktree's `.gitignore` so the coding agent's attempts to stage the scratchpad became silent no-ops. That defeated the signal: agent disobedience became invisible. With canonical scratchpads living outside the worktree (step 2) and a single naming convention in place, we can drop the gitignore approach and rely on visible guards that throw on violation and emit run events.

## What changed

### `src/modules/execution/execution.service.ts` (+81 / −22)

- **Removed** `ensureScratchpadIgnored` method and its call in `executeRun`
- **Added** three private helpers:
  - `isScratchpadPath(path)` — basename regex `/(?:^|\/)SCRATCHPAD_[^/]*\.md$/`
  - `findStagedScratchpadViolations(worktreePath)` — `git diff --cached --name-only` + filter
  - `findCommittedScratchpadViolations(worktreePath, baseRef)` — `git diff --name-only $base...HEAD` (three-dot, matches GitHub PR diff semantics)
- **Guarded `autoStageAndCommit`** — post-staging check runs after `git add -A`. On violation: emits `scratchpad_commit_blocked { phase: "auto_commit", paths }`, throws `BadRequestException` with clear actionable message. Index is **not** reset — operator triages.
- **Guarded `createPullRequest`** twice:
  1. Staged-files check (covers the `auto_commit: false` path) → `phase: "pull_request"`
  2. Committed-history check (catches scratchpads from earlier turns or bypass paths) → `phase: "pull_request_history"`
  Both throw before any `git push` or `gh pr create` — zero remote side effects on rejection.

The agent prompt rule forbidding scratchpad staging is unchanged.

### `src/modules/execution/__tests__/scratchpad-commit-guards.test.ts` (new, +338)

16 new tests across 5 describe blocks, running against real `git init` worktrees in `mkdtempSync` tmp directories. Mocking git would miss the point — the guards are validating actual git index and history semantics.

- `isScratchpadPath` — regex matches at any depth, rejects lowercase / wrong extension / missing slug
- `findStagedScratchpadViolations` — clean index, non-scratchpad staged, scratchpad at root, scratchpad at nested path
- `findCommittedScratchpadViolations` — clean branch, only non-scratchpad committed, committed scratchpad detected
- `autoStageAndCommit` — happy-path commit, clean-worktree no-op, staged scratchpad rejected (throws, emits event, **no commit created**)
- `createPullRequest` guards — both phases trigger correctly; `runGhIn` asserted never-called on rejection, proving zero side effects
- Sanity: `ensureScratchpadIgnored` is gone from the prototype and no `.gitignore` is written

Harness follows the existing pattern (`Object.create(ExecutionService.prototype)` + `vi.fn()` stubs for `appendEvent`, `updateRun`, `runGhIn`).

## Key decisions

- **Post-staging check, not pre-staging.** Catches every staging path (`git add -A`, individual `git add`, any helper) instead of coupling the guard to how files got staged.
- **Both staged + committed history at PR creation.** Defense in depth. Auto-commit is inside an optional branch; a caller can pass `auto_commit: false` (staged check), and earlier turns could have committed a scratchpad before the guard landed (history check).
- **Hard fail, don't auto-recover.** Throwing + emitting `scratchpad_commit_blocked` preserves the disobedience signal. Auto-unstaging would just bring back the gitignore-era problem in a new form.
- **Three-dot `\$base...HEAD`.** Merge-base relative, matches what GitHub shows in PR diffs, and avoids spurious flags when the branch has fallen behind the base on unrelated files.

## Out of scope

- ADR 014 step 7 (run disposition / auto-classification of run failures)
- UI rendering of `scratchpad_commit_blocked` run events (emitted, not visualized)
- Cleanup of any legacy `.gitignore` entries in active worktrees — inert noise, removed when the worktree is cleaned up via the normal flow

## Test plan

### Automated (all green)

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 264 / 264 across 20 files (16 new in \`scratchpad-commit-guards.test.ts\`)
- [x] `npx vite build --config web/vite.config.ts` — 1.38 s, only pre-existing a11y / CSS warnings

### Manual verification (suggested)

- [ ] Launch a new execution run and confirm no `.gitignore` file appears in the worktree
- [ ] Trigger an auto-commit with a \`SCRATCHPAD_<slug>.md\` staged: confirm `BadRequestException` surfaces, the run event log shows `scratchpad_commit_blocked { phase: "auto_commit" }`, and no commit was created
- [ ] Attempt `POST /api/execution/pull-request` with `auto_commit: false` and a staged scratchpad: confirm rejection with `phase: "pull_request"` and no `git push` / `gh` side effects
- [ ] Attempt PR creation on a branch that already has a committed scratchpad (seed manually): confirm rejection with `phase: "pull_request_history"` and no remote side effects