### PR TITLE
[#138] Studio: distinguish open PR and merged PR states in the graph

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -245,6 +245,8 @@ a:hover {
   --graph-frontier-glow: rgba(240, 246, 252, 0.16);
   --graph-in-progress-outline: rgba(255, 244, 214, 0.92);
   --graph-in-progress-shadow: rgba(210, 153, 34, 0.22);
+  --graph-merged-pr-outline: rgba(214, 255, 244, 0.92);
+  --graph-merged-pr-shadow: rgba(46, 160, 143, 0.28);
 }
 
 /* In-progress styling uses an inset dashed outline so it remains distinct
@@ -275,6 +277,42 @@ a:hover {
 .graph-canvas .node[data-state="in_progress"]:hover .in-progress-overlay {
   stroke-width: 1.45px;
   opacity: 1;
+}
+
+/* merged_pr styling uses a solid inset outline so the 'landed' signal
+   carries independent of hue and composes with frontier stripes + the
+   bottom-anchored ✓PR badge. */
+.graph-canvas .node.graph-node--merged-pr,
+.graph-canvas .node[data-state="merged_pr"] {
+  filter: drop-shadow(0 0 0.3rem var(--graph-merged-pr-shadow));
+}
+
+.graph-canvas .node.graph-node--merged-pr .merged-pr-overlay,
+.graph-canvas .node[data-state="merged_pr"] .merged-pr-overlay {
+  fill: none;
+  stroke: var(--graph-merged-pr-outline);
+  stroke-width: 1.4px;
+  stroke-linecap: round;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.graph-canvas .node.graph-node--merged-pr.selected .merged-pr-overlay,
+.graph-canvas .node[data-state="merged_pr"].selected .merged-pr-overlay {
+  stroke-width: 1.6px;
+  opacity: 1;
+}
+
+.graph-canvas .node.graph-node--merged-pr:hover .merged-pr-overlay,
+.graph-canvas .node[data-state="merged_pr"]:hover .merged-pr-overlay {
+  stroke-width: 1.55px;
+  opacity: 1;
+}
+
+.graph-canvas .node.graph-node--frontier.graph-node--merged-pr,
+.graph-canvas .node.graph-node--frontier[data-state="merged_pr"],
+.graph-canvas .node[data-frontier="true"][data-state="merged_pr"] {
+  filter: drop-shadow(0 0 0.3rem var(--graph-frontier-glow)) drop-shadow(0 0 0.2rem var(--graph-merged-pr-shadow));
 }
 
 /* Frontier styling uses an interior overlay so it composes with the graph
@@ -333,6 +371,20 @@ a:hover {
   position: absolute;
   inset: 1px;
   border: 1px dashed rgba(255, 244, 214, 0.95);
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+.graph-legend .legend-swatch.merged-pr {
+  border: 1px solid rgba(214, 255, 244, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(46, 160, 143, 0.18);
+}
+
+.graph-legend .legend-swatch.merged-pr::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border: 1px solid rgba(214, 255, 244, 0.95);
   border-radius: 1px;
   pointer-events: none;
 }

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -99,7 +99,7 @@
         <div class="legend-row"><span class="legend-swatch" style="background:#56d364"></span><code>ready</code></div>
         <div class="legend-row"><span class="legend-swatch in-progress" style="background:#d29922"></span><code>in_progress</code><span class="legend-note">dashed inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#a371f7"></span><code>open_pr</code></div>
-        <div class="legend-row"><span class="legend-swatch" style="background:#8957e5"></span><code>merged_pr</code></div>
+        <div class="legend-row"><span class="legend-swatch merged-pr" style="background:#2ea08f"></span><code>merged_pr</code><span class="legend-note">solid inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#238636"></span><code>done</code></div>
         <div class="legend-row"><span class="legend-swatch frontier"></span><code>frontier</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#8b949e"></span><code>deferred</code></div>

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -7,7 +7,7 @@ const STATE_COLORS = {
   ready: "#56d364",
   in_progress: "#d29922",
   open_pr: "#a371f7",
-  merged_pr: "#8957e5",
+  merged_pr: "#2ea08f",
   done: "#238636",
   deferred: "#8b949e",
   cancelled: "#f85149",

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -160,6 +160,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     const classes = ["graph-node"];
     if (node._isFrontier) classes.push("graph-node--frontier");
     if (node.state === "in_progress") classes.push("graph-node--in-progress");
+    if (node.state === "merged_pr") classes.push("graph-node--merged-pr");
 
     g.setNode(node.id, {
       label: node.id,
@@ -286,6 +287,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     nodeGroup
       .classed("selected", data.id === selectedId)
       .classed("graph-node--in-progress", data.state === "in_progress")
+      .classed("graph-node--merged-pr", data.state === "merged_pr")
       .attr("data-frontier", data._isFrontier ? "true" : "false")
       .attr("data-state", data.state ?? "unknown");
 
@@ -322,6 +324,18 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
           .attr("height", Math.max(0, height - progressInset * 2))
           .attr("rx", Math.max(0, rx - progressInset / 2))
           .attr("ry", Math.max(0, ry - progressInset / 2));
+      }
+
+      if (data.state === "merged_pr") {
+        const mergedInset = Math.min(2.5, width / 6, height / 6);
+        nodeGroup.insert("rect", "g.label")
+          .attr("class", "merged-pr-overlay")
+          .attr("x", x + mergedInset)
+          .attr("y", y + mergedInset)
+          .attr("width", Math.max(0, width - mergedInset * 2))
+          .attr("height", Math.max(0, height - mergedInset * 2))
+          .attr("rx", Math.max(0, rx - mergedInset / 2))
+          .attr("ry", Math.max(0, ry - mergedInset / 2));
       }
     }
 


### PR DESCRIPTION
## Summary
Now Task 5: End-to-end visual verification. Let me re-read the ✓PR badge logic to confirm there's no clash with the new overlay, and run the full quality checks.

actual_files synced: 0 file(s).

## Context
- Work item: studio-138
- Issue: https://github.com/fusupo/escapement-studio/issues/138
- Base branch: develop
- Head branch: studio-138-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775786115253
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-138-branch
- Scope hint: Add distinct graph state/rendering for work items with an open PR versus a merged PR.

## Changed files
- (not recorded)