### PR TITLE
[#172] Studio: render merged PR graph nodes distinctly from open PR nodes

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -399,15 +399,20 @@ a:hover {
 }
 
 .graph-legend .legend-swatch.merged-pr {
-  border: 1px solid rgba(214, 255, 244, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(46, 160, 143, 0.18);
+  /* Double-outline 'stamp' matching the in-graph .merged-pr-overlay +
+     .merged-pr-overlay-inner treatment: bold outer inset + thinner inner
+     inset, symmetric with `.in-progress` dashed-inset swatch. */
+  border: 1px solid rgba(230, 255, 248, 0.98);
+  box-shadow:
+    inset 0 0 0 1px rgba(57, 194, 166, 0.35),
+    0 0 0 0 transparent;
 }
 
 .graph-legend .legend-swatch.merged-pr::after {
   content: "";
   position: absolute;
-  inset: 1px;
-  border: 1px solid rgba(214, 255, 244, 0.95);
+  inset: 2px;
+  border: 1px solid rgba(230, 255, 248, 0.9);
   border-radius: 1px;
   pointer-events: none;
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -245,8 +245,8 @@ a:hover {
   --graph-frontier-glow: rgba(240, 246, 252, 0.16);
   --graph-in-progress-outline: rgba(255, 244, 214, 0.92);
   --graph-in-progress-shadow: rgba(210, 153, 34, 0.22);
-  --graph-merged-pr-outline: rgba(214, 255, 244, 0.92);
-  --graph-merged-pr-shadow: rgba(46, 160, 143, 0.28);
+  --graph-merged-pr-outline: rgba(230, 255, 248, 0.98);
+  --graph-merged-pr-shadow: rgba(57, 194, 166, 0.38);
 }
 
 /* In-progress styling uses an inset dashed outline so it remains distinct
@@ -279,34 +279,57 @@ a:hover {
   opacity: 1;
 }
 
-/* merged_pr styling uses a solid inset outline so the 'landed' signal
-   carries independent of hue and composes with frontier stripes + the
-   bottom-anchored ✓PR badge. */
+/* merged_pr styling uses a double-outline 'stamp' treatment (bold outer
+   inset stroke + thinner inner inset stroke) so the 'landed' signal is
+   obvious at normal zoom independent of hue, and composes with frontier
+   stripes + the bottom-anchored ✓PR badge. */
 .graph-canvas .node.graph-node--merged-pr,
 .graph-canvas .node[data-state="merged_pr"] {
-  filter: drop-shadow(0 0 0.3rem var(--graph-merged-pr-shadow));
+  filter: drop-shadow(0 0 0.32rem var(--graph-merged-pr-shadow));
 }
 
 .graph-canvas .node.graph-node--merged-pr .merged-pr-overlay,
 .graph-canvas .node[data-state="merged_pr"] .merged-pr-overlay {
   fill: none;
   stroke: var(--graph-merged-pr-outline);
-  stroke-width: 1.4px;
+  stroke-width: 2.1px;
   stroke-linecap: round;
-  opacity: 0.9;
+  opacity: 0.98;
+  pointer-events: none;
+}
+
+.graph-canvas .node.graph-node--merged-pr .merged-pr-overlay-inner,
+.graph-canvas .node[data-state="merged_pr"] .merged-pr-overlay-inner {
+  fill: none;
+  stroke: var(--graph-merged-pr-outline);
+  stroke-width: 1.1px;
+  stroke-linecap: round;
+  opacity: 0.88;
   pointer-events: none;
 }
 
 .graph-canvas .node.graph-node--merged-pr.selected .merged-pr-overlay,
 .graph-canvas .node[data-state="merged_pr"].selected .merged-pr-overlay {
-  stroke-width: 1.6px;
+  stroke-width: 2.25px;
   opacity: 1;
+}
+
+.graph-canvas .node.graph-node--merged-pr.selected .merged-pr-overlay-inner,
+.graph-canvas .node[data-state="merged_pr"].selected .merged-pr-overlay-inner {
+  stroke-width: 1.2px;
+  opacity: 0.96;
 }
 
 .graph-canvas .node.graph-node--merged-pr:hover .merged-pr-overlay,
 .graph-canvas .node[data-state="merged_pr"]:hover .merged-pr-overlay {
-  stroke-width: 1.55px;
+  stroke-width: 2.2px;
   opacity: 1;
+}
+
+.graph-canvas .node.graph-node--merged-pr:hover .merged-pr-overlay-inner,
+.graph-canvas .node[data-state="merged_pr"]:hover .merged-pr-overlay-inner {
+  stroke-width: 1.15px;
+  opacity: 0.95;
 }
 
 .graph-canvas .node.graph-node--frontier.graph-node--merged-pr,

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -99,7 +99,7 @@
         <div class="legend-row"><span class="legend-swatch" style="background:#56d364"></span><code>ready</code></div>
         <div class="legend-row"><span class="legend-swatch in-progress" style="background:#d29922"></span><code>in_progress</code><span class="legend-note">dashed inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#a371f7"></span><code>open_pr</code></div>
-        <div class="legend-row"><span class="legend-swatch merged-pr" style="background:#2ea08f"></span><code>merged_pr</code><span class="legend-note">solid inset</span></div>
+        <div class="legend-row"><span class="legend-swatch merged-pr" style="background:#39c2a6"></span><code>merged_pr</code><span class="legend-note">double inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#238636"></span><code>done</code></div>
         <div class="legend-row"><span class="legend-swatch frontier"></span><code>frontier</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#8b949e"></span><code>deferred</code></div>

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -7,7 +7,7 @@ const STATE_COLORS = {
   ready: "#56d364",
   in_progress: "#d29922",
   open_pr: "#a371f7",
-  merged_pr: "#2ea08f",
+  merged_pr: "#39c2a6",
   done: "#238636",
   deferred: "#8b949e",
   cancelled: "#f85149",
@@ -327,15 +327,30 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       }
 
       if (data.state === "merged_pr") {
-        const mergedInset = Math.min(2.5, width / 6, height / 6);
+        // Double-outline 'stamp' treatment: outer bold inset stroke + inner
+        // thinner inset stroke so the node reads as distinct from open_pr
+        // at normal zoom even without color (stroke pattern is shape-based).
+        const mergedOuterInset = Math.min(2.5, width / 6, height / 6);
         nodeGroup.insert("rect", "g.label")
           .attr("class", "merged-pr-overlay")
-          .attr("x", x + mergedInset)
-          .attr("y", y + mergedInset)
-          .attr("width", Math.max(0, width - mergedInset * 2))
-          .attr("height", Math.max(0, height - mergedInset * 2))
-          .attr("rx", Math.max(0, rx - mergedInset / 2))
-          .attr("ry", Math.max(0, ry - mergedInset / 2));
+          .attr("x", x + mergedOuterInset)
+          .attr("y", y + mergedOuterInset)
+          .attr("width", Math.max(0, width - mergedOuterInset * 2))
+          .attr("height", Math.max(0, height - mergedOuterInset * 2))
+          .attr("rx", Math.max(0, rx - mergedOuterInset / 2))
+          .attr("ry", Math.max(0, ry - mergedOuterInset / 2));
+
+        const mergedInnerInset = Math.min(5.5, width / 4, height / 4);
+        if (mergedInnerInset > mergedOuterInset + 1) {
+          nodeGroup.insert("rect", "g.label")
+            .attr("class", "merged-pr-overlay-inner")
+            .attr("x", x + mergedInnerInset)
+            .attr("y", y + mergedInnerInset)
+            .attr("width", Math.max(0, width - mergedInnerInset * 2))
+            .attr("height", Math.max(0, height - mergedInnerInset * 2))
+            .attr("rx", Math.max(0, rx - mergedInnerInset / 2))
+            .attr("ry", Math.max(0, ry - mergedInnerInset / 2));
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
## Task 4: Verify composition with selection, hover, frontier, in-progress

actual_files synced: 0 file(s).

## Context
- Work item: studio-172
- Issue: https://github.com/fusupo/escapement-studio/issues/172
- Base branch: develop
- Head branch: studio-172-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775799558412
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-172-branch
- Scope hint: Fix graph rendering so merged PR state has a distinct visual treatment from open PR state instead of reusing the same node styling.

## Changed files
- (not recorded)