### PR TITLE
feat: minimal UI exposure for plan/run lifecycle (ADR 014 step 8)

### DIFF
--- a/src/__tests__/graph-node-actions.test.ts
+++ b/src/__tests__/graph-node-actions.test.ts
@@ -6,6 +6,8 @@ function makeItem(overrides: Record<string, unknown> = {}) {
   return {
     id: "studio-139",
     name: "Add graph node context menu",
+    kind: "issue",
+    state: "ready",
     repo: "fusupo/escapement-studio",
     issue_number: 139,
     issue_url: "https://github.com/fusupo/escapement-studio/issues/139",
@@ -84,11 +86,133 @@ describe("buildGraphNodeContextMenu", () => {
     });
 
     expect(menu.status).toEqual({ label: "Checking…", tone: "loading" });
-    expect(menu.sections[0].actions[1]).toMatchObject({
+    const launchAction = menu.sections[0].actions.find((a: { id: string }) => a.id === "launch-execution");
+    expect(launchAction).toMatchObject({
       id: "launch-execution",
       label: "Launch execution",
       disabled: true,
       description: "Checking launch eligibility…",
+    });
+  });
+
+  describe("ADR 014 step 8 — plan actions", () => {
+    function actionIds(menu: ReturnType<typeof buildGraphNodeContextMenu>): string[] {
+      return menu?.sections[0].actions.map((a: { id: string }) => a.id) ?? [];
+    }
+
+    it("shows Prepare plan when work item is planned (no plan yet)", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "planned" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: null,
+      });
+      expect(actionIds(menu)).toContain("prepare-plan");
+      expect(actionIds(menu)).not.toContain("approve-plan");
+      expect(actionIds(menu)).not.toContain("review-plan");
+    });
+
+    it("shows Prepare + Approve + Review when plan is drafting", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "drafting" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: { state: "drafting" },
+      });
+      const ids = actionIds(menu);
+      expect(ids).toContain("prepare-plan");
+      expect(ids).toContain("approve-plan");
+      expect(ids).toContain("review-plan");
+    });
+
+    it("shows only Review plan when plan is ready (Prepare is hidden)", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "ready" }),
+        launchEligibility: makeEligibility(),
+        planState: { state: "ready" },
+      });
+      const ids = actionIds(menu);
+      expect(ids).not.toContain("prepare-plan");
+      expect(ids).not.toContain("approve-plan");
+      expect(ids).toContain("review-plan");
+    });
+
+    it("hides Prepare plan for non-issue kinds", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "planned", kind: "capability", issue_url: null, issue_number: null }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: null,
+      });
+      expect(actionIds(menu)).not.toContain("prepare-plan");
+    });
+
+    it("disables launch when work item state is not ready, even if can_launch is true", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "planned" }),
+        launchEligibility: makeEligibility(), // can_launch: true
+        planState: null,
+      });
+      expect(menu.status).toEqual({ label: "Blocked", tone: "blocked" });
+      const launchAction = menu?.sections[0].actions.find(
+        (a: { id: string }) => a.id === "launch-execution",
+      );
+      expect(launchAction).toMatchObject({
+        id: "launch-execution",
+        disabled: true,
+      });
+      expect(launchAction?.description).toMatch(/Approve the plan first/);
+    });
+
+    it("enables launch only when state is ready AND can_launch is true", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "ready" }),
+        launchEligibility: makeEligibility(),
+        planState: { state: "ready" },
+      });
+      expect(menu.status).toEqual({ label: "Dispatchable", tone: "ready" });
+      const launchAction = menu?.sections[0].actions.find(
+        (a: { id: string }) => a.id === "launch-execution",
+      );
+      expect(launchAction).toMatchObject({
+        id: "launch-execution",
+        disabled: false,
+      });
+    });
+
+    it("shows Preparing… label when preparingPlan is true", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "planned" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: null,
+        preparingPlan: true,
+      });
+      const prepareAction = menu?.sections[0].actions.find(
+        (a: { id: string }) => a.id === "prepare-plan",
+      );
+      expect(prepareAction).toMatchObject({ label: "Preparing…", disabled: true });
+    });
+
+    it("shows Approving… label when approvingPlan is true", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "drafting" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: { state: "drafting" },
+        approvingPlan: true,
+      });
+      const approveAction = menu?.sections[0].actions.find(
+        (a: { id: string }) => a.id === "approve-plan",
+      );
+      expect(approveAction).toMatchObject({ label: "Approving…", disabled: true });
+    });
+
+    it("does not show Prepare / Approve for terminal states", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "done" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+        planState: null,
+      });
+      const ids = actionIds(menu);
+      expect(ids).not.toContain("prepare-plan");
+      expect(ids).not.toContain("approve-plan");
+      expect(ids).not.toContain("review-plan");
     });
   });
 });

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -8,6 +8,7 @@
   import FiltersToolbar from "./components/FiltersToolbar.svelte";
   import Sidebar from "./components/Sidebar.svelte";
   import {
+    approvePlan,
     closeGitHubIssue,
     closeMergedPullRequest,
     createEdge,
@@ -17,8 +18,10 @@
     getGitHubIssueDetails,
     getGraph,
     getHealth,
+    getPlan,
     launchExecutionRun,
     listWorkItems,
+    preparePlan,
     syncMergedPullRequest,
     updateWorkItem,
   } from "./lib/api.js";
