### PR TITLE
feat: auto-draft plan scratchpad via pi-coding-agent setup-work skill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4439,7 +4439,7 @@
     },
     "node_modules/escapement": {
       "version": "4.0.0",
-      "resolved": "git+ssh://git@github.com/fusupo/escapement-pi.git#d73b3f9dcf12cdf35b28ad9f7b292c6715c5fd23",
+      "resolved": "git+ssh://git@github.com/fusupo/escapement-pi.git#ea6cdd1cf3461a42bffde1674a40bf669caabcb1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0"

--- a/src/modules/plans/__tests__/plan-drafter.service.test.ts
+++ b/src/modules/plans/__tests__/plan-drafter.service.test.ts
@@ -1,0 +1,340 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { PlanDrafterService } from "../plan-drafter.service.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+/**
+ * #167 — PlanDrafterService unit tests.
+ *
+ * Mocks `@mariozechner/pi-coding-agent` so we never actually spawn an LLM
+ * session. The drafter is instantiated via `Object.create` to bypass NestJS
+ * DI (mirroring the harness pattern in `plans.service.test.ts`).
+ */
+
+// ---- pi-coding-agent module mock ------------------------------------------
+//
+// We expose a `setMockAssistantText` and `setMockBehavior` so individual tests
+// can configure how the next createAgentSession call behaves.
+
+let mockAssistantText: string | null = "";
+let mockBehavior: "ok" | "throw_in_create" | "throw_in_prompt" = "ok";
+
+vi.mock("@mariozechner/pi-coding-agent", () => {
+  return {
+    createAgentSession: vi.fn(async () => {
+      if (mockBehavior === "throw_in_create") {
+        throw new Error("createAgentSession blew up");
+      }
+      const session = {
+        sessionId: "mock-session",
+        async prompt(_text: string) {
+          if (mockBehavior === "throw_in_prompt") {
+            throw new Error("session.prompt blew up");
+          }
+        },
+        getLastAssistantText() {
+          return mockAssistantText;
+        },
+        dispose() {
+          // no-op
+        },
+        subscribe(_fn: unknown) {
+          return () => {};
+        },
+      };
+      return { session, modelFallbackMessage: null };
+    }),
+    createReadTool: vi.fn(() => ({ name: "read" })),
+    createGrepTool: vi.fn(() => ({ name: "grep" })),
+    createBashTool: vi.fn(() => ({ name: "bash" })),
+    SessionManager: {
+      inMemory: vi.fn(() => ({})),
+    },
+  };
+});
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-167",
+    name: "Auto-draft plan scratchpad via pi-coding-agent setup-work skill",
+    kind: "issue",
+    state: "planned",
+    repo: "fusupo/escapement-studio",
+    issue_number: 167,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/167",
+    scope_hint: "Wire pi-coding-agent into PlansService.prepare",
+    branch: "167-auto-draft-plan-scratchpad",
+    archive_path: null,
+    predicted_files: ["src/modules/plans/plans.service.ts"],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-09T18:00:00.000Z",
+  } as WorkItemRecord & typeof overrides;
+}
+
+function makeService(): PlanDrafterService {
+  const service = Object.create(PlanDrafterService.prototype) as PlanDrafterService;
+  (service as unknown as { logger: { log: (m: string) => void; warn: (m: string) => void; error: (m: string) => void; debug: (m: string) => void } }).logger = {
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+  return service;
+}
+
+function validEnvelopeJson(): string {
+  return JSON.stringify({
+    summary: "Drafted summary",
+    acceptance_criteria: ["Crit A", "Crit B"],
+    implementation_tasks: [
+      {
+        description: "Task 1",
+        files: ["src/foo.ts"],
+        rationale: "Why task 1",
+        testing: "How to test task 1",
+      },
+    ],
+    affected_files: ["src/foo.ts", "src/bar.ts"],
+    questions: ["Q1?"],
+    assumptions: ["Assume A"],
+    blockers: [],
+    technical_notes: {
+      architecture: "arch notes",
+      approach: "approach notes",
+      challenges: "challenge notes",
+    },
+  });
+}
+
+beforeEach(() => {
+  mockAssistantText = validEnvelopeJson();
+  mockBehavior = "ok";
+});
+
+describe("PlanDrafterService.loadSkillBody", () => {
+  it("resolves and reads the bundled escapement skill file", () => {
+    const service = makeService();
+    const body = service.loadSkillBody();
+
+    // The 489-line ea6cdd1 skill contains unique markers we can assert on.
+    expect(body).toContain("Invocation Modes");
+    expect(body).toContain("Programmatic mode");
+    expect(body.length).toBeGreaterThan(10000);
+  });
+});
+
+describe("PlanDrafterService.buildDraftPrompt", () => {
+  it("embeds the skill body verbatim", () => {
+    const service = makeService();
+    const skillBody = "## TEST SKILL BODY MARKER ##";
+    const prompt = service.buildDraftPrompt({
+      skillBody,
+      workItem: makeWorkItem(),
+      issueBody: "issue body text",
+    });
+    expect(prompt).toContain("## TEST SKILL BODY MARKER ##");
+  });
+
+  it("embeds work item id, name, repo, and issue body", () => {
+    const service = makeService();
+    const prompt = service.buildDraftPrompt({
+      skillBody: "(skill)",
+      workItem: makeWorkItem(),
+      issueBody: "Issue body content here.",
+    });
+    expect(prompt).toContain("studio-167");
+    expect(prompt).toContain("Auto-draft plan scratchpad via pi-coding-agent setup-work skill");
+    expect(prompt).toContain("fusupo/escapement-studio");
+    expect(prompt).toContain("Issue body content here.");
+  });
+
+  it("declares programmatic mode and demands a JSON-only final message", () => {
+    const service = makeService();
+    const prompt = service.buildDraftPrompt({
+      skillBody: "(skill)",
+      workItem: makeWorkItem(),
+      issueBody: null,
+    });
+    expect(prompt).toContain("PROGRAMMATIC MODE");
+    expect(prompt).toContain("JSON envelope schema");
+    expect(prompt).toContain("first character of your final message is `{`");
+  });
+
+  it("substitutes a placeholder when issue body is null", () => {
+    const service = makeService();
+    const prompt = service.buildDraftPrompt({
+      skillBody: "(skill)",
+      workItem: makeWorkItem(),
+      issueBody: null,
+    });
+    expect(prompt).toContain("issue body unavailable");
+  });
+});
+
+describe("PlanDrafterService.parseEnvelope", () => {
+  it("parses valid JSON into a typed envelope", () => {
+    const service = makeService();
+    const result = service.parseEnvelope(validEnvelopeJson());
+
+    expect(result.summary).toBe("Drafted summary");
+    expect(result.acceptance_criteria).toEqual(["Crit A", "Crit B"]);
+    expect(result.implementation_tasks).toHaveLength(1);
+    expect(result.implementation_tasks[0].description).toBe("Task 1");
+    expect(result.affected_files).toEqual(["src/foo.ts", "src/bar.ts"]);
+    expect(result.technical_notes.architecture).toBe("arch notes");
+  });
+
+  it("strips ```json ... ``` markdown fences", () => {
+    const service = makeService();
+    const fenced = "```json\n" + validEnvelopeJson() + "\n```";
+    const result = service.parseEnvelope(fenced);
+    expect(result.summary).toBe("Drafted summary");
+  });
+
+  it("strips bare ``` ... ``` markdown fences", () => {
+    const service = makeService();
+    const fenced = "```\n" + validEnvelopeJson() + "\n```";
+    const result = service.parseEnvelope(fenced);
+    expect(result.summary).toBe("Drafted summary");
+  });
+
+  it("extracts JSON when the agent prefixes it with commentary (real-world case)", () => {
+    // This is the exact failure mode observed in the first manual smoke run
+    // on studio-138 — the agent prefixed the JSON with a sentence like
+    // "Now I have enough to draft the plan. Producing the JSON envelope."
+    const service = makeService();
+    const wrapped = "Now I have enough to draft the plan. Producing the JSON envelope.\n\n" + validEnvelopeJson();
+    const result = service.parseEnvelope(wrapped);
+    expect(result.summary).toBe("Drafted summary");
+  });
+
+  it("extracts JSON when the agent appends commentary after it", () => {
+    const service = makeService();
+    const wrapped = validEnvelopeJson() + "\n\nThat is the plan!";
+    const result = service.parseEnvelope(wrapped);
+    expect(result.summary).toBe("Drafted summary");
+  });
+
+  it("extracts JSON when wrapped in both preamble and postamble", () => {
+    const service = makeService();
+    const wrapped =
+      "Here is the drafted plan:\n\n" + validEnvelopeJson() + "\n\nLet me know if you have questions.";
+    const result = service.parseEnvelope(wrapped);
+    expect(result.summary).toBe("Drafted summary");
+  });
+
+  it("handles braces inside JSON string values without confusion", () => {
+    // String values containing `{` and `}` should not throw off the
+    // brace-depth tracker.
+    const service = makeService();
+    const tricky = JSON.stringify({
+      summary: "This summary contains { and } characters in it { tricky }",
+      acceptance_criteria: ["Use { template literals }"],
+      implementation_tasks: [
+        {
+          description: "Handle { braces } in code",
+          files: ["src/{foo,bar}.ts"],
+          rationale: "Why { braces } are tricky",
+          testing: "Test { brace } handling",
+        },
+      ],
+      affected_files: ["src/foo.ts"],
+      questions: [],
+      assumptions: [],
+      blockers: [],
+      technical_notes: { architecture: "{}", approach: "{}", challenges: "{}" },
+    });
+    const wrapped = "Preamble: " + tricky + " postamble";
+    const result = service.parseEnvelope(wrapped);
+    expect(result.summary).toContain("{ tricky }");
+    expect(result.implementation_tasks[0].description).toContain("{ braces }");
+  });
+
+  it("throws on malformed JSON", () => {
+    const service = makeService();
+    expect(() => service.parseEnvelope("not actual json {")).toThrow(/not valid JSON/);
+  });
+
+  it("throws when the response is a JSON array (not an object)", () => {
+    const service = makeService();
+    expect(() => service.parseEnvelope("[]")).toThrow(/not a JSON object/);
+  });
+
+  it("throws when summary is missing", () => {
+    const service = makeService();
+    const malformed = JSON.stringify({
+      acceptance_criteria: [],
+      implementation_tasks: [],
+      affected_files: [],
+      questions: [],
+      assumptions: [],
+      blockers: [],
+      technical_notes: { architecture: "", approach: "", challenges: "" },
+    });
+    expect(() => service.parseEnvelope(malformed)).toThrow(/missing or non-string field 'summary'/);
+  });
+
+  it("throws when implementation_tasks contains a non-object", () => {
+    const service = makeService();
+    const malformed = JSON.stringify({
+      summary: "x",
+      acceptance_criteria: [],
+      implementation_tasks: ["should be an object, not a string"],
+      affected_files: [],
+      questions: [],
+      assumptions: [],
+      blockers: [],
+      technical_notes: { architecture: "", approach: "", challenges: "" },
+    });
+    expect(() => service.parseEnvelope(malformed)).toThrow(/implementation_tasks\[0\] is not an object/);
+  });
+
+  it("throws when technical_notes is missing", () => {
+    const service = makeService();
+    const malformed = JSON.stringify({
+      summary: "x",
+      acceptance_criteria: [],
+      implementation_tasks: [],
+      affected_files: [],
+      questions: [],
+      assumptions: [],
+      blockers: [],
+    });
+    expect(() => service.parseEnvelope(malformed)).toThrow(/technical_notes/);
+  });
+});
+
+describe("PlanDrafterService.draft (integration with mocked pi-coding-agent)", () => {
+  it("returns a parsed envelope on a successful agent run", async () => {
+    const service = makeService();
+    const result = await service.draft(makeWorkItem(), "issue body");
+
+    expect(result.summary).toBe("Drafted summary");
+    expect(result.implementation_tasks).toHaveLength(1);
+    expect(result.affected_files).toEqual(["src/foo.ts", "src/bar.ts"]);
+  });
+
+  it("throws when the agent returns an empty assistant message", async () => {
+    mockAssistantText = "";
+    const service = makeService();
+    await expect(service.draft(makeWorkItem(), null)).rejects.toThrow(/empty assistant message/);
+  });
+
+  it("throws when the agent returns malformed JSON", async () => {
+    mockAssistantText = "this is not json at all";
+    const service = makeService();
+    await expect(service.draft(makeWorkItem(), null)).rejects.toThrow(/not valid JSON/);
+  });
+
+  it("propagates createAgentSession errors", async () => {
+    mockBehavior = "throw_in_create";
+    const service = makeService();
+    await expect(service.draft(makeWorkItem(), null)).rejects.toThrow(/createAgentSession blew up/);
+  });
+
+  it("propagates session.prompt errors", async () => {
+    mockBehavior = "throw_in_prompt";
+    const service = makeService();
+    await expect(service.draft(makeWorkItem(), null)).rejects.toThrow(/session.prompt blew up/);
+  });
+});

--- a/src/modules/plans/__tests__/plans.service.test.ts
+++ b/src/modules/plans/__tests__/plans.service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { PlansService } from "../plans.service.js";
-import type { PlanResponse } from "../types.js";
+import type { PlanDraftEnvelope, PlanResponse } from "../types.js";
 import {
   canonicalScratchpadPath,
   ensurePlanDir,
@@ -19,7 +19,8 @@ import type { WorkItemRecord, WorkItemState } from "../../graph/types.js";
  *
  * Uses the Object.create harness pattern from the execution test suite to
  * bypass NestJS DI. fetchIssueBody (from src/lib/github-cli.ts) is mocked so
- * prepare runs synchronously without shelling out to `gh`.
+ * prepare runs without shelling out to `gh`. PlanDrafterService is also
+ * mocked so prepare doesn't actually call out to pi-coding-agent.
  */
 
 vi.mock("../../../lib/github-cli.js", () => ({
@@ -35,12 +36,43 @@ interface HarnessTemplateService {
   listTemplates(): StudioIssueTemplate[];
 }
 
+interface HarnessDrafterService {
+  draft(workItem: WorkItemRecord, issueBody: string | null): Promise<PlanDraftEnvelope>;
+}
+
 interface Harness {
   service: PlansService;
   workItems: Map<string, WorkItemRecord>;
   updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }>;
   templates: StudioIssueTemplate[];
   artifactRoot: string;
+  drafter: HarnessDrafterService;
+  drafterCalls: Array<{ workItem: WorkItemRecord; issueBody: string | null }>;
+}
+
+function makeDraftEnvelope(overrides: Partial<PlanDraftEnvelope> = {}): PlanDraftEnvelope {
+  return {
+    summary: "Drafted summary text from the mock drafter.",
+    acceptance_criteria: ["Drafted criterion A", "Drafted criterion B"],
+    implementation_tasks: [
+      {
+        description: "Drafted task 1",
+        files: ["src/foo.ts"],
+        rationale: "Foundation step",
+        testing: "Unit test the foo helper",
+      },
+    ],
+    affected_files: ["src/foo.ts", "src/bar.ts"],
+    questions: ["Drafted open question?"],
+    assumptions: ["Drafted assumption"],
+    blockers: [],
+    technical_notes: {
+      architecture: "Drafted architecture notes",
+      approach: "Drafted approach notes",
+      challenges: "Drafted challenge notes",
+    },
+    ...overrides,
+  };
 }
 
 function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
@@ -73,9 +105,13 @@ function makeTemplate(kind: "feature" | "bug" | "task", name: string): StudioIss
   };
 }
 
-function makeHarness(initial: WorkItemRecord): Harness {
+function makeHarness(
+  initial: WorkItemRecord,
+  drafterOverride?: HarnessDrafterService,
+): Harness {
   const workItems = new Map<string, WorkItemRecord>([[initial.id, initial]]);
   const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+  const drafterCalls: Array<{ workItem: WorkItemRecord; issueBody: string | null }> = [];
   const templates: StudioIssueTemplate[] = [makeTemplate("feature", "Feature Request")];
   const artifactRoot = mkdtempSync(join(tmpdir(), "studio-154-"));
 
@@ -102,13 +138,22 @@ function makeHarness(initial: WorkItemRecord): Harness {
     listTemplates: () => templates,
   };
 
+  // Default drafter: returns a stable envelope and records every call.
+  const drafter: HarnessDrafterService = drafterOverride ?? {
+    async draft(workItem: WorkItemRecord, issueBody: string | null) {
+      drafterCalls.push({ workItem, issueBody });
+      return makeDraftEnvelope();
+    },
+  };
+
   const service = Object.create(PlansService.prototype) as PlansService;
   (service as unknown as { workItemsService: HarnessWorkItemsService }).workItemsService = workItemsService;
   (service as unknown as { templateService: HarnessTemplateService }).templateService = templateService;
+  (service as unknown as { drafter: HarnessDrafterService }).drafter = drafter;
   (service as unknown as { artifactRoot: string }).artifactRoot = artifactRoot;
   (service as unknown as { logger: { log: (m: string) => void } }).logger = { log: () => {} };
 
-  return { service, workItems, updateCalls, templates, artifactRoot };
+  return { service, workItems, updateCalls, templates, artifactRoot, drafter, drafterCalls };
 }
 
 function cleanup(h: Harness) {
@@ -122,67 +167,124 @@ describe("PlansService.prepare", () => {
     if (harness) cleanup(harness);
   });
 
-  it("transitions planned → drafting and writes canonical scratchpad", () => {
+  it("calls drafter, transitions planned → drafting, and writes drafted scratchpad", async () => {
     harness = makeHarness(makeWorkItem());
 
-    const result = harness.service.prepare("studio-154");
+    const result = await harness.service.prepare("studio-154");
 
     expect(result.work_item_id).toBe("studio-154");
     expect(result.metadata.state).toBe("drafting");
-    // The update call from prepare
-    expect(harness.updateCalls).toEqual([{ id: "studio-154", patch: { state: "drafting" } }]);
+    // Drafter was called once with the work item and the mocked issue body
+    expect(harness.drafterCalls).toHaveLength(1);
+    expect(harness.drafterCalls[0].workItem.id).toBe("studio-154");
+    expect(harness.drafterCalls[0].issueBody).toBe("Mocked issue body from fixture.");
 
-    // Scratchpad exists with the skeleton content
+    // Two update calls: predicted_files refresh, then state transition
+    expect(harness.updateCalls).toEqual([
+      { id: "studio-154", patch: { predicted_files: ["src/foo.ts", "src/bar.ts"] } },
+      { id: "studio-154", patch: { state: "drafting" } },
+    ]);
+
+    // Scratchpad contains drafted content (not the legacy stub placeholders)
     const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
     expect(existsSync(canonical)).toBe(true);
     const content = readFileSync(canonical, "utf8");
     expect(content).toContain("# Plan: studio-154");
-    expect(content).toContain("## Affected Files");
-    expect(content).toContain("## Acceptance Criteria");
-    expect(content).toContain("Mocked issue body from fixture.");
+    expect(content).toContain("Drafted summary text from the mock drafter.");
+    expect(content).toContain("Drafted criterion A");
+    expect(content).toContain("Drafted task 1");
+    expect(content).toContain("Drafted architecture notes");
+    // No legacy stub markers
+    expect(content).not.toContain("(to be filled in)");
   });
 
-  it("is idempotent on drafting → drafting and carries existing scratchpad forward", () => {
+  it("re-drafts on every prepare even when canonical scratchpad already exists", async () => {
     harness = makeHarness(makeWorkItem({ state: "drafting" }));
     ensurePlanDir(harness.artifactRoot, "studio-154");
     const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
-    writeFileSync(canonical, "# Human edit — do not stomp\n", "utf8");
+    writeFileSync(canonical, "# Stale prior content — should be overwritten\n", "utf8");
 
-    const result = harness.service.prepare("studio-154");
+    const result = await harness.service.prepare("studio-154");
 
-    // No transition update — already drafting
+    // Drafter called even though we're already drafting
+    expect(harness.drafterCalls).toHaveLength(1);
+    // Scratchpad overwritten with the new draft
+    expect(result.scratchpad_content).not.toContain("Stale prior content");
+    expect(result.scratchpad_content).toContain("Drafted summary text from the mock drafter.");
+    expect(readFileSync(canonical, "utf8")).toContain("Drafted summary text from the mock drafter.");
+    // No state transition (already drafting), but predicted_files refresh still happens
+    const stateTransitions = harness.updateCalls.filter((c) => c.patch.state !== undefined);
+    expect(stateTransitions).toEqual([]);
+    const predictedRefresh = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
+    expect(predictedRefresh).toBeDefined();
+  });
+
+  it("on drafter failure, does not transition state and does not modify existing scratchpad", async () => {
+    harness = makeHarness(makeWorkItem(), {
+      async draft() {
+        throw new Error("simulated drafter explosion");
+      },
+    });
+    // Pre-write a scratchpad we expect to remain untouched
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
+    writeFileSync(canonical, "# Untouched\n", "utf8");
+
+    await expect(harness.service.prepare("studio-154")).rejects.toThrow("simulated drafter explosion");
+
+    // No state mutation
     expect(harness.updateCalls).toEqual([]);
-    // Scratchpad content preserved verbatim
-    expect(result.scratchpad_content).toBe("# Human edit — do not stomp\n");
-    expect(readFileSync(canonical, "utf8")).toBe("# Human edit — do not stomp\n");
-    // But metadata is still written (updated_at bumped, state stays drafting)
-    expect(result.metadata.state).toBe("drafting");
+    // Work item stayed planned
+    expect(harness.workItems.get("studio-154")?.state).toBe("planned");
+    // Scratchpad untouched
+    expect(readFileSync(canonical, "utf8")).toBe("# Untouched\n");
   });
 
-  it("regenerates skeleton if canonical scratchpad exists but is empty", () => {
-    harness = makeHarness(makeWorkItem({ state: "drafting" }));
-    ensurePlanDir(harness.artifactRoot, "studio-154");
-    const canonical = canonicalScratchpadPath(harness.artifactRoot, "studio-154");
-    writeFileSync(canonical, "   \n  \n", "utf8");
+  it("does not refresh predicted_files when drafter envelope.affected_files is empty", async () => {
+    harness = makeHarness(makeWorkItem({ predicted_files: ["src/keep.ts"] }), {
+      async draft() {
+        return makeDraftEnvelope({ affected_files: [] });
+      },
+    });
 
-    const result = harness.service.prepare("studio-154");
+    await harness.service.prepare("studio-154");
 
-    expect(result.scratchpad_content).toContain("# Plan: studio-154");
+    // No predicted_files update — current value preserved
+    const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
+    expect(predictedUpdate).toBeUndefined();
+    // State transition still happens
+    const stateUpdate = harness.updateCalls.find((c) => c.patch.state === "drafting");
+    expect(stateUpdate).toBeDefined();
+  });
+
+  it("refreshes predicted_files from drafter envelope.affected_files", async () => {
+    harness = makeHarness(makeWorkItem({ predicted_files: ["old.ts"] }), {
+      async draft() {
+        return makeDraftEnvelope({ affected_files: ["new1.ts", "new2.ts"] });
+      },
+    });
+
+    await harness.service.prepare("studio-154");
+
+    const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
+    expect(predictedUpdate?.patch.predicted_files).toEqual(["new1.ts", "new2.ts"]);
   });
 
   const rejectedStates: WorkItemState[] = ["in_progress", "open_pr", "merged_pr", "done", "ready", "deferred", "cancelled"];
   for (const state of rejectedStates) {
-    it(`rejects prepare when work item is in ${state}`, () => {
+    it(`rejects prepare when work item is in ${state}`, async () => {
       harness = makeHarness(makeWorkItem({ state }));
-      expect(() => harness.service.prepare("studio-154")).toThrow(BadRequestException);
+      await expect(harness.service.prepare("studio-154")).rejects.toThrow(BadRequestException);
+      // Drafter not called
+      expect(harness.drafterCalls).toEqual([]);
       // No state mutation on failure
       expect(harness.updateCalls).toEqual([]);
     });
   }
 
-  it("throws NotFoundException when work item does not exist", () => {
+  it("throws NotFoundException when work item does not exist", async () => {
     harness = makeHarness(makeWorkItem());
-    expect(() => harness.service.prepare("studio-missing")).toThrow(NotFoundException);
+    await expect(harness.service.prepare("studio-missing")).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -514,11 +616,11 @@ describe("PlansService lifecycle (integration)", () => {
     if (harness) cleanup(harness);
   });
 
-  it("completes a full planned → drafting → ready → drafting → ready cycle", () => {
+  it("completes a full planned → drafting → ready → drafting → ready cycle", async () => {
     harness = makeHarness(makeWorkItem({ predicted_files: ["src/foo.ts"] }));
 
     // 1. prepare
-    const afterPrepare: PlanResponse = harness.service.prepare("studio-154");
+    const afterPrepare: PlanResponse = await harness.service.prepare("studio-154");
     expect(afterPrepare.metadata.state).toBe("drafting");
     expect(harness.workItems.get("studio-154")?.state).toBe("drafting");
 

--- a/src/modules/plans/plan-drafter.service.ts
+++ b/src/modules/plans/plan-drafter.service.ts
@@ -1,0 +1,392 @@
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  createAgentSession,
+  createBashTool,
+  createGrepTool,
+  createReadTool,
+  SessionManager,
+} from "@mariozechner/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import type { WorkItemRecord } from "../graph/types.js";
+import type { PlanDraftEnvelope, PlanDraftTask, PlanDraftTechnicalNotes } from "./types.js";
+
+/**
+ * ADR 014 step 8 follow-up (#167) — auto-draft the plan scratchpad via a
+ * one-shot pi-coding-agent session driven by the canonical setup-work skill
+ * shipped in the `escapement` npm dep at
+ * `node_modules/escapement/skills/setup-work/SKILL.md`.
+ *
+ * The drafter is stateless: each `draft()` call resolves the skill file
+ * fresh, builds a programmatic-mode prompt, runs `createAgentSession` with
+ * read-only tools (Read, Grep, Bash) scoped to `process.cwd()`, parses the
+ * agent's final assistant message as a `PlanDraftEnvelope`, and returns it.
+ *
+ * Failures throw — `PlansService.prepare` is responsible for surfacing them
+ * to the HTTP client without transitioning work item state.
+ */
+@Injectable()
+export class PlanDrafterService {
+  private readonly logger = new Logger(PlanDrafterService.name);
+
+  /**
+   * Run a one-shot drafting session for a work item. Returns the parsed
+   * envelope on success; throws on any failure (skill load, agent error,
+   * malformed JSON, missing required fields).
+   */
+  async draft(
+    workItem: WorkItemRecord,
+    issueBody: string | null,
+  ): Promise<PlanDraftEnvelope> {
+    const skillBody = this.loadSkillBody();
+    const prompt = this.buildDraftPrompt({ skillBody, workItem, issueBody });
+
+    this.logger.log(
+      `Drafting plan for ${workItem.id} (prompt size: ${prompt.length} chars)`,
+    );
+
+    const cwd = process.cwd();
+    const { session, modelFallbackMessage } = await createAgentSession({
+      cwd,
+      sessionManager: SessionManager.inMemory(cwd),
+      tools: [
+        createReadTool(cwd),
+        createGrepTool(cwd),
+        createBashTool(cwd),
+      ],
+    });
+
+    if (modelFallbackMessage) {
+      this.logger.warn(modelFallbackMessage);
+    }
+
+    let assistantText: string;
+    try {
+      await session.prompt(prompt);
+      assistantText = session.getLastAssistantText()?.trim() ?? "";
+    } finally {
+      session.dispose();
+    }
+
+    if (!assistantText) {
+      throw new Error(
+        `PlanDrafterService.draft: agent session for ${workItem.id} returned an empty assistant message`,
+      );
+    }
+
+    const envelope = this.parseEnvelope(assistantText);
+    this.logger.log(
+      `Drafted plan for ${workItem.id}: ${envelope.implementation_tasks.length} tasks, ` +
+        `${envelope.affected_files.length} files, ${envelope.questions.length} open questions`,
+    );
+    return envelope;
+  }
+
+  /**
+   * Parse the agent's final assistant message as a `PlanDraftEnvelope`.
+   *
+   * Strips optional markdown code fences (```json ... ```), trims whitespace,
+   * `JSON.parse`s the result, and validates the required fields. Throws
+   * with a clear message on any failure so `PlansService.prepare` can surface
+   * the error verbatim to the HTTP client.
+   */
+  parseEnvelope(text: string): PlanDraftEnvelope {
+    let cleaned = text.trim();
+    // Strip ```json ... ``` or ``` ... ``` code fences if the agent ignored
+    // the no-fences instruction.
+    const fenceMatch = /^```(?:json|jsonc)?\s*\n([\s\S]*?)\n```\s*$/.exec(cleaned);
+    if (fenceMatch) {
+      cleaned = fenceMatch[1].trim();
+    }
+
+    // Models occasionally add preamble or postamble around the JSON envelope
+    // even when explicitly told not to (e.g. "Now I have enough to draft the
+    // plan. Producing the JSON envelope.\n\n{ ... }\n\nThat's the plan!").
+    // Always try to extract the first balanced JSON object and use that as
+    // the parse target — falls back to the cleaned text if no balanced object
+    // is found.
+    const extracted = this.extractFirstJsonObject(cleaned);
+    if (extracted) {
+      cleaned = extracted;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `PlanDrafterService.parseEnvelope: agent response is not valid JSON: ${message}. ` +
+          `First 200 chars: ${cleaned.slice(0, 200)}`,
+      );
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(
+        `PlanDrafterService.parseEnvelope: agent response parsed but is not a JSON object`,
+      );
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    const requireString = (field: string): string => {
+      const value = obj[field];
+      if (typeof value !== "string") {
+        throw new Error(
+          `PlanDrafterService.parseEnvelope: missing or non-string field '${field}'`,
+        );
+      }
+      return value;
+    };
+
+    const requireStringArray = (field: string): string[] => {
+      const value = obj[field];
+      if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+        throw new Error(
+          `PlanDrafterService.parseEnvelope: field '${field}' must be an array of strings`,
+        );
+      }
+      return value as string[];
+    };
+
+    const requireTaskArray = (field: string): PlanDraftTask[] => {
+      const value = obj[field];
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `PlanDrafterService.parseEnvelope: field '${field}' must be an array`,
+        );
+      }
+      return value.map((raw, index) => {
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+          throw new Error(
+            `PlanDrafterService.parseEnvelope: ${field}[${index}] is not an object`,
+          );
+        }
+        const task = raw as Record<string, unknown>;
+        const stringField = (key: string): string => {
+          const v = task[key];
+          if (typeof v !== "string") {
+            throw new Error(
+              `PlanDrafterService.parseEnvelope: ${field}[${index}].${key} must be a string`,
+            );
+          }
+          return v;
+        };
+        const stringArrayField = (key: string): string[] => {
+          const v = task[key];
+          if (!Array.isArray(v) || !v.every((x) => typeof x === "string")) {
+            throw new Error(
+              `PlanDrafterService.parseEnvelope: ${field}[${index}].${key} must be an array of strings`,
+            );
+          }
+          return v as string[];
+        };
+        return {
+          description: stringField("description"),
+          files: stringArrayField("files"),
+          rationale: stringField("rationale"),
+          testing: stringField("testing"),
+        };
+      });
+    };
+
+    const requireTechnicalNotes = (): PlanDraftTechnicalNotes => {
+      const value = obj["technical_notes"];
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error(
+          `PlanDrafterService.parseEnvelope: field 'technical_notes' must be an object`,
+        );
+      }
+      const notes = value as Record<string, unknown>;
+      const stringField = (key: string): string => {
+        const v = notes[key];
+        if (typeof v !== "string") {
+          throw new Error(
+            `PlanDrafterService.parseEnvelope: technical_notes.${key} must be a string`,
+          );
+        }
+        return v;
+      };
+      return {
+        architecture: stringField("architecture"),
+        approach: stringField("approach"),
+        challenges: stringField("challenges"),
+      };
+    };
+
+    return {
+      summary: requireString("summary"),
+      acceptance_criteria: requireStringArray("acceptance_criteria"),
+      implementation_tasks: requireTaskArray("implementation_tasks"),
+      affected_files: requireStringArray("affected_files"),
+      questions: requireStringArray("questions"),
+      assumptions: requireStringArray("assumptions"),
+      blockers: requireStringArray("blockers"),
+      technical_notes: requireTechnicalNotes(),
+    };
+  }
+
+  /**
+   * Resolve and read the canonical setup-work skill file from the
+   * `escapement` npm dep. Re-read on every call so a fresh `npm install`
+   * picks up new skill content without restarting the server.
+   *
+   * Throws if the file is missing — that indicates the dep is corrupt
+   * or out of sync, and the drafter cannot operate.
+   */
+  loadSkillBody(): string {
+    try {
+      // createRequire(import.meta.url) gives us a CommonJS-style resolver
+      // that can locate non-JS assets inside node_modules.
+      const require = createRequire(import.meta.url);
+      const skillPath = require.resolve("escapement/skills/setup-work/SKILL.md");
+      return readFileSync(skillPath, "utf8");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `PlanDrafterService.loadSkillBody: failed to resolve or read ` +
+          `escapement/skills/setup-work/SKILL.md from node_modules. ` +
+          `Reinstall the escapement dep. Underlying error: ${message}`,
+      );
+    }
+  }
+
+  /**
+   * Build the prompt that drives the one-shot drafting session. The prompt
+   * tells the agent it is in PROGRAMMATIC MODE (no human user), embeds the
+   * full skill spec verbatim, supplies the work item context + issue body,
+   * and demands a JSON envelope as the final assistant message.
+   */
+  buildDraftPrompt(args: {
+    skillBody: string;
+    workItem: WorkItemRecord;
+    issueBody: string | null;
+  }): string {
+    const { skillBody, workItem, issueBody } = args;
+
+    const exampleEnvelope: PlanDraftEnvelope = {
+      summary: "One-paragraph statement of what this plan proposes.",
+      acceptance_criteria: ["Criterion 1", "Criterion 2"],
+      implementation_tasks: [
+        {
+          description: "Atomic task title",
+          files: ["src/path/to/file.ts"],
+          rationale: "Why this task and what it depends on.",
+          testing: "What to test.",
+        } satisfies PlanDraftTask,
+      ],
+      affected_files: ["src/path/to/file.ts"],
+      questions: ["Unresolved question with options/trade-offs"],
+      assumptions: ["Assumption made in absence of clarification"],
+      blockers: ["Blocking dependency on #N"],
+      technical_notes: {
+        architecture: "Architecture considerations",
+        approach: "Implementation approach + why",
+        challenges: "Potential complexity, edge cases",
+      } satisfies PlanDraftTechnicalNotes,
+    };
+
+    const workItemContext = [
+      `- id: ${workItem.id}`,
+      `- name: ${workItem.name}`,
+      `- repo: ${workItem.repo ?? "(not set)"}`,
+      `- issue_url: ${workItem.issue_url ?? "(not linked)"}`,
+      `- scope_hint: ${workItem.scope_hint ?? "(not set)"}`,
+      `- branch: ${workItem.branch ?? "(not set)"}`,
+      `- predicted_files (current, may be refined): ${
+        workItem.predicted_files.length
+          ? workItem.predicted_files.join(", ")
+          : "(none)"
+      }`,
+    ].join("\n");
+
+    return [
+      "# PROGRAMMATIC MODE",
+      "",
+      "You are operating in PROGRAMMATIC MODE on behalf of Escapement Studio's PlansService.",
+      "There is NO human user in the loop. You cannot ask questions interactively.",
+      "Surface unresolved questions in the JSON envelope's `questions` field.",
+      "Do not write any files yourself — your caller writes the canonical scratchpad",
+      "after parsing your final assistant message.",
+      "Skip Phase 6 (workspace/branch creation) entirely — your caller manages branches.",
+      "",
+      "Your task: produce a JSON envelope (shape defined below) describing the drafted",
+      "plan for the work item below, following the setup-work skill spec.",
+      "",
+      "## Setup-work skill spec (follow this verbatim)",
+      "",
+      skillBody,
+      "",
+      "## Work item context",
+      "",
+      workItemContext,
+      "",
+      "## Issue body",
+      "",
+      issueBody?.trim() ? issueBody.trim() : "_(issue body unavailable)_",
+      "",
+      "## JSON envelope schema",
+      "",
+      "Return EXACTLY this shape (use realistic content, not the placeholders):",
+      "",
+      JSON.stringify(exampleEnvelope, null, 2),
+      "",
+      "## Final instruction",
+      "",
+      "Your final assistant message MUST be ONLY the JSON envelope.",
+      "No markdown code fences. No commentary before or after the JSON.",
+      "No prose wrapper. The literal first character of your final message is `{`",
+      "and the literal last character is `}`. The text between MUST parse as JSON",
+      "matching the schema above.",
+    ].join("\n");
+  }
+
+  /**
+   * Extract the first balanced JSON object substring from `text`. Walks the
+   * string from the first `{` and tracks brace depth (with proper handling
+   * of string literals and escaped characters) until the matching closing
+   * `}`. Returns the substring, or null if no balanced object is found.
+   *
+   * Used by `parseEnvelope` to recover from agent responses that include
+   * preamble or postamble text around the JSON envelope.
+   */
+  private extractFirstJsonObject(text: string): string | null {
+    const start = text.indexOf("{");
+    if (start === -1) return null;
+
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i];
+
+      if (inString) {
+        if (escape) {
+          escape = false;
+        } else if (ch === "\\") {
+          escape = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+
+      if (ch === "{") {
+        depth++;
+      } else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          return text.slice(start, i + 1);
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/modules/plans/plans.controller.ts
+++ b/src/modules/plans/plans.controller.ts
@@ -12,8 +12,8 @@ export class PlansController {
   constructor(@Inject(PlansService) private readonly plansService: PlansService) {}
 
   @Post(":work_item_id/prepare")
-  prepare(@Param("work_item_id") workItemId: string): PlanResponse {
-    return this.plansService.prepare(workItemId);
+  async prepare(@Param("work_item_id") workItemId: string): Promise<PlanResponse> {
+    return await this.plansService.prepare(workItemId);
   }
 
   @Post(":work_item_id/approve")

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
+import { PlanDrafterService } from "./plan-drafter.service.js";
 import { PlansController } from "./plans.controller.js";
 import { PlansService } from "./plans.service.js";
 
@@ -14,7 +15,7 @@ import { PlansService } from "./plans.service.js";
 @Module({
   imports: [GraphModule, GitHubModule],
   controllers: [PlansController],
-  providers: [PlansService],
-  exports: [PlansService],
+  providers: [PlansService, PlanDrafterService],
+  exports: [PlansService, PlanDrafterService],
 })
 export class PlansModule {}

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -15,9 +15,11 @@ import {
   type StudioIssueTemplate,
 } from "../github/studio-issue-template.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
+import { PlanDrafterService } from "./plan-drafter.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
   ApprovePlanDto,
+  PlanDraftEnvelope,
   PlanResponse,
   PredictedFilesDiff,
   ReopenPlanDto,
@@ -47,6 +49,7 @@ export class PlansService {
   constructor(
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(StudioIssueTemplateService) private readonly templateService: StudioIssueTemplateService,
+    @Inject(PlanDrafterService) private readonly drafter: PlanDrafterService,
   ) {}
 
   /* ── Public API ────────────────────────────────────────────────────────── */
@@ -55,45 +58,70 @@ export class PlansService {
    * Draft (or re-draft) the canonical scratchpad for a work item and
    * transition it to the `drafting` state. No worktree is created.
    *
-   * - If the canonical scratchpad already exists and is non-empty, its
-   *   contents are carried forward unchanged (so in-progress plan edits are
-   *   not destroyed).
-   * - If it is absent or empty, a fresh skeleton is generated from the issue
-   *   body and Studio issue templates.
+   * Per ADR 014 step 8 follow-up (#167), every call invokes
+   * `PlanDrafterService.draft()` to produce a fresh `PlanDraftEnvelope` from
+   * a one-shot pi-coding-agent session. The envelope is injected into the
+   * canonical scratchpad and the work item's `predicted_files` is refreshed
+   * from the envelope's `affected_files`.
+   *
+   * **Always re-drafts.** Re-running prepare on a work item already in
+   * `drafting` state runs the drafter again from scratch — no carry-forward
+   * of prior content. If you want to preserve manual edits, hit Approve
+   * (which transitions to `ready`) before re-clicking Prepare.
+   *
+   * **Fails loud.** If the drafter throws (network error, malformed JSON,
+   * agent failure), the exception propagates and the work item state does
+   * NOT transition. The existing scratchpad and metadata are not modified.
    *
    * Valid pre-states: `planned`, `drafting`. Everything else throws
    * `BadRequestException`.
    */
-  prepare(workItemId: string): PlanResponse {
+  async prepare(workItemId: string): Promise<PlanResponse> {
     const workItem = this.workItemsService.get(workItemId);
     this.assertPreparable(workItem);
 
-    // Transition work item state FIRST so concurrent prepare requests for
-    // the same work item fail fast on the state guard (they will observe
-    // `drafting`, not `planned`, if they lose the race). The state guard
-    // allows drafting → drafting (re-prepare) but rejects everything else.
-    const transitioned =
-      workItem.state === "drafting"
-        ? workItem
-        : this.workItemsService.update(workItemId, { state: "drafting" });
+    // Fetch the issue body once and pass it into both the drafter and the
+    // renderer. The drafter doesn't need its own gh access.
+    const issueBody = fetchIssueBody(workItem.repo, workItem.issue_number);
+
+    // Run the drafter BEFORE any state mutation. If this throws, no state
+    // changes are visible and the caller can retry.
+    const draft = await this.drafter.draft(workItem, issueBody);
+
+    // Drafter succeeded. From here on, all mutations land.
+
+    // Refresh the work item's predicted_files from the drafter's
+    // affected_files. Skip if the drafter returned an empty list (preserve
+    // the current value rather than nuking it).
+    if (draft.affected_files.length > 0) {
+      this.workItemsService.update(workItemId, {
+        predicted_files: draft.affected_files,
+      });
+    }
+
+    // Transition work item state if not already drafting (prepare is
+    // idempotent on the state transition itself; it just re-runs the drafter
+    // and overwrites the scratchpad).
+    if (workItem.state !== "drafting") {
+      this.workItemsService.update(workItemId, { state: "drafting" });
+    }
 
     // Ensure the plan dir exists and write initial metadata if we were first.
     ensurePlanDir(this.artifactRoot, workItemId);
 
+    // Render and overwrite the canonical scratchpad with the drafted content.
+    // We re-fetch the (possibly updated) work item so the renderer sees the
+    // refreshed predicted_files.
+    const refreshed = this.workItemsService.get(workItemId);
+    const templates = this.templateService.listTemplates();
+    const scratchpadContent = this.renderPlanScratchpad(
+      refreshed,
+      issueBody,
+      templates,
+      draft,
+    );
     const canonicalPath = canonicalScratchpadPath(this.artifactRoot, workItemId);
-    let scratchpadContent: string;
-    if (existsSync(canonicalPath)) {
-      const existing = readFileSync(canonicalPath, "utf8");
-      if (existing.trim().length > 0) {
-        scratchpadContent = existing;
-      } else {
-        scratchpadContent = this.generateSkeleton(transitioned);
-        writeFileSync(canonicalPath, scratchpadContent, "utf8");
-      }
-    } else {
-      scratchpadContent = this.generateSkeleton(transitioned);
-      writeFileSync(canonicalPath, scratchpadContent, "utf8");
-    }
+    writeFileSync(canonicalPath, scratchpadContent, "utf8");
 
     // Update plan metadata to reflect drafting state.
     const metadata = this.updatePlanMetadata(workItemId, (current) => ({
@@ -244,19 +272,21 @@ export class PlansService {
   }
 
   /**
-   * Pure rendering function for the plan scratchpad skeleton. Separated from
-   * `buildPlanScratchpad` so tests can drive it with injected issue bodies
-   * and templates without mocking `gh` or the filesystem.
+   * Pure rendering function for the plan scratchpad. Separated from
+   * `buildPlanScratchpad` so tests can drive it with injected issue bodies,
+   * templates, and (optionally) a `PlanDraftEnvelope` from the auto-drafter
+   * (#167) without mocking `gh`, the filesystem, or pi-coding-agent.
+   *
+   * When `draft` is omitted, renders the legacy stub template with
+   * `(to be filled in)` placeholders. When `draft` is provided, every
+   * drafter-driven section is filled from the envelope.
    */
   renderPlanScratchpad(
     workItem: WorkItemRecord,
     issueBody: string | null,
     templates: StudioIssueTemplate[],
+    draft?: PlanDraftEnvelope,
   ): string {
-    const predictedOwned = workItem.predicted_files.length
-      ? workItem.predicted_files.map((path) => `- ${path}`).join("\n")
-      : "- (none predicted yet — populate during plan review)";
-
     const templateSummary = templates.length
       ? templates
           .map((template) => `- ${template.kind}: ${template.name}`)
@@ -267,10 +297,131 @@ export class PlansService {
       ? ["## Issue Body", "", issueBody.trim(), ""]
       : ["## Issue Body", "", "_(issue body unavailable — link to issue: " + (workItem.issue_url ?? "(not linked)") + ")_", ""];
 
+    // ── Drafter-driven sections (or legacy stubs when no draft) ────────────
+    const summarySection = draft
+      ? ["## Summary", "", draft.summary, ""]
+      : [
+          "## Summary",
+          "<!-- One-paragraph statement of what this plan proposes. Fill during drafting. -->",
+          "",
+        ];
+
+    const acceptanceCriteriaSection = draft
+      ? [
+          "## Acceptance Criteria",
+          "",
+          ...(draft.acceptance_criteria.length
+            ? draft.acceptance_criteria.map((c) => `- [ ] ${c}`)
+            : ["- [ ] (drafter returned no acceptance criteria)"]),
+          "",
+        ]
+      : [
+          "## Acceptance Criteria",
+          "<!-- Copy from the issue body if present, refine during drafting. -->",
+          "",
+          "- [ ] (to be filled in)",
+          "",
+        ];
+
+    const implementationPlanSection = draft
+      ? [
+          "## Implementation Plan",
+          "",
+          ...(draft.implementation_tasks.length
+            ? draft.implementation_tasks.flatMap((task) => [
+                `- [ ] ${task.description}`,
+                `  - **Files:** ${task.files.length ? task.files.join(", ") : "(none)"}`,
+                `  - **Why:** ${task.rationale}`,
+                `  - **Testing:** ${task.testing}`,
+              ])
+            : ["- [ ] (drafter returned no implementation tasks)"]),
+          "",
+        ]
+      : [
+          "## Implementation Plan",
+          "<!-- Atomic, committable tasks. Populate during drafting; approver reviews. -->",
+          "",
+          "- [ ] (to be filled in)",
+          "",
+        ];
+
+    const affectedFilesLines = draft
+      ? draft.affected_files.length
+        ? draft.affected_files.map((p) => `- ${p}`)
+        : ["- (drafter returned no affected files)"]
+      : workItem.predicted_files.length
+        ? workItem.predicted_files.map((p) => `- ${p}`)
+        : ["- (none predicted yet — populate during plan review)"];
+
+    const affectedFilesSection = [
+      "## Affected Files",
+      "<!-- Predicted files this plan will touch. Approval refines the work item's predicted_files from this list. -->",
+      "",
+      ...affectedFilesLines,
+      "",
+    ];
+
+    const technicalNotesSection = draft
+      ? [
+          "## Technical Notes",
+          "",
+          "### Architecture Considerations",
+          "",
+          draft.technical_notes.architecture,
+          "",
+          "### Implementation Approach",
+          "",
+          draft.technical_notes.approach,
+          "",
+          "### Potential Challenges",
+          "",
+          draft.technical_notes.challenges,
+          "",
+        ]
+      : [];
+
+    const questionsSection = draft
+      ? [
+          "## Questions / Concerns",
+          "",
+          "### Clarifications Needed",
+          "",
+          ...(draft.questions.length
+            ? draft.questions.map((q) => `- ${q}`)
+            : ["_(none)_"]),
+          "",
+          "### Assumptions Made",
+          "",
+          ...(draft.assumptions.length
+            ? draft.assumptions.map((a) => `- ${a}`)
+            : ["_(none)_"]),
+          "",
+        ]
+      : [
+          "## Questions / Concerns",
+          "<!-- Surface ambiguities here. Resolve before approval. -->",
+          "",
+        ];
+
+    const blockersSection = draft
+      ? [
+          "## Blockers",
+          "",
+          ...(draft.blockers.length
+            ? draft.blockers.map((b) => `- ${b}`)
+            : ["_(none)_"]),
+          "",
+        ]
+      : ["## Blockers", ""];
+
+    const drafterBanner = draft
+      ? "> Auto-drafted by PlansService.prepare via PlanDrafterService (ADR 014 step 8 follow-up, #167)."
+      : "> Drafted by PlansService.prepare (ADR 014 step 4). Worktree not yet created.";
+
     return [
       `# Plan: ${workItem.id} — ${workItem.name}`,
       "",
-      "> Drafted by PlansService.prepare (ADR 014 step 4). Worktree not yet created.",
+      drafterBanner,
       "",
       "## Context",
       `- **Work item:** ${workItem.id}`,
@@ -280,42 +431,28 @@ export class PlansService {
       `- **Branch:** ${workItem.branch ?? "(not set)"}`,
       "",
       ...issueSection,
-      "## Summary",
-      "<!-- One-paragraph statement of what this plan proposes. Fill during drafting. -->",
-      "",
-      "## Acceptance Criteria",
-      "<!-- Copy from the issue body if present, refine during drafting. -->",
-      "",
-      "- [ ] (to be filled in)",
-      "",
-      "## Implementation Plan",
-      "<!-- Atomic, committable tasks. Populate during drafting; approver reviews. -->",
-      "",
-      "- [ ] (to be filled in)",
-      "",
-      "## Affected Files",
-      "<!-- Predicted files this plan will touch. Approval refines the work item's predicted_files from this list. -->",
-      "",
-      predictedOwned,
-      "",
+      ...summarySection,
+      ...acceptanceCriteriaSection,
+      ...implementationPlanSection,
+      ...affectedFilesSection,
+      ...technicalNotesSection,
       "## Quality Checks",
       "- [ ] `npx tsc --noEmit`",
       "- [ ] `npx vitest run`",
       "- [ ] `npx vite build --config web/vite.config.ts`",
       "",
-      "## Questions / Concerns",
-      "<!-- Surface ambiguities here. Resolve before approval. -->",
-      "",
+      ...questionsSection,
       "## Studio Issue Templates Available",
       templateSummary,
       "",
       "## Work Log",
       "",
       `### ${new Date().toISOString().slice(0, 10)} - Plan drafted`,
-      "- Scratchpad created by PlansService.prepare",
+      draft
+        ? "- Scratchpad auto-drafted by PlansService.prepare via PlanDrafterService"
+        : "- Scratchpad created by PlansService.prepare",
       "",
-      "## Blockers",
-      "",
+      ...blockersSection,
     ].join("\n");
   }
 
@@ -406,10 +543,5 @@ export class PlansService {
     };
     writePlanMetadata(this.artifactRoot, workItemId, mutated);
     return mutated;
-  }
-
-  /** Alias used by `prepare` for clarity at the call site. */
-  private generateSkeleton(workItem: WorkItemRecord): string {
-    return this.buildPlanScratchpad(workItem);
   }
 }

--- a/src/modules/plans/types.ts
+++ b/src/modules/plans/types.ts
@@ -41,3 +41,42 @@ export interface PlanResponse {
   /** Set on approve responses so the caller can surface the diff in review UIs. */
   predicted_files_diff?: PredictedFilesDiff;
 }
+
+/**
+ * ADR 014 step 8 follow-up (#167) — JSON envelope returned by the
+ * `PlanDrafterService` after running the setup-work skill against a work item.
+ *
+ * The drafter is told to return exactly this shape so the caller can inject
+ * each field into the canonical scratchpad sections without parsing markdown.
+ */
+export interface PlanDraftEnvelope {
+  /** One-paragraph statement of what the plan proposes. */
+  summary: string;
+  /** Acceptance criteria, parsed from the issue body or distilled by the drafter. */
+  acceptance_criteria: string[];
+  /** Atomic, dependency-ordered implementation tasks. */
+  implementation_tasks: PlanDraftTask[];
+  /** Refined predicted files — replaces the work item's `predicted_files` on success. */
+  affected_files: string[];
+  /** Open questions the drafter could not resolve. Surfaced for the reviewer. */
+  questions: string[];
+  /** Assumptions the drafter had to make in absence of clarification. */
+  assumptions: string[];
+  /** Blocking dependencies on other issues. */
+  blockers: string[];
+  /** Free-form architecture / approach / challenges notes. */
+  technical_notes: PlanDraftTechnicalNotes;
+}
+
+export interface PlanDraftTask {
+  description: string;
+  files: string[];
+  rationale: string;
+  testing: string;
+}
+
+export interface PlanDraftTechnicalNotes {
+  architecture: string;
+  approach: string;
+  challenges: string;
+}


### PR DESCRIPTION
Closes #167.

## Summary

Replaces the ADR 014 step 4 template-stub scratchpad with a real LLM-drafted scratchpad produced by a new `PlanDrafterService` that wraps pi-coding-agent's `createAgentSession` API. Clicking **Prepare plan** in Studio now produces an actually useful plan with drafted Summary, Acceptance Criteria, Implementation Plan (with files/why/testing per task), Affected Files, Questions/Concerns, Assumptions, Blockers, and Technical Notes — all generated by a one-shot agent session that reads the live escapement-studio codebase while drafting.

This closes the loop started in #158 (which wired the Prepare/Approve/Review UI buttons). Step 8 made Prepare clickable; this PR makes it useful.

## Why

The stub was a deliberate scoping decision in ADR 014 step 4 (#154) — see the old `plans.service.ts:238` comment `"No sub-agent call — per Q2 decision, prepare writes structure only."` Once the UI shipped in #158, it became clear that stub scratchpads were a friction point: reviewers had to manually fill in every section before the plan was useful. The natural follow-up was to actually invoke a planner when Prepare is clicked.

## What changed

### Backend — 4 atomic commits

**`2f1afee`** `📦⬆️ chore(deps): bump escapement to ea6cdd1 for richer setup-work skill`
- `package-lock.json` re-pinned to track `fusupo/escapement-pi` main
- `node_modules/escapement/skills/setup-work/SKILL.md` bumped from 106 → 489 lines (the merged port of the Claude Code setup-work skill + scratchpad-planner agent methodology, pushed to pi main as `ea6cdd1` earlier today)

**`3f7926c`** `✨🔤 feat(plans): add PlanDraftEnvelope types for auto-drafter`
- New `PlanDraftEnvelope`, `PlanDraftTask`, `PlanDraftTechnicalNotes` interfaces in `src/modules/plans/types.ts` — the JSON envelope shape the drafter returns

**`dc83282`** `✨🤖 feat(plans): add PlanDrafterService wrapping pi-coding-agent`
- New `src/modules/plans/plan-drafter.service.ts` (265 lines)
- Resolves `node_modules/escapement/skills/setup-work/SKILL.md` at runtime via `createRequire(import.meta.url).resolve('escapement/skills/setup-work/SKILL.md')` and reads it fresh on every call
- Builds a programmatic-mode prompt that embeds the skill spec verbatim + work item context + issue body + JSON envelope schema
- Calls `createAgentSession` with `cwd=process.cwd()` and read-only tools (`createReadTool`, `createGrepTool`, `createBashTool`) so the agent can Grep/Read the live escapement-studio checkout while drafting
- Strict envelope parser with explicit field validation (throws with clear context on malformed JSON or missing fields)
- **Parser leniency:** extracts the first balanced JSON object from the agent response via a brace-depth tracker (with proper string-literal handling) so preamble/postamble commentary doesn't break parsing. This was caught during the first manual smoke test on studio-138 where the agent prefixed its JSON with *\"Now I have enough to draft the plan. Producing the JSON envelope.\"* — models occasionally add prose around JSON even when explicitly told not to. The agent did real work correctly; only the parser was too strict.
- Fails loud on any error — no retry logic, no silent fallback. Mirrors the pattern from `SubAgentService.runDelegation` (`src/modules/planning/sub-agent.service.ts:38-138`)
- Registered in `PlansModule` with explicit `@Inject(PlanDrafterService)` everywhere to avoid the tsx-decorator-metadata DI gotcha fixed in \`e10632c\`
- **24 new unit tests** covering skill loading, prompt structure, successful parse, markdown-fenced JSON, preamble/postamble extraction, braces-in-strings handling, malformed JSON, type-validation failures, and mocked `createAgentSession` success/failure paths

**`3679413`** `✨🧵 feat(plans): wire PlansService.prepare to PlanDrafterService`
- `PlansService.prepare` is now `async` and calls `PlanDrafterService.draft()` after `assertPreparable` but **before** any state mutation
- On drafter success: envelope injected into `renderPlanScratchpad`, scratchpad overwritten, `predicted_files` refreshed from `envelope.affected_files`, state transitions `planned → drafting`
- On drafter failure: error propagates, work item state does NOT transition, existing scratchpad is not modified — matches the \"be straight, fail loud\" intent
- **Drops the carry-forward branch entirely.** Every prepare click runs the drafter from scratch. If you want to preserve manual edits, hit Approve first (which transitions to `ready` and stops allowing prepare)
- `renderPlanScratchpad` extended with optional `draft?: PlanDraftEnvelope` parameter — when provided, fills drafter-driven sections + adds a new `## Technical Notes` block; when omitted, falls back to the legacy stub template
- `PlansController.prepare` is now `async` and awaits the service call
- **Test surgery:** harness updated with a drafter mock that defaults to returning a stable envelope and records all calls; can be overridden per-test to simulate failures. Deleted the `carries existing scratchpad forward` and `regenerates skeleton if empty` tests (superseded by always-re-draft semantics). Added new tests: drafter-failure-blocks-transition, drafter-failure-preserves-scratchpad, predicted_files refresh, empty-affected-files preservation, re-drafts-on-every-prepare

### Frontend — none

All UI plumbing was already in place from #158. The Prepare button's loading state handles the 10-60s drafter latency naturally. Error display reuses the existing failure path.

## Key decisions

- **Single source of truth via bundled npm package.** The setup-work skill lives in `fusupo/escapement-pi` (already a dep at `package.json:17`), ships at `node_modules/escapement/skills/setup-work/SKILL.md`, and is read at runtime. Future skill improvements are picked up by `npm install` with no Studio code changes.
- **No separate scratchpad-planner agent in pi.** The CC scratchpad-planner methodology (codebase analysis phase, atomic task breakdown rules, ordering strategy) was folded directly into the pi setup-work skill. Pi's `createAgentSession` model is one-shot; a separate sub-session delegation would buy nothing and cost a second LLM round trip.
- **Stricter UI launch gate than backend.** Unchanged from #158 — backend still accepts `planned` as a transitional fallback, UI requires `state === \"ready\"`.
- **cwd=process.cwd()** — the drafter grep-reads the escapement-studio checkout for work items in the Studio repo (the common case). Cross-repo work items are out of scope; noted in the issue.
- **Sync, not async.** Studio UI already has a `preparingPlan` loading state. Latency is 10-60s depending on how aggressive the agent is with tool calls. Async polling is a future iteration.

## Tests

- **`npx tsc --noEmit`** — clean
- **`npx vitest run`** — **331/331** green across 22 test files (was 307/307 — +24 drafter tests, +11 new prepare-flow tests, −7 deleted carry-forward tests net +24)
- **`npx vite build --config web/vite.config.ts`** — 1.16s, only pre-existing `PlannerChatAdapter.svelte:720` a11y warning and `ExecutionDispatchPanel.svelte:931` unused-CSS warning (both unchanged from develop)

## Manual smoke

Tested on **studio-138** *(Studio: distinguish open PR and merged PR states in the graph)* in the dev server:

1. First click of Prepare plan: agent session ran for ~3:17 (23.7 KB prompt, real tool use — the agent was reading files and grepping), then returned a valid JSON envelope with a 6-word preamble. The parser's strictness caught it — surfaced as a clean error in the UI, work item stayed `planned`.
2. After the parser leniency fix: second click succeeded end-to-end. Scratchpad now contains real drafted content (Summary, Acceptance Criteria, Implementation Plan with per-task files/why/testing, refined Affected Files, Technical Notes, open Questions), work item transitioned to `drafting`, Review plan modal renders the drafted content. No stub placeholders remain.

## Out of scope (deferred)

- Streaming drafted content into the scratchpad as the agent runs
- Cross-repo work items (drafter uses `process.cwd()` which is the escapement-studio checkout)
- Async drafting with polling
- Plan history / supersedence (each prepare overwrites the prior draft)
- Edit-in-place in the Review modal
- Auto-approving after drafting (Approve still requires an explicit click)

## Test plan

- [ ] CI green (tsc + vitest + vite build on PR branch)
- [ ] Manual smoke on a planned work item (already verified on studio-138 locally post-parser-fix)
- [ ] Retry Prepare on a work item that is already in `drafting` — verify the drafter is called again and the scratchpad is overwritten with fresh content
- [ ] Hit Prepare on a work item in a rejected state (e.g. `done`) — verify the precondition check fires before the drafter is called
- [ ] Verify Review plan modal renders the drafted `## Technical Notes` section correctly