### PR TITLE
[#132] Studio: surface pi model selection in the Settings panel

### DIFF
--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,11 +1,12 @@
 import { forwardRef, Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
+import { SettingsModule } from "../settings/settings.module.js";
 import { ExecutionController } from "./execution.controller.js";
 import { ExecutionService } from "./execution.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), GitHubModule],
+  imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
   controllers: [ExecutionController],
   providers: [ExecutionService],
   exports: [ExecutionService],

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -22,6 +22,7 @@ import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-w
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
+import { SettingsService } from "../settings/settings.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
   ActivityLogEntry,
@@ -75,6 +76,7 @@ export class ExecutionService {
     @Inject(GraphService) private readonly graphService: GraphService,
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(SettingsService) private readonly settingsService: SettingsService,
   ) {
     this.githubService.registerPullRequestTruthRefresher((pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options));
   }
@@ -713,6 +715,7 @@ export class ExecutionService {
       cwd: run.worktree_path,
       sessionManager: SessionManager.inMemory(run.worktree_path),
       tools: createCodingTools(run.worktree_path),
+      model: this.settingsService.getSelectedModel(),
     });
 
     if (modelFallbackMessage) {
@@ -982,6 +985,7 @@ export class ExecutionService {
       cwd: run.worktree_path,
       sessionManager: SessionManager.inMemory(run.worktree_path),
       tools: createCodingTools(run.worktree_path),
+      model: this.settingsService.getSelectedModel(),
     });
 
     if (modelFallbackMessage) {

--- a/src/modules/planning/__tests__/planning.service.test.ts
+++ b/src/modules/planning/__tests__/planning.service.test.ts
@@ -52,6 +52,7 @@ function makePlanningService(createdIssues: CreatedIssue[]) {
     {} as never,
     { createIssue } as never,
     {} as never,
+    {} as never,
   );
 
   (service as any).currentTurnId = "turn_0001";

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
+import { SettingsModule } from "../settings/settings.module.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { PlanningController } from "./planning.controller.js";
@@ -9,7 +10,7 @@ import { SubAgentService } from "./sub-agent.service.js";
 import { ReconciliationModule } from "../reconciliation/reconciliation.module.js";
 
 @Module({
-  imports: [GraphModule, GitHubModule, ReconciliationModule],
+  imports: [GraphModule, GitHubModule, ReconciliationModule, SettingsModule],
   controllers: [PlanningController],
   providers: [PlanningService, ContextService, MemoryService, SubAgentService],
   exports: [PlanningService, ContextService, MemoryService, SubAgentService],

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -22,6 +22,7 @@ import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 import { ReconciliationService } from "../reconciliation/reconciliation.service.js";
+import { SettingsService } from "../settings/settings.service.js";
 import type {
   ApproveGitHubSyncDto,
   ApproveMutationProposalDto,
@@ -85,6 +86,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     @Inject(SubAgentService) private readonly subAgentService: SubAgentService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(ReconciliationService) private readonly reconciliationService: ReconciliationService,
+    @Inject(SettingsService) private readonly settingsService: SettingsService,
   ) {}
 
   async onModuleInit() {
@@ -296,6 +298,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd: process.cwd(),
       sessionManager: SessionManager.continueRecent(process.cwd(), this.sessionDir),
+      model: this.settingsService.getSelectedModel(),
       customTools: [
         this.createGraphQueryTool(),
         this.createProposeMutationsTool(),

--- a/src/modules/planning/sub-agent.service.ts
+++ b/src/modules/planning/sub-agent.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Injectable, Inject, Logger } from "@nestjs/common";
 import {
   createAgentSession,
   createBashTool,
@@ -18,6 +18,7 @@ import type {
   SubAgentRunStatus,
   SubAgentType,
 } from "./types.js";
+import { SettingsService } from "../settings/settings.service.js";
 
 interface RunHooks {
   onStatus?: (run: SubAgentRunRecord) => void;
@@ -30,6 +31,10 @@ export class SubAgentService {
   private readonly artifactRoot = resolve(getConfig().artifactRoot);
   private readonly recentRuns: SubAgentRunRecord[] = [];
   private readonly recentRunLimit = 12;
+
+  constructor(
+    @Inject(SettingsService) private readonly settingsService: SettingsService,
+  ) {}
 
   listRecentRuns(): SubAgentRunRecord[] {
     return [...this.recentRuns].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
@@ -66,6 +71,7 @@ export class SubAgentService {
       const { session, modelFallbackMessage } = await createAgentSession({
         cwd: process.cwd(),
         sessionManager: SessionManager.inMemory(process.cwd()),
+        model: this.settingsService.getSelectedModel(),
         tools: [
           createReadTool(process.cwd()),
           createBashTool(process.cwd()),

--- a/src/modules/plans/__tests__/plan-drafter.service.test.ts
+++ b/src/modules/plans/__tests__/plan-drafter.service.test.ts
@@ -73,6 +73,9 @@ function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
 
 function makeService(): PlanDrafterService {
   const service = Object.create(PlanDrafterService.prototype) as PlanDrafterService;
+  (service as unknown as { settingsService: { getSelectedModel: () => undefined } }).settingsService = {
+    getSelectedModel: () => undefined,
+  };
   (service as unknown as { logger: { log: (m: string) => void; warn: (m: string) => void; error: (m: string) => void; debug: (m: string) => void } }).logger = {
     log: () => {},
     warn: () => {},

--- a/src/modules/plans/plan-drafter.service.ts
+++ b/src/modules/plans/plan-drafter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Inject, Logger } from "@nestjs/common";
 import {
   createAgentSession,
   createBashTool,
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import type { WorkItemRecord } from "../graph/types.js";
 import type { PlanDraftEnvelope, PlanDraftTask, PlanDraftTechnicalNotes } from "./types.js";
+import { SettingsService } from "../settings/settings.service.js";
 
 /**
  * ADR 014 step 8 follow-up (#167) — auto-draft the plan scratchpad via a
@@ -28,6 +29,10 @@ import type { PlanDraftEnvelope, PlanDraftTask, PlanDraftTechnicalNotes } from "
 @Injectable()
 export class PlanDrafterService {
   private readonly logger = new Logger(PlanDrafterService.name);
+
+  constructor(
+    @Inject(SettingsService) private readonly settingsService: SettingsService,
+  ) {}
 
   /**
    * Run a one-shot drafting session for a work item. Returns the parsed
@@ -49,6 +54,7 @@ export class PlanDrafterService {
     const { session, modelFallbackMessage } = await createAgentSession({
       cwd,
       sessionManager: SessionManager.inMemory(cwd),
+      model: this.settingsService.getSelectedModel(),
       tools: [
         createReadTool(cwd),
         createGrepTool(cwd),

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
+import { SettingsModule } from "../settings/settings.module.js";
 import { PlanDrafterService } from "./plan-drafter.service.js";
 import { PlansController } from "./plans.controller.js";
 import { PlansService } from "./plans.service.js";
@@ -13,7 +14,7 @@ import { PlansService } from "./plans.service.js";
  * PlansModule, so no forwardRef cycles.
  */
 @Module({
-  imports: [GraphModule, GitHubModule],
+  imports: [GraphModule, GitHubModule, SettingsModule],
   controllers: [PlansController],
   providers: [PlansService, PlanDrafterService],
   exports: [PlansService, PlanDrafterService],

--- a/src/modules/settings/model-registry.service.ts
+++ b/src/modules/settings/model-registry.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ModelRegistry, AuthStorage } from "@mariozechner/pi-coding-agent";
+import type { Api, Model } from "@mariozechner/pi-ai";
+
+export interface ModelInfo {
+  provider: string;
+  id: string;
+  name: string;
+  reasoning: boolean;
+  contextWindow: number;
+  available: boolean;
+}
+
+/**
+ * Wraps pi-coding-agent's ModelRegistry as a NestJS singleton.
+ * Exposes available models for the settings UI and resolves
+ * persisted model selections to Model instances.
+ */
+@Injectable()
+export class ModelRegistryService {
+  private readonly logger = new Logger(ModelRegistryService.name);
+  private registry: ModelRegistry;
+
+  constructor() {
+    try {
+      const authStorage = AuthStorage.create();
+      this.registry = ModelRegistry.create(authStorage);
+      const error = this.registry.getError();
+      if (error) {
+        this.logger.warn(`ModelRegistry loaded with warnings: ${error}`);
+      }
+    } catch (err) {
+      this.logger.error(`Failed to create ModelRegistry: ${err}`);
+      // Create an in-memory fallback so the service doesn't crash
+      const authStorage = AuthStorage.inMemory();
+      this.registry = ModelRegistry.inMemory(authStorage);
+    }
+  }
+
+  /**
+   * List all models with availability info for the frontend.
+   */
+  listModels(): ModelInfo[] {
+    const all = this.registry.getAll();
+    return all.map((m) => ({
+      provider: m.provider,
+      id: m.id,
+      name: m.name,
+      reasoning: m.reasoning,
+      contextWindow: m.contextWindow,
+      available: this.registry.hasConfiguredAuth(m),
+    }));
+  }
+
+  /**
+   * Find and return a Model instance by provider + modelId.
+   * Returns undefined if the model is not in the registry.
+   */
+  find(provider: string, modelId: string): Model<Api> | undefined {
+    return this.registry.find(provider, modelId);
+  }
+}

--- a/src/modules/settings/settings.controller.ts
+++ b/src/modules/settings/settings.controller.ts
@@ -1,9 +1,13 @@
 import { Body, Controller, Get, Inject, Put } from "@nestjs/common";
 import { SettingsService, type SettingsUpdate } from "./settings.service.js";
+import { ModelRegistryService } from "./model-registry.service.js";
 
 @Controller("api/settings")
 export class SettingsController {
-  constructor(@Inject(SettingsService) private readonly settings: SettingsService) {}
+  constructor(
+    @Inject(SettingsService) private readonly settings: SettingsService,
+    @Inject(ModelRegistryService) private readonly modelRegistry: ModelRegistryService,
+  ) {}
 
   @Get()
   getSettings() {
@@ -13,5 +17,10 @@ export class SettingsController {
   @Put()
   updateSettings(@Body() body: SettingsUpdate) {
     return this.settings.updateSettings(body);
+  }
+
+  @Get("models")
+  getAvailableModels() {
+    return this.modelRegistry.listModels();
   }
 }

--- a/src/modules/settings/settings.module.ts
+++ b/src/modules/settings/settings.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { GraphModule } from "../graph/graph.module.js";
+import { ModelRegistryService } from "./model-registry.service.js";
 import { SettingsController } from "./settings.controller.js";
 import { SettingsService } from "./settings.service.js";
 
 @Module({
   imports: [GraphModule],
   controllers: [SettingsController],
-  providers: [SettingsService],
-  exports: [SettingsService],
+  providers: [SettingsService, ModelRegistryService],
+  exports: [SettingsService, ModelRegistryService],
 })
 export class SettingsModule {}

--- a/src/modules/settings/settings.service.ts
+++ b/src/modules/settings/settings.service.ts
@@ -1,16 +1,24 @@
 import { Inject, Injectable } from "@nestjs/common";
+import type { Api, Model } from "@mariozechner/pi-ai";
 import { SQLiteService } from "../graph/sqlite.service.js";
 import { getConfig } from "../../config.js";
+import { ModelRegistryService } from "./model-registry.service.js";
 
 export interface RepoSettings {
   default_branch: string;
   included: boolean;
 }
 
+export interface SelectedModel {
+  provider: string;
+  modelId: string;
+}
+
 export interface SettingsConfig {
   manifestPath: string;
   planningSessionDir: string;
   artifactRoot: string;
+  selectedModel: SelectedModel | null;
 }
 
 export interface SettingsPayload {
@@ -27,7 +35,10 @@ const SETTINGS_KEY = "studio_settings";
 
 @Injectable()
 export class SettingsService {
-  constructor(@Inject(SQLiteService) private readonly sqlite: SQLiteService) {}
+  constructor(
+    @Inject(SQLiteService) private readonly sqlite: SQLiteService,
+    @Inject(ModelRegistryService) private readonly modelRegistry: ModelRegistryService,
+  ) {}
 
   getSettings(): SettingsPayload {
     const db = this.sqlite.getDb();
@@ -73,6 +84,9 @@ export class SettingsService {
       if (payload.config.artifactRoot !== undefined) {
         current.config.artifactRoot = payload.config.artifactRoot;
       }
+      if (payload.config.selectedModel !== undefined) {
+        current.config.selectedModel = payload.config.selectedModel;
+      }
     }
 
     const db = this.sqlite.getDb();
@@ -82,6 +96,17 @@ export class SettingsService {
     ).run(SETTINGS_KEY, JSON.stringify(current));
 
     return current;
+  }
+
+  /**
+   * Resolve the persisted model selection to a pi-ai Model instance.
+   * Returns undefined when no model is selected or the selection doesn't
+   * match any model in the registry — callers should let pi use its default.
+   */
+  getSelectedModel(): Model<Api> | undefined {
+    const { config } = this.getSettings();
+    if (!config.selectedModel) return undefined;
+    return this.modelRegistry.find(config.selectedModel.provider, config.selectedModel.modelId);
   }
 
   /**
@@ -135,6 +160,7 @@ export class SettingsService {
         manifestPath: appConfig.manifestPath,
         planningSessionDir: appConfig.planningSessionDir,
         artifactRoot: appConfig.artifactRoot,
+        selectedModel: null,
       },
     };
   }
@@ -147,6 +173,7 @@ export class SettingsService {
         manifestPath: stored.config?.manifestPath ?? defaults.config.manifestPath,
         planningSessionDir: stored.config?.planningSessionDir ?? defaults.config.planningSessionDir,
         artifactRoot: stored.config?.artifactRoot ?? defaults.config.artifactRoot,
+        selectedModel: stored.config?.selectedModel ?? defaults.config.selectedModel,
       },
     };
   }

--- a/web/src/components/SettingsPanel.svelte
+++ b/web/src/components/SettingsPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { getSettings, updateSettings } from "../lib/api.js";
+  import { getSettings, updateSettings, getAvailableModels } from "../lib/api.js";
 
   export let health = null;
 
@@ -17,6 +17,11 @@
   let newRepoSlug = "";
   let newRepoBranch = "main";
 
+  // Model selection state
+  let availableModels = [];
+  let modelsLoadError = "";
+  let selectedModelKey = ""; // "" means use pi default; otherwise "provider::modelId"
+
   onMount(async () => {
     await load();
   });
@@ -27,11 +32,52 @@
     try {
       settings = await getSettings();
       syncEditState();
+      await loadModels();
     } catch (loadError) {
       error = loadError.message;
     } finally {
       loading = false;
     }
+  }
+
+  async function loadModels() {
+    modelsLoadError = "";
+    try {
+      availableModels = await getAvailableModels();
+    } catch (err) {
+      modelsLoadError = err.message;
+      availableModels = [];
+    }
+  }
+
+  $: modelsByProvider = groupModelsByProvider(availableModels);
+  $: selectedModelInfo = findModelInfo(availableModels, selectedModelKey);
+  $: selectedModelUnavailable =
+    selectedModelKey && selectedModelInfo && !selectedModelInfo.available;
+  $: selectedModelMissing =
+    selectedModelKey && !selectedModelInfo && availableModels.length > 0;
+
+  function groupModelsByProvider(models) {
+    const groups = new Map();
+    for (const m of models) {
+      if (!groups.has(m.provider)) groups.set(m.provider, []);
+      groups.get(m.provider).push(m);
+    }
+    const sorted = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+    for (const [, list] of sorted) {
+      list.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return sorted;
+  }
+
+  function findModelInfo(models, key) {
+    if (!key) return null;
+    const [provider, id] = key.split("::");
+    return models.find((m) => m.provider === provider && m.id === id) ?? null;
+  }
+
+  function modelKey(provider, id) {
+    return `${provider}::${id}`;
   }
 
   function syncEditState() {
@@ -40,6 +86,20 @@
       .map(([slug, info]) => ({ slug, ...info }))
       .sort((a, b) => a.slug.localeCompare(b.slug));
     editConfig = { ...settings.config };
+    selectedModelKey = editConfig.selectedModel
+      ? modelKey(editConfig.selectedModel.provider, editConfig.selectedModel.modelId)
+      : "";
+  }
+
+  function onModelChange(event) {
+    const value = event.target.value;
+    selectedModelKey = value;
+    if (!value) {
+      editConfig = { ...editConfig, selectedModel: null };
+      return;
+    }
+    const [provider, modelId] = value.split("::");
+    editConfig = { ...editConfig, selectedModel: { provider, modelId } };
   }
 
   async function save() {
@@ -147,6 +207,51 @@
               <span class="status-pill" class:healthy={health.db.hasSchema}>{health.db.hasSchema ? "Yes" : "No"}</span>
             </span>
           </div>
+        {/if}
+      </div>
+    </section>
+
+    <!-- Model selection -->
+    <section class="settings-section">
+      <h2>Model</h2>
+      <p class="muted">Choose which pi-backed model Studio uses for planning, execution, and plan drafting. Leave on <em>Default</em> to let pi pick the first available model.</p>
+      <div class="settings-card">
+        {#if modelsLoadError}
+          <div class="banner error inline-banner">Failed to load models: {modelsLoadError}</div>
+        {/if}
+        <div class="settings-row">
+          <span class="settings-label">Current</span>
+          <span class="settings-value">
+            {#if selectedModelInfo}
+              <code>{selectedModelInfo.provider} / {selectedModelInfo.name}</code>
+              {#if !selectedModelInfo.available}
+                <span class="status-pill" style="margin-left: 0.5rem;">No auth configured</span>
+              {/if}
+            {:else if selectedModelMissing}
+              <code>{editConfig.selectedModel?.provider} / {editConfig.selectedModel?.modelId}</code>
+              <span class="status-pill" style="margin-left: 0.5rem;">Not in registry</span>
+            {:else}
+              <em class="muted">Default (pi first-available)</em>
+            {/if}
+          </span>
+        </div>
+        <label>
+          Model
+          <select value={selectedModelKey} on:change={onModelChange} disabled={availableModels.length === 0}>
+            <option value="">— Use default —</option>
+            {#each modelsByProvider as [provider, models]}
+              <optgroup label={provider}>
+                {#each models as m}
+                  <option value={modelKey(m.provider, m.id)}>
+                    {m.name}{m.available ? "" : " (no auth)"}
+                  </option>
+                {/each}
+              </optgroup>
+            {/each}
+          </select>
+        </label>
+        {#if selectedModelUnavailable}
+          <p class="muted"><strong>Warning:</strong> The selected model has no configured auth. Studio will fall back to pi's default model until credentials are configured.</p>
         {/if}
       </div>
     </section>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -294,3 +294,7 @@ export function discoverSettingsRepo(path) {
   const query = new URLSearchParams({ path });
   return request(`/api/settings/repos/discover?${query.toString()}`);
 }
+
+export function getAvailableModels() {
+  return request("/api/settings/models");
+}


### PR DESCRIPTION
## Summary
Good — the scratchpad is gitignored as expected. All work is complete.

## Final Summary

### What I changed

**Backend (TypeScript / NestJS):**
1. **`src/modules/settings/model-registry.service.ts`** *(new)* — NestJS singleton wrapping pi-coding-agent's `ModelRegistry.create(AuthStorage.create())`. Exposes `listModels()` → `{ provider, id, name, reasoning, contextWindow, available }[]` and a `find()` passthrough. Falls back to `ModelRegistry.inMemory` if the pi agent dir is unreadable.
2. **`src/modules/settings/settings.controller.ts`** — Added `GET /api/settings/models` endpoint.
3. **`src/modules/settings/settings.module.ts`** — Registered & exported `ModelRegistryService`.
4. **`src/modules/settings/settings.service.ts`** — Added `SelectedModel` interface and `selectedModel: SelectedModel | null` field on `SettingsConfig`. `mergeWithDefaults` gracefully handles the new field for existing installs. New `getSelectedModel()` resolves the persisted pair via `ModelRegistryService.find()`, returning `undefined` when missing (graceful fallback to pi default).
5. **`src/modules/execution/execution.service.ts`** + **module** — Injected `SettingsService`, passed `model` into both `createAgentSession` call sites; `ExecutionModule` now imports `SettingsModule`.
6. **`src/modules/planning/planning.service.ts`** + **module** — Same treatment for the planner session.
7. **`src/modules/planning/sub-agent.service.ts`** — Added constructor injection; passes `model` into the sub-agent's `createAgentSession`.
8. **`src/modules/plans/plan-drafter.service.ts`** + **plans module** — Same treatment for the auto-drafter.
9. **Tests** — `planning.service.test.ts` updated with an extra mock arg; `plan-drafter.service.test.ts` `makeService()` stubs `settingsService.getSelectedModel()` to `undefined`.

**Frontend (Svelte):**
10. **`web/src/lib/api.js`** — Added `getAvailableModels()` helper hitting `/api/settings/models`.
11. **`web/src/components/SettingsPanel.svelte`** — New "Model" section between Server and Configuration with:
   - Current model display (provider/name or "Default")
   - Provider-grouped `<select>` with "— Use default —" option
   - "No auth configured" pill when selected model lacks auth
   - "Not in registry" pill for stale selections
   - Warning text on missing auth
   - Flows through the existing `editConfig` save pipeline

### Commits
- `7ed77b1` feat(settings): add ModelRegistryService and GET /api/settings/models endpoint
- `97d7396` feat(settings): add selectedModel to SettingsConfig with getSelectedModel() resolver
- `5c24a8f` feat(agents): thread selected model into createAgentSession call sites
- `1645709` feat(web): add Model selector section to SettingsPanel

### Quality checks
- ✅ `npm run check` (tsc --noEmit) — clean
- ✅ `npm run build:web` (vite build) — built in 1.24s, no warnings specific to this change
- ⚠️ `npm test` — **313 passing**, 18 failures. The failures are all in `src/__tests__/state-machine-allowlist.test.ts` and `src/modules/graph/__tests__/graph-writer.service.test.ts`, and are **pre-existing better-sqlite3 native-module binding errors** unrelated to this change. Confirmed by running the same failing suite against the stashed working tree before my commits.
- ✅ Targeted tests for touched code: `plan-drafter.service.test.ts` (22 passed), `planning.service.test.ts` (4 passed).

### Remaining blockers / follow-ups
- None. All four tasks from the implementation plan are complete and committed.
- The 18 pre-existing sqlite test failures should be tracked separately — they're a dev environment / native-module issue, not a code regression from this change.
- Optional future enhancements noted in the plan (not scoped to this issue): per-surface model selection (planning vs execution vs drafting), and an availability refresh button on the settings panel.

actual_files synced: 0 file(s).

## Context
- Work item: studio-132
- Issue: https://github.com/fusupo/escapement-studio/issues/132
- Base branch: develop
- Head branch: studio-132-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775797863930
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-132-branch
- Scope hint: Expose pi-backed model/provider selection in the Studio Settings panel and persist the chosen model for supported Studio agent flows.

## Changed files
- (not recorded)