@@ -42,6 +45,14 @@
   let launchEligibilityLoadingIds = {};
   let launchEligibilityRequestTokenById = {};
   let graphContextMenu = { open: false, x: 0, y: 0, item: null };
+
+  // ADR 014 step 8 — plan state + plan review modal
+  let preparingPlan = false;
+  let approvingPlan = false;
+  let planStateById = {};
+  let planStateLoadingIds = {};
+  let planStateRequestTokenById = {};
+  let planReview = null; // { workItemId, scratchpadContent } | null
 
   // Panel collapse state
   let chatCollapsed = false;
@@ -98,11 +109,21 @@
   $: selectedLaunchEligibilityLoading = selectedItem ? !!launchEligibilityLoadingIds[selectedItem.id] : false;
   $: contextMenuLaunchEligibility = graphContextMenu.item ? launchEligibilityById[graphContextMenu.item.id] ?? null : null;
   $: contextMenuLaunchEligibilityLoading = graphContextMenu.item ? !!launchEligibilityLoadingIds[graphContextMenu.item.id] : false;
+  $: contextMenuPlanState = graphContextMenu.item
+    ? planStateById[graphContextMenu.item.id]?.metadata ?? null
+    : null;
+  $: contextMenuPlanStateLoading = graphContextMenu.item
+    ? !!planStateLoadingIds[graphContextMenu.item.id]
+    : false;
   $: graphContextMenuModel = buildGraphNodeContextMenu({
     item: graphContextMenu.item,
     launchEligibility: contextMenuLaunchEligibility,
     launchEligibilityLoading: contextMenuLaunchEligibilityLoading,
     launchingExecution,
+    planState: contextMenuPlanState,
+    planStateLoading: contextMenuPlanStateLoading,
+    preparingPlan,
+    approvingPlan,
   });
   $: filterOptions = {
     repos: [...new Set(catalog.map((item) => item.repo).filter(Boolean))].sort(),
@@ -114,6 +135,14 @@
   $: activeFilterCount = Object.values(filters).filter(Boolean).length;
   $: if (selectedItem?.id) {
     void ensureLaunchEligibility(selectedItem.id);
+  }
+  // Auto-fetch plan state for the selected item when it's in a state where
+  // a plan should exist. Terminal states (done, cancelled, deferred) and
+  // non-issue kinds are skipped to avoid pointless 404 round-trips.
+  $: if (selectedItem?.id
+    && selectedItem?.kind === "issue"
+    && ["drafting", "ready", "in_progress", "open_pr", "merged_pr"].includes(selectedItem.state)) {
+    void ensurePlanState(selectedItem.id);
   }
 
   function closeGraphContextMenu() {
@@ -132,6 +161,41 @@
       launch_unavailable_reason: message,
       dispatch_node: null,
     };
+  }
+
+  // ADR 014 step 8 — plan state fetcher. Returns null when no plan exists
+  // (GET /api/plans/:id returns 404 for planned items with no plan dir yet).
+  // Uses a per-work-item request token so stale responses can't clobber
+  // fresh selections, mirroring ensureLaunchEligibility above.
+  async function ensurePlanState(workItemId, { force = false } = {}) {
+    if (!workItemId) return null;
+    if (!force && planStateById[workItemId] !== undefined) {
+      return planStateById[workItemId];
+    }
+
+    const token = (planStateRequestTokenById[workItemId] || 0) + 1;
+    planStateRequestTokenById = { ...planStateRequestTokenById, [workItemId]: token };
+    planStateLoadingIds = { ...planStateLoadingIds, [workItemId]: true };
+
+    try {
+      const plan = await getPlan(workItemId);
+      if (planStateRequestTokenById[workItemId] === token) {
+        planStateById = { ...planStateById, [workItemId]: plan };
+      }
+      return plan;
+    } catch (lookupError) {
+      const message = lookupError?.message ?? "";
+      // 404 = no plan dir yet (expected for planned items). Cache null so
+      // we don't re-fetch on every reactive tick.
+      if (/No plan found/i.test(message) && planStateRequestTokenById[workItemId] === token) {
+        planStateById = { ...planStateById, [workItemId]: null };
+      }
+      return null;
+    } finally {
+      if (planStateRequestTokenById[workItemId] === token) {
+        planStateLoadingIds = { ...planStateLoadingIds, [workItemId]: false };
+      }
+    }
   }
 
   async function ensureLaunchEligibility(workItemId, { force = false } = {}) {
@@ -178,6 +242,9 @@
       launchEligibilityById = {};
       launchEligibilityLoadingIds = {};
       launchEligibilityRequestTokenById = {};
+      planStateById = {};
+      planStateLoadingIds = {};
+      planStateRequestTokenById = {};
       if (selectedId && !graph.items.some((item) => item.id === selectedId)) {
         selectedId = null;
         closeGraphContextMenu();
@@ -349,12 +416,86 @@
       item: detail.item,
     };
     await ensureLaunchEligibility(detail.item.id);
+    // Also prime plan state for issue kinds so the context menu can gate
+    // Prepare / Approve / Review correctly. Non-issue kinds skip the fetch.
+    if (detail.item.kind === "issue"
+      && ["drafting", "ready", "in_progress", "open_pr", "merged_pr", "planned"].includes(detail.item.state)) {
+      await ensurePlanState(detail.item.id);
+    }
   }
 
   function handleGlobalKeydown(event) {
     if (event.key === "Escape") {
       closeGraphContextMenu();
+      if (planReview) {
+        closePlanReview();
+      }
     }
+  }
+
+  // ADR 014 step 8 — plan action handlers.
+  async function handlePreparePlan(item = selectedItem) {
+    const workItemId = item?.id;
+    if (!workItemId) return;
+
+    preparingPlan = true;
+    error = "";
+    try {
+      await preparePlan(workItemId);
+      // Refresh plan cache + graph so the work item state reflects the
+      // `planned → drafting` transition that prepare triggers.
+      await ensurePlanState(workItemId, { force: true });
+      await loadGraph();
+    } catch (prepareError) {
+      error = prepareError.message;
+    } finally {
+      preparingPlan = false;
+    }
+  }
+
+  async function handleApprovePlan(item = selectedItem) {
+    const workItemId = item?.id;
+    if (!workItemId) return;
+
+    approvingPlan = true;
+    error = "";
+    try {
+      await approvePlan(workItemId, {});
+      // Approve transitions plan drafting → ready AND work item to ready.
+      await ensurePlanState(workItemId, { force: true });
+      await loadGraph();
+    } catch (approveError) {
+      error = approveError.message;
+    } finally {
+      approvingPlan = false;
+    }
+  }
+
+  async function handleReviewPlan(item = selectedItem, cachedPlan = null) {
+    const workItemId = item?.id;
+    if (!workItemId) return;
+
+    error = "";
+    try {
+      // Prefer the cached plan passed in from the Sidebar/context menu; fall
+      // back to a fresh fetch if we don't have one yet.
+      const plan = cachedPlan ?? planStateById[workItemId] ?? await ensurePlanState(workItemId, { force: true });
+      if (!plan) {
+        error = `No plan to review for ${workItemId}. Try Prepare plan first.`;
+        return;
+      }
+      planReview = {
+        workItemId,
+        scratchpadContent: plan.scratchpad_content ?? "",
+        planState: plan.metadata?.state ?? null,
+      };
+    } catch (reviewError) {
+      error = reviewError.message;
+    }
+  }
+
+  function closePlanReview() {
+    planReview = null;
   }
 
   async function handleLaunchExecution(item = selectedItem) {
@@ -364,6 +505,14 @@
     launchingExecution = true;
     error = "";
     try {
+      // ADR 014 step 8 — stricter UI gate than the backend: require work
+      // item state to be `ready` so users can't skip plan approval via the
+      // UI, even though the backend still accepts `planned` as a
+      // transitional fallback.
+      if (item?.state !== "ready") {
+        error = `Approve the plan first — work item state is ${item?.state ?? "unknown"}, expected ready.`;
+        return;
+      }
       const eligibility = await ensureLaunchEligibility(workItemId, { force: true });
       if (!eligibility?.can_launch) {
         error = eligibility?.launch_unavailable_reason || "Launch execution is not available for this node.";
@@ -554,6 +703,11 @@
                   launchingExecution={launchingExecution}
                   onLaunchExecution={handleLaunchExecution}
                   onGitHubTruthRefresh={handleGitHubTruthRefresh}
+                  onPreparePlan={handlePreparePlan}
+                  onApprovePlan={handleApprovePlan}
+                  onReviewPlan={handleReviewPlan}
+                  {preparingPlan}
+                  {approvingPlan}
                   {graph}
                   {saving}
                   {edgeSaving}
@@ -608,12 +762,50 @@
         x={graphContextMenu.x}
         y={graphContextMenu.y}
         on:action={(event) => {
+          const item = graphContextMenu.item;
           if (event.detail.id === "launch-execution") {
-            handleLaunchExecution(graphContextMenu.item);
+            handleLaunchExecution(item);
+          } else if (event.detail.id === "prepare-plan") {
+            handlePreparePlan(item);
+            closeGraphContextMenu();
+          } else if (event.detail.id === "approve-plan") {
+            handleApprovePlan(item);
+            closeGraphContextMenu();
+          } else if (event.detail.id === "review-plan") {
+            handleReviewPlan(item, planStateById[item.id] ?? null);
+            closeGraphContextMenu();
           }
         }}
         on:requestclose={closeGraphContextMenu}
       />
+    {/if}
+
+    <!-- ADR 014 step 8 — Plan review modal -->
+    {#if planReview}
+      <div
+        class="plan-review-overlay"
+        role="presentation"
+        on:click={closePlanReview}
+      >
+        <div
+          class="plan-review-card"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="plan-review-title"
+          on:click|stopPropagation
+        >
+          <header class="plan-review-header">
+            <h3 id="plan-review-title">
+              Plan — {planReview.workItemId}
+              {#if planReview.planState}
+                <span class="status-pill {planReview.planState === 'ready' ? 'healthy' : 'warn'}">{planReview.planState}</span>
+              {/if}
+            </h3>
+            <button class="small" on:click={closePlanReview} aria-label="Close plan review">×</button>
+          </header>
+          <pre class="plan-review-body">{planReview.scratchpadContent}</pre>
+        </div>
+      </div>
     {/if}
 
     <!-- Status bar -->

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1372,3 +1372,79 @@ a:hover {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── ADR 014 step 8 — plan status + review modal ── */
+.plan-status-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.plan-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.plan-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.plan-review-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.plan-review-card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  width: min(900px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.plan-review-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.plan-review-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.plan-review-body {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  background: var(--bg-base);
+  color: var(--text-primary);
+}

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -1,5 +1,17 @@
 <script>
-  import { getPullRequestDetails } from "../lib/api.js";
+  import { getPlan, getPullRequestDetails } from "../lib/api.js";
+
+  // ADR 014 step 8 — work item states where a plan should already exist on
+  // disk. For planned items the plan may not exist yet (GET 404). Terminal
+  // states (done, cancelled, deferred) are skipped to avoid pointless fetches.
+  const PLAN_FETCHABLE_STATES = new Set([
+    "drafting",
+    "ready",
+    "in_progress",
+    "open_pr",
+    "merged_pr",
+  ]);
+  const PLAN_SHOW_PREPARE_STATES = new Set(["planned", "drafting"]);
 
   const defaultWorkItem = {
     id: "",
@@ -33,12 +45,24 @@
   export let onCloseIssue = () => {};
   export let onLaunchExecution = () => {};
   export let onGitHubTruthRefresh = () => {};
+  export let onPreparePlan = () => {};
+  export let onApprovePlan = () => {};
+  export let onReviewPlan = () => {};
   export let closingIssue = false;
+  export let preparingPlan = false;
+  export let approvingPlan = false;
 
   let linkedPrDetails = null;
   let loadingPr = false;
   let linkedPrLookupToken = 0;
   let lastLinkedPrLookupKey = null;
+
+  // ADR 014 step 8 — plan state tracking for the Execution card.
+  let planStatus = null; // { work_item_id, metadata, scratchpad_content } | null
+  let planStatusLoading = false;
+  let planStatusError = null;
+  let planFetchToken = 0;
+  let lastPlanFetchKey = null;
 
   let editForm = { ...defaultWorkItem };
   let createForm = { ...defaultWorkItem };
@@ -104,6 +128,91 @@
   $: canCloseIssue = issueDetails
     && issueDetails.state?.toLowerCase() === "open"
     && linkedPrDetails?.merged_at != null;
+
+  // ADR 014 step 8 — fetch plan status when the selected item is in a state
+  // where a plan should exist. Use a token pattern (mirrors linkedPrLookupToken
+  // above) so stale responses can't clobber fresh selections.
+  $: planFetchKey = selectedItem?.id && selectedItem?.kind === "issue"
+    && PLAN_FETCHABLE_STATES.has(selectedItem.state)
+    ? `${selectedItem.id}:${selectedItem.state}`
+    : null;
+  $: if (planFetchKey !== lastPlanFetchKey) {
+    lastPlanFetchKey = planFetchKey;
+    if (planFetchKey) {
+      void loadPlanStatus(selectedItem.id);
+    } else {
+      planStatus = null;
+      planStatusError = null;
+      planStatusLoading = false;
+    }
+  }
+
+  async function loadPlanStatus(workItemId) {
+    const token = ++planFetchToken;
+    planStatusLoading = true;
+    planStatusError = null;
+    try {
+      const plan = await getPlan(workItemId);
+      if (token === planFetchToken) {
+        planStatus = plan;
+      }
+    } catch (err) {
+      if (token === planFetchToken) {
+        // 404 means no plan dir exists yet (expected for planned items).
+        // Anything else is surfaced so the user can see it.
+        planStatus = null;
+        const message = err?.message ?? "";
+        if (!/No plan found/i.test(message)) {
+          planStatusError = message || "Failed to load plan status";
+        }
+      }
+    } finally {
+      if (token === planFetchToken) {
+        planStatusLoading = false;
+      }
+    }
+  }
+
+  // Re-fetch plan status on demand (e.g., after Prepare or Approve).
+  export async function refreshPlanStatus() {
+    if (selectedItem?.id) {
+      await loadPlanStatus(selectedItem.id);
+    }
+  }
+
+  function planStatusTone(state) {
+    if (state === "ready") return "healthy";
+    if (state === "drafting") return "warn";
+    return "info";
+  }
+
+  async function handlePreparePlanClick() {
+    if (!selectedItem) return;
+    await onPreparePlan(selectedItem);
+    await loadPlanStatus(selectedItem.id);
+  }
+
+  async function handleApprovePlanClick() {
+    if (!selectedItem) return;
+    await onApprovePlan(selectedItem);
+    await loadPlanStatus(selectedItem.id);
+  }
+
+  function handleReviewPlanClick() {
+    if (!selectedItem) return;
+    onReviewPlan(selectedItem, planStatus);
+  }
+
+  $: planSubState = planStatus?.metadata?.state ?? null;
+  $: showPreparePlan = selectedItem?.kind === "issue"
+    && PLAN_SHOW_PREPARE_STATES.has(selectedItem?.state);
+  $: showApprovePlan = planSubState === "drafting";
+  $: showReviewPlan = planSubState === "drafting" || planSubState === "ready";
+  $: launchStateOk = selectedItem?.state === "ready";
+  $: launchDisabled = !launchEligibility?.can_launch
+    || launchEligibilityLoading
+    || launchingExecution
+    || !launchStateOk;
 
   $: if (!selectedItem && edgeForm.from_id && !graph.items.some((item) => item.id === edgeForm.from_id)) {
     edgeForm = { ...defaultEdge };
@@ -210,22 +319,72 @@
           <h3>Execution</h3>
         </div>
 
+        <!-- ADR 014 step 8 — plan status + plan actions -->
+        {#if selectedItem?.kind === "issue"}
+          <div class="plan-status-row">
+            <span class="plan-label">Plan</span>
+            {#if planStatusLoading}
+              <span class="status-pill">loading…</span>
+            {:else if planSubState}
+              <span class="status-pill {planStatusTone(planSubState)}">{planSubState}</span>
+            {:else if selectedItem?.state === "planned"}
+              <span class="status-pill">not prepared</span>
+            {:else}
+              <span class="status-pill">unknown</span>
+            {/if}
+          </div>
+          {#if planStatusError}
+            <p class="muted">Plan status error: {planStatusError}</p>
+          {/if}
+          <div class="plan-actions">
+            {#if showPreparePlan}
+              <button
+                class="small"
+                on:click={handlePreparePlanClick}
+                disabled={preparingPlan || planStatusLoading}
+              >
+                {preparingPlan ? "Preparing…" : "Prepare plan"}
+              </button>
+            {/if}
+            {#if showApprovePlan}
+              <button
+                class="small"
+                on:click={handleApprovePlanClick}
+                disabled={approvingPlan || planStatusLoading}
+              >
+                {approvingPlan ? "Approving…" : "Approve plan"}
+              </button>
+            {/if}
+            {#if showReviewPlan}
+              <button
+                class="small"
+                on:click={handleReviewPlanClick}
+                disabled={planStatusLoading}
+              >
+                Review plan
+              </button>
+            {/if}
+          </div>
+        {/if}
+
         {#if launchEligibilityLoading}
           <p class="muted">Checking frontier eligibility…</p>
         {:else if launchEligibility}
-          <span class="status-pill {launchEligibility.can_launch ? 'healthy' : 'warn'}">{launchEligibility.can_launch ? 'dispatchable' : 'blocked'}</span>
+          <span class="status-pill {launchEligibility.can_launch && launchStateOk ? 'healthy' : 'warn'}">{launchEligibility.can_launch && launchStateOk ? 'dispatchable' : 'blocked'}</span>
           {#if launchEligibility.dispatch_node}
             <p class="muted">
               Branch <code>{launchEligibility.dispatch_node.branch}</code>
               · Base <code>{launchEligibility.dispatch_node.default_base_ref}</code>
             </p>
           {/if}
-          {#if launchEligibility.launch_unavailable_reason}
+          {#if !launchEligibility.can_launch && launchEligibility.launch_unavailable_reason}
             <p class="muted">{launchEligibility.launch_unavailable_reason}</p>
-          {:else}
+          {:else if launchEligibility.can_launch && !launchStateOk}
+            <p class="muted">Approve the plan first — work item state is {selectedItem?.state ?? "unknown"}, expected <code>ready</code>.</p>
+          {:else if launchEligibility.can_launch && launchStateOk}
             <p class="muted">This node is currently on the frontier and can be launched into execution.</p>
           {/if}
-          <button on:click={() => onLaunchExecution(selectedItem)} disabled={!launchEligibility.can_launch || launchingExecution}>
+          <button on:click={() => onLaunchExecution(selectedItem)} disabled={launchDisabled}>
             {launchingExecution ? "Launching..." : "Launch execution"}
           </button>
         {:else}
@@ -255,8 +414,11 @@
           State
           <select bind:value={editForm.state}>
             <option value="planned">planned</option>
+            <option value="drafting">drafting</option>
+            <option value="ready">ready</option>
             <option value="in_progress">in_progress</option>
             <option value="open_pr">open_pr</option>
+            <option value="merged_pr">merged_pr</option>
             <option value="done">done</option>
             <option value="deferred">deferred</option>
             <option value="cancelled">cancelled</option>
@@ -309,8 +471,11 @@
         State
         <select bind:value={createForm.state}>
           <option value="planned">planned</option>
+          <option value="drafting">drafting</option>
+          <option value="ready">ready</option>
           <option value="in_progress">in_progress</option>
           <option value="open_pr">open_pr</option>
+          <option value="merged_pr">merged_pr</option>
           <option value="done">done</option>
           <option value="deferred">deferred</option>
           <option value="cancelled">cancelled</option>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -179,6 +179,39 @@ export function archiveAndCloseMergedPullRequest(workItemId) {
   });
 }
 
+// ADR 014 step 8 — plan lifecycle endpoints.
+// See src/modules/plans/plans.controller.ts. The GET endpoint returns
+// { work_item_id, metadata, scratchpad_content } and 404s when no plan
+// dir exists yet for the work item.
+
+export function getPlan(workItemId) {
+  return request(`/api/plans/${encodeURIComponent(workItemId)}`);
+}
+
+export function preparePlan(workItemId) {
+  return request(`/api/plans/${encodeURIComponent(workItemId)}/prepare`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: "{}",
+  });
+}
+
+export function approvePlan(workItemId, payload = {}) {
+  return request(`/api/plans/${encodeURIComponent(workItemId)}/approve`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
+export function reopenPlan(workItemId, payload = {}) {
+  return request(`/api/plans/${encodeURIComponent(workItemId)}/reopen`, {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function getReconciliationReports(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {

--- a/web/src/lib/graph-node-actions.js
+++ b/web/src/lib/graph-node-actions.js
@@ -1,26 +1,48 @@
 const DEFAULT_MENU_PADDING = 12;
 
+// ADR 014 step 8 — plan action gating.
+// Preparable states mirror PlansService.assertPreparable (planned | drafting).
+const PREPARABLE_STATES = new Set(["planned", "drafting"]);
+
 export function buildGraphNodeContextMenu({
   item,
   launchEligibility,
   launchEligibilityLoading = false,
   launchingExecution = false,
+  planState = null,
+  planStateLoading = false,
+  preparingPlan = false,
+  approvingPlan = false,
 } = {}) {
   if (!item) {
     return null;
   }
 
+  const workItemState = item.state ?? null;
+  const planSubState = planState?.state ?? null;
+
+  // UI gate is stricter than the backend: require work item state to be
+  // `ready` before Launch is enabled, even though the server still accepts
+  // `planned` as a transitional fallback. This nudges users toward the
+  // approved-plan flow.
+  const launchGateOk = !launchEligibilityLoading
+    && !launchingExecution
+    && launchEligibility?.can_launch === true
+    && workItemState === "ready";
+
   const launchStatus = launchEligibilityLoading
     ? { label: "Checking…", tone: "loading" }
-    : launchEligibility?.can_launch
+    : launchGateOk
       ? { label: "Dispatchable", tone: "ready" }
       : { label: "Blocked", tone: "blocked" };
 
   const launchDescription = launchEligibilityLoading
     ? "Checking launch eligibility…"
-    : launchEligibility?.can_launch
-      ? formatDispatchNodeSummary(launchEligibility.dispatch_node)
-      : launchEligibility?.launch_unavailable_reason || "Launch execution is unavailable for this node.";
+    : !launchEligibility?.can_launch
+      ? launchEligibility?.launch_unavailable_reason || "Launch execution is unavailable for this node."
+      : workItemState !== "ready"
+        ? `Approve the plan first — work item state is ${workItemState ?? "unknown"}, expected ready.`
+        : formatDispatchNodeSummary(launchEligibility.dispatch_node);
 
   const actions = [];
 
@@ -35,12 +57,50 @@ export function buildGraphNodeContextMenu({
     });
   }
 
+  // Prepare plan — visible while the work item is still planned/drafting and
+  // kind is `issue` (non-issue kinds don't get a scratchpad plan).
+  if (item.kind === "issue" && PREPARABLE_STATES.has(workItemState)) {
+    actions.push({
+      id: "prepare-plan",
+      kind: "button",
+      label: preparingPlan ? "Preparing…" : "Prepare plan",
+      description: planSubState === "drafting"
+        ? "Re-run plan preparation to refresh the canonical scratchpad."
+        : "Create a draft plan scratchpad for this work item.",
+      disabled: preparingPlan || planStateLoading,
+    });
+  }
+
+  // Approve plan — only meaningful while the plan is drafting.
+  if (planSubState === "drafting") {
+    actions.push({
+      id: "approve-plan",
+      kind: "button",
+      label: approvingPlan ? "Approving…" : "Approve plan",
+      description: "Transition the plan from drafting → ready and the work item to ready.",
+      disabled: approvingPlan || planStateLoading,
+    });
+  }
+
+  // Review plan — visible once a plan exists. Loading is informational only;
+  // the button stays enabled because clicking it opens the modal which
+  // handles its own fetch state.
+  if (planSubState === "drafting" || planSubState === "ready") {
+    actions.push({
+      id: "review-plan",
+      kind: "button",
+      label: "Review plan",
+      description: `Open the canonical scratchpad (plan is ${planSubState}).`,
+      disabled: false,
+    });
+  }
+
   actions.push({
     id: "launch-execution",
     kind: "button",
     label: launchingExecution ? "Launching…" : "Launch execution",
     description: launchDescription,
-    disabled: launchEligibilityLoading || launchingExecution || !launchEligibility?.can_launch,
+    disabled: !launchGateOk,
     emphasis: "primary",
   });
 


### PR DESCRIPTION
## Summary

Wire the smallest useful UI surface for the plan/run lifecycle introduced by ADR 014. Adds **Prepare plan**, **Approve plan**, and **Review plan** actions to both the Sidebar and the graph node context menu, shows plan sub-state alongside work item state, and tightens the Launch button to require `state === "ready"` at the UI layer.

Closes #158. Final step (8 of 8) of the ADR 014 series.

## Why

Steps 1–7 (#151–#157) shipped the plans + runs model server-side but left the UI untouched per ADR 014's deferred-UI strategy. Without this, a user has no way to prepare, approve, or review a plan from Studio — they have to hit the API directly or use the planner agent. This closes that gap with the minimum viable surface:

- A plan status pill in the Sidebar Execution card
- Prepare / Approve / Review / Launch buttons, each correctly gated
- A first-in-project modal overlay for reviewing scratchpad markdown

All four actions work in the Sidebar **and** the graph node context menu (consistent with the existing Launch pattern).

## What changed

### Backend
**None.** All endpoints shipped in steps 4 and 5 (#154, #155): `POST /api/plans/:id/{prepare,approve,reopen}` + `GET /api/plans/:id`.

### Frontend

**\`web/src/lib/api.js\`** — 4 new helpers (\`getPlan\`, \`preparePlan\`, \`approvePlan\`, \`reopenPlan\`) matching the existing close-merged / post-merge-sync style from #157.

**\`web/src/lib/graph-node-actions.js\`** — \`buildGraphNodeContextMenu\` now accepts \`planState\`, \`planStateLoading\`, \`preparingPlan\`, \`approvingPlan\` and emits Prepare / Approve / Review actions gated by:
- \`prepare-plan\` — kind=issue, state in {planned, drafting}
- \`approve-plan\` — plan metadata.state === drafting
- \`review-plan\` — plan metadata.state in {drafting, ready}

Launch gate tightened: UI now requires work item state === \`ready\` (the backend still accepts \`planned\` as a transitional fallback, but the stricter UI gate nudges users toward the approved-plan flow). Disabled tooltip copy explains the state requirement when that's the cause.

**\`web/src/components/Sidebar.svelte\`** — plan status display in the Execution card + three action buttons. Uses a \`planFetchToken\` pattern (mirroring the existing \`linkedPrLookupToken\`) to discard stale responses. 404 is treated as "no plan yet" (expected for \`planned\` items); other errors surface as \`planStatusError\`. **Also fixes** the state dropdowns (edit + create forms) to list all 9 canonical states — they were missing \`drafting\`, \`ready\`, and \`merged_pr\` since the #153 state machine expansion.

**\`web/src/App.svelte\`** — \`handlePreparePlan\` / \`handleApprovePlan\` / \`handleReviewPlan\` handlers, \`ensurePlanState\` cache with per-work-item request tokens, cache-clearing in \`loadGraph\`, auto-fetch on selection and context menu open, extended context menu action dispatch, \`handleLaunchExecution\` hard-rejects at UI layer when \`state !== "ready"\`, Escape key closes both context menu and plan review modal.

**\`web/src/app.css\`** — ~80 lines for plan status row + plan action layout + full-page modal overlay. First overlay primitive in the project: \`role="presentation"\` outer with click-to-dismiss, \`role="dialog"\` inner card stopping propagation, scrollable \`<pre>\` for scratchpad content.

### Tests

**\`src/__tests__/graph-node-actions.test.ts\`** — 9 new tests (16 total in file) covering:
- Prepare plan visible when state=planned, no plan yet
- Prepare + Approve + Review all visible when plan=drafting
- Only Review visible when plan=ready
- Prepare hidden for non-issue kinds
- Launch disabled when can_launch=true but state≠ready (with "Approve the plan first" tooltip)
- Launch enabled only when state=ready AND can_launch=true
- Preparing… / Approving… loading labels
- Prepare/Approve/Review all hidden for terminal states (done)

## Key decisions (from Phase 3.5 Q&A)

1. **Action surface:** Sidebar + context menu, not just Sidebar. Keeps parity with the existing Launch pattern and gets automatic test coverage via \`buildGraphNodeContextMenu\`.
2. **Review modality:** Full-page modal overlay. The Sidebar is ~320px — too cramped for a multi-kB scratchpad. First modal primitive in the project, kept minimal.
3. **Approve plan included:** Without it, \`drafting → ready\` can only happen via raw API or planner agent, leaving a UX gap the Launch button can't close. Small addition, keeps Prepare → Review → Approve → Launch usable end-to-end from Studio alone.
4. **State dropdown fix in scope:** Discovered during planning — dropdowns only listed 6 of 9 canonical states. One-line fix per form, atomic with the rest of the Sidebar pass rather than a follow-up.

## Out of scope

- **Archive UI / disposition buttons** — deferred to #83 epic (per the issue body).
- **Planner-side scratchpad editor** — deferred. Scratchpad remains markdown; Review is read-only.
- **Dispatch candidate list (\`ExecutionDispatchListItem\`) plan awareness** — the execution preview response doesn't carry \`plan_state\` today, and the backend's \`can_launch\` already enforces the \`ready\`-state gate. No change needed for V1; noted as a potential follow-up if the dispatch panel surfaces plan state later.
- **\`approved_by\` reviewer threading** — \`POST /api/plans/:id/approve\` accepts an optional body; V1 calls with \`{}\`. Future enhancement.
- **\`superseded\` plan state** — mentioned in the issue body but doesn't actually exist in \`PlanState\` (\`drafting | ready | null\`). UI handles the two real states + null.

## Test plan

### Automated (already green)
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 307/307 across 21 test files (+9 new graph-node-actions tests, was 298)
- [x] \`npx vite build --config web/vite.config.ts\` — clean (only pre-existing PlannerChatAdapter / ExecutionDispatchPanel warnings, not regressed)

### Manual smoke (suggested pre-merge)
- [ ] Select a \`planned\` issue-kind work item — Prepare plan button visible, plan pill shows \"not prepared\", Launch is disabled with explanatory tooltip
- [ ] Click Prepare plan — work item transitions to \`drafting\`, plan pill becomes \`drafting\`, Approve + Review buttons appear
- [ ] Click Review plan — modal opens with scratchpad content, Escape closes it, click-outside closes it
- [ ] Click Approve plan — plan pill becomes \`ready\`, work item transitions to \`ready\`, Prepare/Approve disappear, Launch becomes enabled
- [ ] Click Launch — existing launch flow runs, Execute tab opens
- [ ] Same flow via the graph node right-click context menu
- [ ] Edit a work item's state using the Sidebar dropdown — all 9 states selectable
- [ ] Select a terminal-state item (\`done\`, \`cancelled\`) — no plan actions visible