### PR TITLE
[#174] Studio: auto-advance open_pr work items to merged_pr during GitHub truth refresh

### DIFF
--- a/src/modules/github/__tests__/github.service.test.ts
+++ b/src/modules/github/__tests__/github.service.test.ts
@@ -130,6 +130,7 @@ describe("GitHubService reconciliation", () => {
     const result = await service.readPullRequest("fusupo/escapement-studio", 70);
 
     expect(update).toHaveBeenCalledWith("studio-91", {
+      state: "merged_pr",
       meta: expect.objectContaining({
         pull_request: expect.objectContaining({
           number: 70,
@@ -142,7 +143,131 @@ describe("GitHubService reconciliation", () => {
     expect(result.reconciliation).toEqual({
       updated_work_item_ids: ["studio-91"],
       updated_run_ids: ["exec_123"],
-      work_items: [expect.objectContaining({ id: "studio-91" })],
+      work_items: [expect.objectContaining({ id: "studio-91", state: "merged_pr" })],
+    });
+  });
+
+  describe("merged PR state advancement", () => {
+    function openPrWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+      return makeWorkItem({
+        state: "open_pr",
+        meta: {
+          pull_request: {
+            number: 70,
+            url: "https://github.com/fusupo/escapement-studio/pull/70",
+            title: "Refresh cached GitHub truth",
+            is_draft: false,
+            head_ref: "studio-91-branch",
+            base_ref: "develop",
+            state: "OPEN",
+            merged_at: null,
+          },
+        },
+        ...overrides,
+      });
+    }
+
+    function buildService(workItem: WorkItemRecord) {
+      const update = vi.fn((id: string, patch: Partial<WorkItemRecord>) => {
+        expect(id).toBe(workItem.id);
+        return applyPatch(workItem, patch);
+      });
+      const service = new GitHubService({ getDb: () => ({}) } as any, {
+        listByRepoPullRequestNumber: vi.fn(() => []),
+        listByRepoBranch: vi.fn(() => [workItem]),
+        update,
+      } as any);
+      service.registerPullRequestTruthRefresher(() => ({ updated_run_ids: [] }));
+      return { service, update };
+    }
+
+    function mockMergedPr(service: GitHubService, mergedAt: string | null) {
+      (service as any).runGhJson = vi.fn().mockResolvedValue({
+        number: 70,
+        url: "https://github.com/fusupo/escapement-studio/pull/70",
+        title: "Refresh cached GitHub truth",
+        body: "PR body",
+        state: mergedAt ? "MERGED" : "OPEN",
+        isDraft: false,
+        baseRefName: "develop",
+        headRefName: "studio-91-branch",
+        mergedAt,
+        mergeCommit: mergedAt ? { oid: "abc123" } : null,
+      });
+    }
+
+    it("advances open_pr to merged_pr when the fetched PR is merged", async () => {
+      const workItem = openPrWorkItem();
+      const { service, update } = buildService(workItem);
+      mockMergedPr(service, "2026-04-09T00:00:00Z");
+
+      const result = await service.readPullRequest("fusupo/escapement-studio", 70);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      const patch = update.mock.calls[0]![1] as Partial<WorkItemRecord>;
+      expect(patch.state).toBe("merged_pr");
+      expect(result.reconciliation?.updated_work_item_ids).toEqual(["studio-91"]);
+      expect(result.reconciliation?.work_items).toHaveLength(1);
+      expect(result.reconciliation?.work_items[0]?.state).toBe("merged_pr");
+    });
+
+    it("leaves already merged_pr work items stable (idempotent)", async () => {
+      const workItem = openPrWorkItem({
+        state: "merged_pr",
+        meta: {
+          pull_request: {
+            number: 70,
+            url: "https://github.com/fusupo/escapement-studio/pull/70",
+            title: "Refresh cached GitHub truth",
+            is_draft: false,
+            head_ref: "studio-91-branch",
+            base_ref: "develop",
+            state: "MERGED",
+            merged_at: "2026-04-09T00:00:00Z",
+            merge_commit_sha: "abc123",
+          },
+        },
+      });
+      const { service, update } = buildService(workItem);
+      mockMergedPr(service, "2026-04-09T00:00:00Z");
+
+      const result = await service.readPullRequest("fusupo/escapement-studio", 70);
+
+      // Nothing changed — neither state nor PR meta — so update is not called.
+      expect(update).not.toHaveBeenCalled();
+      expect(result.reconciliation?.updated_work_item_ids).toEqual([]);
+      expect(result.reconciliation?.work_items[0]?.state).toBe("merged_pr");
+    });
+
+    it("does not rewrite work items in unrelated states to merged_pr", async () => {
+      const workItem = openPrWorkItem({ state: "in_progress" });
+      const { service, update } = buildService(workItem);
+      mockMergedPr(service, "2026-04-09T00:00:00Z");
+
+      const result = await service.readPullRequest("fusupo/escapement-studio", 70);
+
+      // PR meta still refreshes, but state must NOT be touched.
+      expect(update).toHaveBeenCalledTimes(1);
+      const patch = update.mock.calls[0]![1] as Partial<WorkItemRecord>;
+      expect(patch.state).toBeUndefined();
+      expect(patch.meta).toBeDefined();
+      expect(result.reconciliation?.work_items[0]?.state).toBe("in_progress");
+    });
+
+    it("does not change work item state when the fetched PR is not merged", async () => {
+      const workItem = openPrWorkItem();
+      const { service, update } = buildService(workItem);
+      mockMergedPr(service, null);
+
+      const result = await service.readPullRequest("fusupo/escapement-studio", 70);
+
+      // PR meta may refresh (state OPEN vs stored OPEN is already same so no change)
+      // but even if it did, no state field should be included in the patch.
+      if (update.mock.calls.length > 0) {
+        const patch = update.mock.calls[0]![1] as Partial<WorkItemRecord>;
+        expect(patch.state).toBeUndefined();
+      }
+      expect(result.reconciliation?.work_items[0]?.state).toBe("open_pr");
     });
   });
 });

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { SQLiteService } from "../graph/sqlite.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
-import type { WorkItemRecord } from "../graph/types.js";
+import type { UpdateWorkItemDto, WorkItemRecord } from "../graph/types.js";
 import type {
   GitHubIssueDetails,
   GitHubIssueAssignee,
@@ -400,12 +400,23 @@ export class GitHubService {
         }
       }
 
+      const updatePatch: UpdateWorkItemDto = { meta: nextMeta };
+      // Narrowly advance open_pr → merged_pr when GitHub truth shows the PR merged.
+      // Keep the guard strict on 'open_pr' so already-merged_pr items stay stable and
+      // unrelated states (in_progress, ready, done, ...) are never rewritten. The fuller
+      // ExecutionService.syncMergedPullRequest flow still owns runs / actual_files /
+      // archive_path / studio_post_merge_sync and remains the source of truth for those.
+      if (pullRequest.merged_at && workItem.state === "open_pr") {
+        updatePatch.state = "merged_pr";
+        changed = true;
+      }
+
       if (!changed) {
         return workItem;
       }
 
       updatedWorkItemIds.push(workItem.id);
-      return this.workItems.update(workItem.id, { meta: nextMeta });
+      return this.workItems.update(workItem.id, updatePatch);
     });
 
     const refreshResult = this.pullRequestTruthRefresher?.(pullRequest, {


### PR DESCRIPTION
## Summary
SCRATCHPAD_studio_174.md is gitignored as expected. All work is done and committed. Here is the final summary:

## Summary

### What I Changed

1. **`src/modules/github/github.service.ts`** — commit `2ee901c`
   - Imported `UpdateWorkItemDto`.
   - Inside `withPullRequestReconciliation`, refactored the work-item update from `this.workItems.update(id, { meta: nextMeta })` into an explicit `updatePatch: UpdateWorkItemDto` object and added a narrow guarded branch:
     ```ts
     if (pullRequest.merged_at && workItem.state === "open_pr") {
       updatePatch.state = "merged_pr";
       changed = true;
     }
     ```
   - This advances `open_pr → merged_pr` on GitHub-truth refresh whenever the fetched PR has `merged_at` set, while leaving all other states untouched and keeping the explicit `ExecutionService.syncMergedPullRequest` flow as the source of truth for runs / actual_files / archive_path / studio_post_merge_sync.

2. **`src/modules/github/__tests__/github.service.test.ts`** — commit `e430b59`
   - Updated the pre-existing "reconciles stale pull request truth" test to assert the new `state: "merged_pr"` on both the `update` patch and `reconciliation.work_items[0]`.
   - Added a `describe("merged PR state advancement", …)` block with four new cases covering all acceptance criteria: (a) `open_pr → merged_pr` advancement, (b) `merged_pr` idempotent/stable, (c) non-`open_pr` states (`in_progress`) never rewritten, (d) `merged_at: null` does not alter state.
   - Extracted `openPrWorkItem` / `buildService` / `mockMergedPr` helpers to keep the new tests compact.

3. **`web/src/App.svelte`** — verification only, no code change
   - Confirmed `mergeReconciledWorkItems` (lines 263–287) does a wholesale `nextById.get(item.id) ?? item` swap, so the new `state: "merged_pr"` on the reconciled work item propagates through `graph.items` and `catalog` without any UI-layer change.
   - Confirmed `merged_pr` is already fully wired into the renderer (`web/src/lib/graph.js`), legend (`GraphView.svelte`), sidebar state selector, and CSS styling.

### Checks Run

| Check | Result |
|---|---|
| `npx tsc --noEmit` | ✅ Clean |
| `npx vitest run src/modules/github/__tests__/github.service.test.ts` | ✅ 6/6 passing |
| `npx vitest run` (full suite) | ⚠️ 317 passing, 18 pre-existing failures in `graph-writer.service.test.ts` + `state-machine-allowlist.test.ts` — native better-sqlite3 binding issue in this worktree, **confirmed present with my changes stashed** (unrelated to this PR) |
| `npm run build:web` | ✅ Built successfully (warnings are pre-existing unused-CSS lints) |

### Commits

```
e430b59 test(github): cover open_pr → merged_pr advancement in PR reconciliation
2ee901c feat(github): advance open_pr → merged_pr during PR reconciliation
```

### Blockers / Follow-ups

- **None blocking this PR.**
- The 18 pre-existing vitest failures in graph-writer / state-machine-allowlist are a worktree environment issue (better-sqlite3 native binding failed to load) and should be tracked separately if they persist on CI.

Ready for PR.

actual_files synced: 0 file(s).

## Context
- Work item: studio-174
- Issue: https://github.com/fusupo/escapement-studio/issues/174
- Base branch: develop
- Head branch: studio-174-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775801526592
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-174-branch
- Scope hint: Update GitHub pull-request reconciliation so merged PR detection promotes linked work items from open_pr to merged_pr and returns the updated item to the UI.

## Changed files
- (not recorded)