### PR TITLE
[#176] Work item reconciler: derive next-action view from graph + disk + GitHub + worktree

### DIFF
--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+
+function makeRun(runId: string, overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: runId,
+    run_type: "execution",
+    work_item_id: "studio-176",
+    work_item_name: "Work item reconciler",
+    status: "completed",
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    completed_at: "2026-04-10T00:05:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/176",
+    branch: "studio-176-branch",
+    base_ref: "develop",
+    worktree_path: "/tmp/worktrees/studio-176-branch",
+    artifact_dir: `/tmp/runs/${runId}`,
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function writeRun(runsDir: string, run: ExecutionRunRecord): void {
+  const dir = join(runsDir, run.run_id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+}
+
+describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    artifactRoot = mkdtempSync(join(tmpdir(), "exec-rehydrate-"));
+    mkdirSync(join(artifactRoot, "runs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  function makeServiceWithEmptyBuffer(): ExecutionService {
+    const service = Object.create(ExecutionService.prototype) as ExecutionService;
+    (service as any).logger = { log: vi.fn(), warn: vi.fn() };
+    (service as any).artifactRoot = artifactRoot;
+    (service as any).recentRuns = [];
+    (service as any).recentRunLimit = 16;
+    return service;
+  }
+
+  it("loads completed runs from disk into recentRuns sorted newest-first", () => {
+    const runsDir = join(artifactRoot, "runs");
+    writeRun(runsDir, makeRun("run_a", { updated_at: "2026-04-01T00:00:00.000Z" }));
+    writeRun(runsDir, makeRun("run_b", { updated_at: "2026-04-03T00:00:00.000Z" }));
+    writeRun(runsDir, makeRun("run_c", { updated_at: "2026-04-02T00:00:00.000Z" }));
+
+    const service = makeServiceWithEmptyBuffer();
+    service.hydrateRecentRunsFromDisk();
+
+    expect((service as any).recentRuns.map((r: ExecutionRunRecord) => r.run_id)).toEqual([
+      "run_b",
+      "run_c",
+      "run_a",
+    ]);
+  });
+
+  it("dedupes by run_id when the in-memory buffer already has an entry", () => {
+    const runsDir = join(artifactRoot, "runs");
+    writeRun(runsDir, makeRun("run_a"));
+
+    const service = makeServiceWithEmptyBuffer();
+    (service as any).recentRuns.push(makeRun("run_a", { progress_message: "already-tracked" }));
+    service.hydrateRecentRunsFromDisk();
+
+    const runs = (service as any).recentRuns as ExecutionRunRecord[];
+    expect(runs).toHaveLength(1);
+    // In-memory entry wins — disk copy does not overwrite live state.
+    expect(runs[0].progress_message).toBe("already-tracked");
+  });
+
+  it("respects recentRunLimit and keeps the newest entries", () => {
+    const runsDir = join(artifactRoot, "runs");
+    for (let i = 0; i < 20; i += 1) {
+      writeRun(
+        runsDir,
+        makeRun(`run_${String(i).padStart(2, "0")}`, {
+          updated_at: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00.000Z`,
+        }),
+      );
+    }
+
+    const service = makeServiceWithEmptyBuffer();
+    service.hydrateRecentRunsFromDisk();
+
+    const runs = (service as any).recentRuns as ExecutionRunRecord[];
+    expect(runs).toHaveLength(16);
+    expect(runs[0].run_id).toBe("run_19");
+    expect(runs.at(-1)?.run_id).toBe("run_04");
+  });
+
+  it("is a no-op when the runs dir does not exist", () => {
+    rmSync(join(artifactRoot, "runs"), { recursive: true, force: true });
+    const service = makeServiceWithEmptyBuffer();
+    service.hydrateRecentRunsFromDisk();
+    expect((service as any).recentRuns).toEqual([]);
+  });
+});
+
+describe("ExecutionService.onModuleInit", () => {
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    artifactRoot = mkdtempSync(join(tmpdir(), "exec-onmoduleinit-"));
+    mkdirSync(join(artifactRoot, "runs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  it("runs the startup reconcile then rehydrates recentRuns", async () => {
+    const runsDir = join(artifactRoot, "runs");
+    writeRun(runsDir, makeRun("run_completed", { status: "completed" }));
+    writeRun(runsDir, makeRun("run_running", { status: "running" as ExecutionRunStatus }));
+
+    const reconcilerStub = {
+      runStartupReconcile: vi.fn(async () => ({
+        reconciled: [],
+        orphans: [],
+        summary: { total: 0, orphans_rewritten: 1, next_actions: {} as any, generated_at: "" },
+      })),
+    };
+
+    const service = Object.create(ExecutionService.prototype) as ExecutionService;
+    (service as any).logger = { log: vi.fn(), warn: vi.fn() };
+    (service as any).artifactRoot = artifactRoot;
+    (service as any).recentRuns = [];
+    (service as any).recentRunLimit = 16;
+    (service as any).workItemReconciler = reconcilerStub;
+
+    await service.onModuleInit();
+
+    expect(reconcilerStub.runStartupReconcile).toHaveBeenCalledTimes(1);
+    const runs = (service as any).recentRuns as ExecutionRunRecord[];
+    // Both runs ended up in recentRuns — the disk-rewrite of the running
+    // run is owned by runStartupReconcile (stubbed), so the raw file is
+    // untouched here. What matters for onModuleInit is that the buffer
+    // reflects whatever is on disk after that pass.
+    expect(runs.map((r) => r.run_id).sort()).toEqual(["run_completed", "run_running"]);
+  });
+
+  it("swallows reconcile errors and still rehydrates", async () => {
+    const runsDir = join(artifactRoot, "runs");
+    writeRun(runsDir, makeRun("run_completed", { status: "completed" }));
+
+    const logger = { log: vi.fn(), warn: vi.fn() };
+    const service = Object.create(ExecutionService.prototype) as ExecutionService;
+    (service as any).logger = logger;
+    (service as any).artifactRoot = artifactRoot;
+    (service as any).recentRuns = [];
+    (service as any).recentRunLimit = 16;
+    (service as any).workItemReconciler = {
+      runStartupReconcile: vi.fn(async () => {
+        throw new Error("reconciler boom");
+      }),
+    };
+
+    await service.onModuleInit();
+
+    expect(logger.warn).toHaveBeenCalled();
+    expect((service as any).recentRuns).toHaveLength(1);
+  });
+});

--- a/src/modules/execution/__tests__/run-disk-store.test.ts
+++ b/src/modules/execution/__tests__/run-disk-store.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  detectAndMarkOrphans,
+  loadRunRecordsFromDisk,
+} from "../run-disk-store.js";
+import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+
+function makeRun(runId: string, overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: runId,
+    run_type: "execution",
+    work_item_id: "studio-176",
+    work_item_name: "Work item reconciler",
+    status: "completed",
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    completed_at: "2026-04-10T00:00:00.000Z",
+    branch: "studio-176-branch",
+    base_ref: "develop",
+    worktree_path: `/tmp/worktrees/${runId}`,
+    artifact_dir: `/tmp/runs/${runId}`,
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function writeRunStatus(runsDir: string, run: ExecutionRunRecord): string {
+  const runDir = join(runsDir, run.run_id);
+  mkdirSync(runDir, { recursive: true });
+  const path = join(runDir, "status.json");
+  writeFileSync(path, JSON.stringify(run, null, 2), "utf8");
+  return path;
+}
+
+describe("loadRunRecordsFromDisk", () => {
+  let runsDir: string;
+
+  beforeEach(() => {
+    runsDir = mkdtempSync(join(tmpdir(), "run-disk-store-"));
+  });
+
+  afterEach(() => {
+    rmSync(runsDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty array when the runs root does not exist", () => {
+    expect(loadRunRecordsFromDisk(join(runsDir, "missing"))).toEqual([]);
+  });
+
+  it("loads every status.json and sorts by updated_at descending", () => {
+    writeRunStatus(runsDir, makeRun("run_a", { updated_at: "2026-04-01T00:00:00.000Z" }));
+    writeRunStatus(runsDir, makeRun("run_b", { updated_at: "2026-04-03T00:00:00.000Z" }));
+    writeRunStatus(runsDir, makeRun("run_c", { updated_at: "2026-04-02T00:00:00.000Z" }));
+
+    const records = loadRunRecordsFromDisk(runsDir);
+    expect(records.map((r) => r.run_id)).toEqual(["run_b", "run_c", "run_a"]);
+  });
+
+  it("skips directories that are missing a status.json", () => {
+    mkdirSync(join(runsDir, "empty_run"), { recursive: true });
+    writeRunStatus(runsDir, makeRun("run_ok"));
+
+    const records = loadRunRecordsFromDisk(runsDir);
+    expect(records.map((r) => r.run_id)).toEqual(["run_ok"]);
+  });
+
+  it("skips malformed JSON without throwing and warns", () => {
+    const runDir = join(runsDir, "broken_run");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "status.json"), "{not-json", "utf8");
+    writeRunStatus(runsDir, makeRun("run_ok"));
+
+    const warn = vi.fn();
+    const records = loadRunRecordsFromDisk(runsDir, { onWarn: warn });
+    expect(records.map((r) => r.run_id)).toEqual(["run_ok"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(/malformed JSON/);
+  });
+
+  it("skips records missing required fields", () => {
+    const runDir = join(runsDir, "partial");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "status.json"), JSON.stringify({ run_id: "partial" }), "utf8");
+
+    const warn = vi.fn();
+    const records = loadRunRecordsFromDisk(runsDir, { onWarn: warn });
+    expect(records).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("detectAndMarkOrphans", () => {
+  let runsDir: string;
+
+  beforeEach(() => {
+    runsDir = mkdtempSync(join(tmpdir(), "run-disk-orphan-"));
+  });
+
+  afterEach(() => {
+    rmSync(runsDir, { recursive: true, force: true });
+  });
+
+  it("leaves terminal statuses untouched", () => {
+    writeRunStatus(runsDir, makeRun("run_done", { status: "completed" }));
+    writeRunStatus(runsDir, makeRun("run_err", { status: "error" }));
+    writeRunStatus(runsDir, makeRun("run_blocked", { status: "blocked" }));
+
+    const results = detectAndMarkOrphans(runsDir);
+    expect(results).toEqual([]);
+
+    for (const id of ["run_done", "run_err", "run_blocked"]) {
+      const raw = JSON.parse(readFileSync(join(runsDir, id, "status.json"), "utf8"));
+      // Untouched — still original updated_at.
+      expect(raw.updated_at).toBe("2026-04-10T00:00:00.000Z");
+    }
+  });
+
+  it.each<ExecutionRunStatus>(["queued", "preparing", "running", "disambiguating"])(
+    "rewrites %s to error with an orphan activity_log entry",
+    (status) => {
+      writeRunStatus(runsDir, makeRun(`run_${status}`, { status }));
+
+      const results = detectAndMarkOrphans(runsDir, { now: () => "2026-04-10T05:00:00.000Z" });
+      expect(results).toHaveLength(1);
+      expect(results[0]).toMatchObject({ run_id: `run_${status}`, previous_status: status });
+
+      const raw = JSON.parse(readFileSync(join(runsDir, `run_${status}`, "status.json"), "utf8")) as ExecutionRunRecord;
+      expect(raw.status).toBe("error");
+      expect(raw.updated_at).toBe("2026-04-10T05:00:00.000Z");
+      expect(raw.progress_message).toMatch(/Orphaned by server restart/);
+      expect(raw.activity_log.at(-1)?.message).toMatch(/orphaned by server restart/);
+      expect(raw.errors?.some((e) => e.code === "orphaned_by_restart")).toBe(true);
+    },
+  );
+
+  it("is idempotent — a second call is a no-op", () => {
+    writeRunStatus(runsDir, makeRun("run_r", { status: "running" }));
+
+    const first = detectAndMarkOrphans(runsDir, { now: () => "2026-04-10T05:00:00.000Z" });
+    expect(first).toHaveLength(1);
+
+    const second = detectAndMarkOrphans(runsDir, { now: () => "2026-04-10T06:00:00.000Z" });
+    expect(second).toEqual([]);
+
+    const raw = JSON.parse(readFileSync(join(runsDir, "run_r", "status.json"), "utf8")) as ExecutionRunRecord;
+    // updated_at should still be the first rewrite timestamp.
+    expect(raw.updated_at).toBe("2026-04-10T05:00:00.000Z");
+  });
+
+  it("warns and skips malformed status files", () => {
+    const runDir = join(runsDir, "bad_run");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "status.json"), "<<<not json", "utf8");
+    writeRunStatus(runsDir, makeRun("run_ok", { status: "running" }));
+
+    const warn = vi.fn();
+    const results = detectAndMarkOrphans(runsDir, { now: () => "2026-04-10T05:00:00.000Z", onWarn: warn });
+    expect(results.map((r) => r.run_id)).toEqual(["run_ok"]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("returns an empty result when the runs dir does not exist", () => {
+    expect(detectAndMarkOrphans(join(runsDir, "missing"))).toEqual([]);
+  });
+});

--- a/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { WorkItemReconcilerController } from "../work-item-reconciler.controller.js";
+import type { WorkItemReconcilerService } from "../work-item-reconciler.service.js";
+import type { ReconciledWorkItem } from "../work-item-reconciler.types.js";
+
+function makeReconciled(id: string): ReconciledWorkItem {
+  return {
+    work_item_id: id,
+    graph_state: "in_progress",
+    latest_run: null,
+    github_pr: null,
+    worktree: null,
+    next_action: "relaunch",
+    rationale: "stub",
+  };
+}
+
+describe("WorkItemReconcilerController", () => {
+  it("returns the reconciled list from the service", async () => {
+    const reconcile = vi.fn(async () => [makeReconciled("studio-1"), makeReconciled("studio-2")]);
+    const service = { reconcile } as unknown as WorkItemReconcilerService;
+    const controller = new WorkItemReconcilerController(service);
+
+    const result = await controller.getReconciled();
+    expect(result).toHaveLength(2);
+    expect(reconcile).toHaveBeenCalledWith({});
+  });
+
+  it("forwards work_item_id filter (trimmed) to the service", async () => {
+    const reconcile = vi.fn(async () => [makeReconciled("studio-176")]);
+    const service = { reconcile } as unknown as WorkItemReconcilerService;
+    const controller = new WorkItemReconcilerController(service);
+
+    const result = await controller.getReconciled("  studio-176  ");
+    expect(result).toHaveLength(1);
+    expect(reconcile).toHaveBeenCalledWith({ work_item_id: "studio-176" });
+  });
+
+  it("omits the filter when work_item_id is blank", async () => {
+    const reconcile = vi.fn(async () => []);
+    const service = { reconcile } as unknown as WorkItemReconcilerService;
+    const controller = new WorkItemReconcilerController(service);
+
+    await controller.getReconciled("   ");
+    expect(reconcile).toHaveBeenCalledWith({});
+  });
+});

--- a/src/modules/execution/__tests__/work-item-reconciler.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  decideNextAction,
+  WorkItemReconcilerService,
+  type GitRunner,
+  type ReconcilerDiskStore,
+} from "../work-item-reconciler.service.js";
+import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+import type { ReconciledPullRequest, ReconciledWorktree } from "../work-item-reconciler.types.js";
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-176",
+    name: "Work item reconciler",
+    kind: "issue",
+    state: "in_progress",
+    repo: "fusupo/escapement-studio",
+    issue_number: 176,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/176",
+    scope_hint: null,
+    branch: "studio-176-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_176",
+    run_type: "execution",
+    work_item_id: "studio-176",
+    work_item_name: "Work item reconciler",
+    status: "completed",
+    created_at: "2026-04-10T00:00:00.000Z",
+    updated_at: "2026-04-10T00:00:00.000Z",
+    completed_at: "2026-04-10T00:05:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/176",
+    branch: "studio-176-branch",
+    base_ref: "develop",
+    worktree_path: "/tmp/worktrees/studio-176-branch",
+    artifact_dir: "/tmp/runs/exec_176",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+describe("decideNextAction (decision table)", () => {
+  const workItem = makeWorkItem();
+  const existsWorktree: ReconciledWorktree = {
+    exists: true,
+    branch: "studio-176-branch",
+    commits_ahead: 2,
+    dirty: false,
+  };
+
+  it("row 1: completed run + merged PR → close_out", () => {
+    const pr: ReconciledPullRequest = {
+      number: 200,
+      state: "MERGED",
+      merged_at: "2026-04-10T01:00:00.000Z",
+      url: "https://github.com/fusupo/escapement-studio/pull/200",
+    };
+    const result = decideNextAction({ workItem, latestRun: makeRun(), worktree: existsWorktree, githubPr: pr });
+    expect(result.nextAction).toBe("close_out");
+    expect(result.rationale).toMatch(/merged/);
+  });
+
+  it("row 2: completed run + open PR → awaiting_review", () => {
+    const pr: ReconciledPullRequest = {
+      number: 201,
+      state: "OPEN",
+      merged_at: null,
+      url: "https://github.com/fusupo/escapement-studio/pull/201",
+    };
+    const result = decideNextAction({ workItem, latestRun: makeRun(), worktree: existsWorktree, githubPr: pr });
+    expect(result.nextAction).toBe("awaiting_review");
+    expect(result.rationale).toMatch(/open/);
+  });
+
+  it("row 3: completed run + closed (not merged) PR → abandon", () => {
+    const pr: ReconciledPullRequest = {
+      number: 202,
+      state: "CLOSED",
+      merged_at: null,
+      url: "https://github.com/fusupo/escapement-studio/pull/202",
+    };
+    const result = decideNextAction({ workItem, latestRun: makeRun(), worktree: existsWorktree, githubPr: pr });
+    expect(result.nextAction).toBe("abandon");
+    expect(result.rationale).toMatch(/closed without merge/);
+  });
+
+  it("row 4: completed run + no PR + commits ahead → open_pr", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: makeRun(),
+      worktree: existsWorktree,
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("open_pr");
+    expect(result.rationale).toMatch(/2 commit/);
+  });
+
+  it("row 5: completed run + no PR + no commits ahead → none", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: makeRun(),
+      worktree: { ...existsWorktree, commits_ahead: 0 },
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("none");
+  });
+
+  it("row 6: error run → investigate", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: makeRun({
+        status: "error",
+        progress_message: "Execution failed: boom",
+      }),
+      worktree: existsWorktree,
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("investigate");
+    expect(result.rationale).toMatch(/boom/);
+  });
+
+  it("row 7a: no run on disk → relaunch", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: null,
+      worktree: existsWorktree,
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("relaunch");
+    expect(result.rationale).toMatch(/worktree exists/);
+  });
+
+  it("row 7b: non-terminal run (e.g. running) → relaunch", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: makeRun({ status: "running" as ExecutionRunStatus }),
+      worktree: existsWorktree,
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("relaunch");
+  });
+
+  it("blocked run is treated as investigate (maps to investigate row)", () => {
+    const result = decideNextAction({
+      workItem,
+      latestRun: makeRun({ status: "blocked" }),
+      worktree: existsWorktree,
+      githubPr: null,
+    });
+    expect(result.nextAction).toBe("investigate");
+  });
+});
+
+describe("WorkItemReconcilerService.reconcile", () => {
+  function makeService(stubs: {
+    workItems: WorkItemRecord[];
+    runs: ExecutionRunRecord[];
+    pr?: { state: string; number: number; url: string; merged_at: string | null } | null;
+    git?: Partial<Record<"count" | "status", string>>;
+    worktreeExists?: boolean;
+  }) {
+    const service = Object.create(WorkItemReconcilerService.prototype) as WorkItemReconcilerService;
+    const diskStore: ReconcilerDiskStore = {
+      loadRunRecords: vi.fn(() => stubs.runs),
+      detectAndMarkOrphans: vi.fn(() => []),
+    };
+    const gitRunner: GitRunner = {
+      run: vi.fn((args: string[]) => {
+        if (args[0] === "rev-list") return stubs.git?.count ?? "0\n";
+        if (args[0] === "status") return stubs.git?.status ?? "";
+        return "";
+      }),
+    };
+    const workItemsService = {
+      list: vi.fn((filters: { state?: string }) => {
+        if (filters.state === "in_progress") {
+          return stubs.workItems.filter((w) => w.state === "in_progress");
+        }
+        return stubs.workItems;
+      }),
+      get: vi.fn((id: string) => {
+        const match = stubs.workItems.find((w) => w.id === id);
+        if (!match) throw new Error("not found");
+        return match;
+      }),
+    };
+    const githubService = {
+      findPullRequestForBranch: vi.fn(async () => stubs.pr ?? null),
+    };
+
+    (service as any).logger = { log: vi.fn(), warn: vi.fn() };
+    (service as any).artifactRoot = "/tmp/artifact-root";
+    (service as any).runsDir = "/tmp/artifact-root/runs";
+    (service as any).worktreeRoot = "/tmp/artifact-root/worktrees";
+    (service as any).workItemsService = workItemsService;
+    (service as any).githubService = githubService;
+    service.diskStore = diskStore;
+    service.gitRunner = gitRunner;
+    service.pathExists = () => stubs.worktreeExists ?? false;
+
+    return { service, diskStore, gitRunner, workItemsService, githubService };
+  }
+
+  it("returns an empty array when no work items are in_progress", async () => {
+    const { service } = makeService({
+      workItems: [makeWorkItem({ state: "planned" })],
+      runs: [],
+    });
+    expect(await service.reconcile()).toEqual([]);
+  });
+
+  it("uses the stored PR on the latest run without calling gh", async () => {
+    const run = makeRun({
+      pull_request: {
+        number: 200,
+        url: "https://github.com/x/y/pull/200",
+        title: "t",
+        body: "b",
+        base_ref: "develop",
+        head_ref: "studio-176-branch",
+        is_draft: false,
+        created_at: "2026-04-10T00:00:00.000Z",
+        state: "MERGED",
+        merged_at: "2026-04-10T01:00:00.000Z",
+        merge_commit_sha: "deadbeef",
+      },
+    });
+    const { service, githubService } = makeService({ workItems: [makeWorkItem()], runs: [run], worktreeExists: true });
+
+    const reconciled = await service.reconcile();
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0].github_pr).toMatchObject({ number: 200, state: "MERGED" });
+    expect(reconciled[0].next_action).toBe("close_out");
+    expect(githubService.findPullRequestForBranch).not.toHaveBeenCalled();
+  });
+
+  it("calls GitHubService.findPullRequestForBranch when no stored PR", async () => {
+    const { service, githubService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+      pr: { number: 201, state: "OPEN", merged_at: null, url: "https://github.com/x/y/pull/201" },
+      git: { count: "2\n" },
+      worktreeExists: true,
+    });
+
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].github_pr).toMatchObject({ number: 201, state: "OPEN" });
+    expect(reconciled[0].next_action).toBe("awaiting_review");
+    expect(githubService.findPullRequestForBranch).toHaveBeenCalledWith(
+      "fusupo/escapement-studio",
+      "studio-176-branch",
+    );
+  });
+
+  it("degrades gracefully when findPullRequestForBranch throws", async () => {
+    const { service, githubService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+      git: { count: "3\n" },
+      worktreeExists: true,
+    });
+    (githubService.findPullRequestForBranch as any).mockRejectedValueOnce(new Error("gh rate limited"));
+
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].github_pr).toBeNull();
+    // With commits_ahead > 0 and no PR → open_pr
+    expect(reconciled[0].next_action).toBe("open_pr");
+  });
+
+  it("filters by single work_item_id when provided", async () => {
+    const a = makeWorkItem({ id: "studio-100" });
+    const b = makeWorkItem({ id: "studio-176" });
+    const { service, workItemsService } = makeService({
+      workItems: [a, b],
+      runs: [makeRun({ work_item_id: "studio-176" })],
+    });
+    const reconciled = await service.reconcile({ work_item_id: "studio-176" });
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0].work_item_id).toBe("studio-176");
+    expect(workItemsService.get).toHaveBeenCalledWith("studio-176");
+  });
+
+  it("relaunch row when no run recorded and worktree missing", async () => {
+    const { service } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [],
+      worktreeExists: false,
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].next_action).toBe("relaunch");
+    expect(reconciled[0].latest_run).toBeNull();
+  });
+});
+
+describe("WorkItemReconcilerService.runStartupReconcile", () => {
+  it("invokes detectOrphans then reconcile and emits a summary line", async () => {
+    const service = Object.create(WorkItemReconcilerService.prototype) as WorkItemReconcilerService;
+    const orphan = { run_id: "exec_x", previous_status: "running" as const, rewritten_at: "2026-04-10T05:00:00.000Z" };
+    const diskStore: ReconcilerDiskStore = {
+      loadRunRecords: vi.fn(() => []),
+      detectAndMarkOrphans: vi.fn(() => [orphan]),
+    };
+    const logger = { log: vi.fn(), warn: vi.fn() };
+    (service as any).logger = logger;
+    (service as any).runsDir = "/tmp/runs";
+    (service as any).workItemsService = { list: vi.fn(() => []), get: vi.fn() };
+    (service as any).githubService = { findPullRequestForBranch: vi.fn() };
+    service.diskStore = diskStore;
+    service.gitRunner = { run: vi.fn(() => "") };
+    service.pathExists = () => false;
+
+    const result = await service.runStartupReconcile();
+    expect(result.orphans).toHaveLength(1);
+    expect(result.reconciled).toHaveLength(0);
+    expect(result.summary.orphans_rewritten).toBe(1);
+    expect(logger.log).toHaveBeenCalled();
+    expect((logger.log.mock.calls[0]?.[0] ?? "") as string).toMatch(/orphan/);
+  });
+});

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -4,11 +4,13 @@ import { GraphModule } from "../graph/graph.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
 import { ExecutionController } from "./execution.controller.js";
 import { ExecutionService } from "./execution.service.js";
+import { WorkItemReconcilerController } from "./work-item-reconciler.controller.js";
+import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 
 @Module({
   imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
-  controllers: [ExecutionController],
-  providers: [ExecutionService],
-  exports: [ExecutionService],
+  controllers: [ExecutionController, WorkItemReconcilerController],
+  providers: [ExecutionService, WorkItemReconcilerService],
+  exports: [ExecutionService, WorkItemReconcilerService],
 })
 export class ExecutionModule {}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, Logger, MessageEvent } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleInit } from "@nestjs/common";
 import { createAgentSession, createCodingTools, SessionManager, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -19,6 +19,8 @@ import {
 } from "../../lib/context-layout.js";
 import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
+import { loadRunRecordsFromDisk } from "./run-disk-store.js";
+import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
@@ -54,7 +56,7 @@ import type {
 } from "./types.js";
 
 @Injectable()
-export class ExecutionService {
+export class ExecutionService implements OnModuleInit {
   private readonly logger = new Logger(ExecutionService.name);
   private readonly streamId = "execution-runs";
   private readonly eventSubject = new Subject<MessageEvent>();
@@ -77,8 +79,63 @@ export class ExecutionService {
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
+    @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
   ) {
     this.githubService.registerPullRequestTruthRefresher((pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options));
+  }
+
+  /**
+   * Issue #176: at startup, rewrite any runs left in a non-terminal
+   * status to `error` (orphaned by server restart), rehydrate
+   * `recentRuns` from disk so completed runs survive a restart, and
+   * run an initial reconcile pass to populate the derived view.
+   *
+   * This is a read-only-ish pass: the only disk mutation is the orphan
+   * rewrite, which happens before the in-memory buffer is populated.
+   * Any IO errors are logged and swallowed so a broken status file can
+   * never prevent the server from booting.
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.workItemReconciler.runStartupReconcile();
+    } catch (error) {
+      this.logger.warn(
+        `Startup reconcile failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    try {
+      this.hydrateRecentRunsFromDisk();
+    } catch (error) {
+      this.logger.warn(
+        `Failed to hydrate recentRuns from disk: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Issue #176: populate `recentRuns` from `runs/<id>/status.json` on
+   * disk, keeping the most recent `recentRunLimit` entries ordered by
+   * `updated_at` descending. Existing in-memory entries are preserved
+   * and deduplicated by `run_id` so a second call during tests is a
+   * no-op for runs already tracked.
+   *
+   * Exposed as a method (not a bare field initializer) so tests can
+   * exercise the rehydration path independently of `onModuleInit`.
+   */
+  hydrateRecentRunsFromDisk(): void {
+    const runsDir = join(this.artifactRoot, "runs");
+    const loaded = loadRunRecordsFromDisk(runsDir);
+    const existingIds = new Set(this.recentRuns.map((run) => run.run_id));
+    for (const run of loaded) {
+      if (existingIds.has(run.run_id)) continue;
+      this.recentRuns.push(run);
+      existingIds.add(run.run_id);
+    }
+    this.recentRuns.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    if (this.recentRuns.length > this.recentRunLimit) {
+      this.recentRuns.splice(this.recentRunLimit);
+    }
   }
 
   stream(): Observable<MessageEvent> {

--- a/src/modules/execution/run-disk-store.ts
+++ b/src/modules/execution/run-disk-store.ts
@@ -1,0 +1,279 @@
+import { existsSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { runsRoot } from "../../lib/context-layout.js";
+import type { ActivityLogEntry, ExecutionRunRecord, ExecutionRunStatus } from "./types.js";
+
+/**
+ * Issue #176: pure filesystem helpers for reading and rewriting execution
+ * run status files on disk.
+ *
+ * Separated from ExecutionService / WorkItemReconcilerService so that
+ *
+ *   (a) reconciler logic stays free of direct filesystem IO, and
+ *   (b) the ExecutionService startup rehydration path and the reconciler
+ *       both share the same loader / orphan-detector implementation.
+ *
+ * None of the helpers here are Nest providers — callers construct paths
+ * via `runsRoot(artifactRoot)` (from `src/lib/context-layout.ts`) and
+ * pass them in directly. This keeps unit tests free of Nest bootstrapping.
+ */
+
+const NON_TERMINAL_STATUSES: ReadonlySet<ExecutionRunStatus> = new Set<ExecutionRunStatus>([
+  "queued",
+  "preparing",
+  "disambiguating",
+  "running",
+]);
+
+/**
+ * Load every `runs/<id>/status.json` under the given runs root, newest
+ * first by `updated_at`. Malformed entries are logged to the supplied
+ * `onWarn` hook (or `console.warn` by default) and skipped without
+ * throwing — a single broken status file must not kill the whole reconcile
+ * pass.
+ *
+ * Returns an empty array when the runs root does not exist.
+ */
+export function loadRunRecordsFromDisk(
+  runsDir: string,
+  options: { onWarn?: (message: string) => void } = {},
+): ExecutionRunRecord[] {
+  if (!existsSync(runsDir)) {
+    return [];
+  }
+
+  const warn = options.onWarn ?? ((message) => console.warn(`[run-disk-store] ${message}`));
+  const records: ExecutionRunRecord[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(runsDir);
+  } catch (error) {
+    warn(`failed to read runs dir ${runsDir}: ${formatError(error)}`);
+    return [];
+  }
+
+  for (const entry of entries) {
+    const runDirPath = join(runsDir, entry);
+    const statusPath = join(runDirPath, "status.json");
+    if (!existsSync(statusPath)) {
+      continue;
+    }
+    let dirStat;
+    try {
+      dirStat = statSync(runDirPath);
+    } catch {
+      continue;
+    }
+    if (!dirStat.isDirectory()) {
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(statusPath, "utf8");
+    } catch (error) {
+      warn(`failed to read ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      warn(`malformed JSON in ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    const record = coerceRecord(parsed);
+    if (!record) {
+      warn(`status.json at ${statusPath} did not match ExecutionRunRecord shape; skipping`);
+      continue;
+    }
+
+    records.push(record);
+  }
+
+  records.sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+  return records;
+}
+
+/**
+ * Convenience wrapper: derive the canonical runs dir from `artifactRoot`
+ * and forward to `loadRunRecordsFromDisk`.
+ */
+export function loadRunRecordsForArtifactRoot(
+  artifactRoot: string,
+  options: { onWarn?: (message: string) => void } = {},
+): ExecutionRunRecord[] {
+  return loadRunRecordsFromDisk(runsRoot(artifactRoot), options);
+}
+
+export interface OrphanDetectionResult {
+  run_id: string;
+  previous_status: ExecutionRunStatus;
+  rewritten_at: string;
+}
+
+/**
+ * Scan every run directory under `runsDir` for runs left in a
+ * non-terminal status (`queued`/`preparing`/`disambiguating`/`running`)
+ * and rewrite them to `error` with an explanatory
+ * `activity_log` entry. Idempotent — calling twice is a no-op after the
+ * first pass.
+ *
+ * The rewrite uses a write-then-rename flow (`status.json.tmp` → atomic
+ * rename) so a crash mid-rewrite leaves the original status.json intact.
+ *
+ * Returns one entry per rewritten run. Malformed entries, missing
+ * status files, and unknown statuses are skipped with a warning.
+ */
+export function detectAndMarkOrphans(
+  runsDir: string,
+  options: { now?: () => string; onWarn?: (message: string) => void } = {},
+): OrphanDetectionResult[] {
+  if (!existsSync(runsDir)) {
+    return [];
+  }
+
+  const now = options.now ?? (() => new Date().toISOString());
+  const warn = options.onWarn ?? ((message) => console.warn(`[run-disk-store] ${message}`));
+  const results: OrphanDetectionResult[] = [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(runsDir);
+  } catch (error) {
+    warn(`failed to read runs dir ${runsDir}: ${formatError(error)}`);
+    return [];
+  }
+
+  for (const entry of entries) {
+    const runDirPath = join(runsDir, entry);
+    const statusPath = join(runDirPath, "status.json");
+    if (!existsSync(statusPath)) {
+      continue;
+    }
+    let dirStat;
+    try {
+      dirStat = statSync(runDirPath);
+    } catch {
+      continue;
+    }
+    if (!dirStat.isDirectory()) {
+      continue;
+    }
+
+    let raw: string;
+    try {
+      raw = readFileSync(statusPath, "utf8");
+    } catch (error) {
+      warn(`failed to read ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      warn(`malformed JSON in ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    const record = coerceRecord(parsed);
+    if (!record) {
+      warn(`status.json at ${statusPath} did not match ExecutionRunRecord shape; skipping orphan check`);
+      continue;
+    }
+
+    if (!NON_TERMINAL_STATUSES.has(record.status)) {
+      continue;
+    }
+
+    const timestamp = now();
+    const previousStatus = record.status;
+    const orphanEntry: ActivityLogEntry = {
+      timestamp,
+      kind: "status_change",
+      message: `orphaned by server restart at ${timestamp}`,
+      detail: `Run was in status "${previousStatus}" when the Studio server restarted. ` +
+        `The in-memory AgentSession and disambiguation gate are gone; the run cannot be resumed. ` +
+        `Rewriting to "error" so the reconciler can surface it.`,
+    };
+
+    const rewritten: ExecutionRunRecord = {
+      ...record,
+      status: "error",
+      updated_at: timestamp,
+      completed_at: record.completed_at ?? timestamp,
+      progress_message: `Orphaned by server restart at ${timestamp} (was "${previousStatus}").`,
+      result_summary: record.result_summary ?? `Orphaned by server restart at ${timestamp}.`,
+      activity_log: [...(record.activity_log ?? []), orphanEntry],
+      errors: [
+        ...(record.errors ?? []),
+        {
+          code: "orphaned_by_restart",
+          message: `Run was in status "${previousStatus}" when the Studio server restarted and could not be resumed.`,
+        },
+      ],
+    };
+
+    try {
+      atomicWriteJson(statusPath, rewritten);
+    } catch (error) {
+      warn(`failed to rewrite orphan status at ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    results.push({ run_id: record.run_id, previous_status: previousStatus, rewritten_at: timestamp });
+  }
+
+  return results;
+}
+
+function atomicWriteJson(path: string, value: unknown): void {
+  const tmpPath = `${path}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(value, null, 2), "utf8");
+  renameSync(tmpPath, path);
+}
+
+/**
+ * Runtime guard: the on-disk `status.json` shape must include at least
+ * the fields the reconciler and rehydration paths read. We tolerate
+ * extra fields (forward compatibility) and missing optional fields by
+ * filling them with safe defaults, but a missing `run_id` / `status` /
+ * `updated_at` / `branch` / `artifact_dir` is treated as corruption.
+ */
+function coerceRecord(raw: unknown): ExecutionRunRecord | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as Record<string, unknown>;
+
+  if (typeof record.run_id !== "string" || !record.run_id) return null;
+  if (typeof record.work_item_id !== "string" || !record.work_item_id) return null;
+  if (typeof record.status !== "string") return null;
+  if (typeof record.updated_at !== "string") return null;
+  if (typeof record.branch !== "string") return null;
+  if (typeof record.artifact_dir !== "string") return null;
+
+  const activityLog = Array.isArray(record.activity_log) ? (record.activity_log as ActivityLogEntry[]) : [];
+  const safetyChecks = Array.isArray(record.safety_checks) ? record.safety_checks : [];
+
+  // Pass through the raw parsed object with required fields verified and
+  // defaults filled for list/object fields. The cast is narrowing — we've
+  // verified the string fields above and the two array fields here.
+  return {
+    run_type: (record.run_type as ExecutionRunRecord["run_type"]) ?? "execution",
+    work_item_name: (record.work_item_name as string) ?? record.work_item_id as string,
+    created_at: (record.created_at as string) ?? (record.updated_at as string),
+    base_ref: (record.base_ref as string) ?? "",
+    worktree_path: (record.worktree_path as string) ?? "",
+    prompt: (record.prompt as string) ?? "",
+    ...record,
+    activity_log: activityLog,
+    safety_checks: safetyChecks as ExecutionRunRecord["safety_checks"],
+  } as ExecutionRunRecord;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/modules/execution/work-item-reconciler.controller.ts
+++ b/src/modules/execution/work-item-reconciler.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Inject, Query } from "@nestjs/common";
+import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
+import type { ReconciledWorkItem } from "./work-item-reconciler.types.js";
+
+/**
+ * Issue #176: exposes the reconciled work-item view.
+ *
+ * Lives under `src/modules/execution/` rather than
+ * `src/modules/graph/work-items.controller.ts` so the reconciler can pull
+ * execution-layer dependencies (run-disk-store, ExecutionService wiring)
+ * without dragging them into the graph module. The URL path is still
+ * `/api/work-items/reconciled` per the issue spec.
+ */
+@Controller("api/work-items")
+export class WorkItemReconcilerController {
+  constructor(
+    @Inject(WorkItemReconcilerService) private readonly reconciler: WorkItemReconcilerService,
+  ) {}
+
+  @Get("reconciled")
+  async getReconciled(@Query("work_item_id") workItemId?: string): Promise<ReconciledWorkItem[]> {
+    return this.reconciler.reconcile(workItemId?.trim() ? { work_item_id: workItemId.trim() } : {});
+  }
+}

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -1,0 +1,383 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import { runsRoot, worktreesRoot } from "../../lib/context-layout.js";
+import { GitHubService } from "../github/github.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { WorkItemRecord } from "../graph/types.js";
+import {
+  detectAndMarkOrphans,
+  loadRunRecordsFromDisk,
+  type OrphanDetectionResult,
+} from "./run-disk-store.js";
+import type { ExecutionRunRecord } from "./types.js";
+import type {
+  NextAction,
+  ReconcileSummary,
+  ReconciledPullRequest,
+  ReconciledWorkItem,
+  ReconciledWorktree,
+} from "./work-item-reconciler.types.js";
+
+/**
+ * Injectable git runner so unit tests can stub worktree probes without
+ * hitting the real filesystem. Production code uses `defaultGitRunner`.
+ */
+export interface GitRunner {
+  run(args: string[], options: { cwd: string }): string;
+}
+
+export const defaultGitRunner: GitRunner = {
+  run(args, { cwd }) {
+    try {
+      return execFileSync("git", args, { cwd, encoding: "utf8", maxBuffer: 1024 * 1024 * 4 });
+    } catch {
+      return "";
+    }
+  },
+};
+
+/** Minimal disk-store contract — matches the exported helpers from
+ * `run-disk-store.ts`. Parameterized so tests can stub loading. */
+export interface ReconcilerDiskStore {
+  loadRunRecords(runsDir: string): ExecutionRunRecord[];
+  detectAndMarkOrphans(runsDir: string, now?: () => string): OrphanDetectionResult[];
+}
+
+export const defaultReconcilerDiskStore: ReconcilerDiskStore = {
+  loadRunRecords(runsDir) {
+    return loadRunRecordsFromDisk(runsDir);
+  },
+  detectAndMarkOrphans(runsDir, now) {
+    return detectAndMarkOrphans(runsDir, now ? { now } : {});
+  },
+};
+
+export interface ReconcilerOptions {
+  /** Filter by a single work item id. When omitted, all `in_progress`
+   * work items are reconciled. */
+  work_item_id?: string;
+}
+
+const EMPTY_NEXT_ACTION_COUNTS: Record<NextAction, number> = {
+  open_pr: 0,
+  awaiting_review: 0,
+  close_out: 0,
+  relaunch: 0,
+  investigate: 0,
+  abandon: 0,
+  none: 0,
+};
+
+/**
+ * Issue #176: joins graph state, runs/<id>/status.json, GitHub PR truth,
+ * and worktree state into a derived "next action" view per work item.
+ *
+ * Pure derived state — no new persistent schema. All IO collaborators
+ * (WorkItemsService, GitHubService, disk-store, git runner) are injected
+ * so the decision table can be exercised in unit tests with stubs.
+ */
+@Injectable()
+export class WorkItemReconcilerService {
+  private readonly logger = new Logger(WorkItemReconcilerService.name);
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+  private readonly runsDir = runsRoot(this.artifactRoot);
+  private readonly worktreeRoot = worktreesRoot(this.artifactRoot);
+
+  /** Overridable for tests — production code uses defaults. */
+  diskStore: ReconcilerDiskStore = defaultReconcilerDiskStore;
+  gitRunner: GitRunner = defaultGitRunner;
+  /** Wrapped so tests can stub filesystem probes without reaching into node:fs. */
+  pathExists: (path: string) => boolean = (path) => existsSync(path);
+
+  constructor(
+    @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(GitHubService) private readonly githubService: GitHubService,
+  ) {}
+
+  /**
+   * Run the orphan-detection pass on disk, rewriting any
+   * non-terminal runs to `error` with an explanatory activity_log entry.
+   * Returns one entry per rewritten run.
+   *
+   * Called from ExecutionService.onModuleInit before `reconcile()` so
+   * that runs left hanging across a restart enter the decision table as
+   * terminal (`error`) records.
+   */
+  detectOrphans(): OrphanDetectionResult[] {
+    return this.diskStore.detectAndMarkOrphans(this.runsDir);
+  }
+
+  /**
+   * Join graph + disk + GitHub + worktree and produce a
+   * `ReconciledWorkItem` per `in_progress` work item (or just the one
+   * matching `options.work_item_id`).
+   *
+   * The decision table row order is preserved: earlier rows win when
+   * multiple conditions match (e.g. close_out beats awaiting_review when
+   * both a completed run and a merged PR exist).
+   */
+  async reconcile(options: ReconcilerOptions = {}): Promise<ReconciledWorkItem[]> {
+    const workItems = this.selectWorkItems(options);
+    if (workItems.length === 0) {
+      return [];
+    }
+
+    const runs = this.diskStore.loadRunRecords(this.runsDir);
+    const runsByWorkItem = new Map<string, ExecutionRunRecord[]>();
+    for (const run of runs) {
+      const list = runsByWorkItem.get(run.work_item_id) ?? [];
+      list.push(run);
+      runsByWorkItem.set(run.work_item_id, list);
+    }
+
+    const out: ReconciledWorkItem[] = [];
+    for (const workItem of workItems) {
+      const latestRun = this.pickLatestRun(runsByWorkItem.get(workItem.id) ?? []);
+      const worktree = this.probeWorktree(workItem, latestRun);
+      const githubPr = await this.probePullRequest(workItem, latestRun);
+      const { nextAction, rationale } = decideNextAction({ workItem, latestRun, worktree, githubPr });
+
+      out.push({
+        work_item_id: workItem.id,
+        graph_state: workItem.state,
+        latest_run: latestRun,
+        github_pr: githubPr,
+        worktree,
+        next_action: nextAction,
+        rationale,
+      });
+    }
+
+    return out;
+  }
+
+  /**
+   * Convenience wrapper used by the startup path: runs orphan detection,
+   * then reconciles, then emits a summary line. Returns both the
+   * reconciled list and a structured summary so callers can assert on the
+   * numbers.
+   */
+  async runStartupReconcile(): Promise<{
+    reconciled: ReconciledWorkItem[];
+    orphans: OrphanDetectionResult[];
+    summary: ReconcileSummary;
+  }> {
+    const orphans = this.detectOrphans();
+    const reconciled = await this.reconcile();
+    const summary = this.buildSummary(reconciled, orphans);
+
+    this.logger.log(
+      `Startup reconcile: ${summary.total} work item(s), ${summary.orphans_rewritten} orphan(s) rewritten, ` +
+        Object.entries(summary.next_actions)
+          .filter(([, count]) => count > 0)
+          .map(([action, count]) => `${action}=${count}`)
+          .join(" ") || "Startup reconcile: no work items to reconcile",
+    );
+
+    return { reconciled, orphans, summary };
+  }
+
+  private selectWorkItems(options: ReconcilerOptions): WorkItemRecord[] {
+    if (options.work_item_id) {
+      try {
+        const single = this.workItemsService.get(options.work_item_id);
+        return single.state === "in_progress" ? [single] : [];
+      } catch {
+        return [];
+      }
+    }
+    return this.workItemsService.list({ state: "in_progress" });
+  }
+
+  private pickLatestRun(runs: ExecutionRunRecord[]): ExecutionRunRecord | null {
+    if (runs.length === 0) return null;
+    // runs are already sorted by updated_at desc from loadRunRecordsFromDisk,
+    // but we defensively sort again in case a caller passes raw input.
+    return [...runs].sort((a, b) => b.updated_at.localeCompare(a.updated_at))[0]!;
+  }
+
+  private probeWorktree(workItem: WorkItemRecord, latestRun: ExecutionRunRecord | null): ReconciledWorktree | null {
+    const branch = latestRun?.branch ?? workItem.branch ?? null;
+    if (!branch) return null;
+
+    // Prefer the run's recorded worktree_path (absolute path), falling
+    // back to the canonical worktrees root for this artifactRoot. This
+    // lets reconciles still find the worktree even when the branch name
+    // has been sanitized.
+    const worktreePath = latestRun?.worktree_path?.trim() || this.worktreePathForBranch(branch);
+
+    if (!this.pathExists(worktreePath)) {
+      return { exists: false, branch, commits_ahead: 0, dirty: false };
+    }
+
+    const baseRef = latestRun?.base_ref?.trim() || this.defaultBaseRefForWorkItem(workItem);
+    const aheadRaw = this.gitRunner
+      .run(["rev-list", "--count", `${baseRef}..${branch}`], { cwd: worktreePath })
+      .trim();
+    const aheadParsed = Number(aheadRaw);
+    const commitsAhead = Number.isFinite(aheadParsed) ? aheadParsed : 0;
+
+    const statusRaw = this.gitRunner.run(["status", "--porcelain"], { cwd: worktreePath });
+    const dirty = statusRaw.trim().length > 0;
+
+    return { exists: true, branch, commits_ahead: commitsAhead, dirty };
+  }
+
+  private async probePullRequest(
+    workItem: WorkItemRecord,
+    latestRun: ExecutionRunRecord | null,
+  ): Promise<ReconciledPullRequest | null> {
+    // Prefer the PR already stored on the latest run — avoids a network
+    // call and matches what the run UI already shows.
+    const storedPr = latestRun?.pull_request;
+    if (storedPr && Number.isInteger(storedPr.number)) {
+      return {
+        number: storedPr.number,
+        state: storedPr.state ?? "OPEN",
+        merged_at: storedPr.merged_at ?? null,
+        url: storedPr.url,
+      };
+    }
+
+    const repo = workItem.repo ?? latestRun?.repo ?? null;
+    const branch = latestRun?.branch ?? workItem.branch ?? null;
+    if (!repo || !branch) return null;
+
+    try {
+      const found = await this.githubService.findPullRequestForBranch(repo, branch);
+      if (!found) return null;
+      return {
+        number: found.number,
+        state: found.state,
+        merged_at: found.merged_at,
+        url: found.url,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `findPullRequestForBranch failed for ${repo}#${branch}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  private worktreePathForBranch(branch: string): string {
+    const safeBranch = branch.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "execution-run";
+    return `${this.worktreeRoot}/${safeBranch}`;
+  }
+
+  private defaultBaseRefForWorkItem(_workItem: WorkItemRecord): string {
+    // The reconciler's `commits_ahead` is an informational hint — a
+    // wrong base_ref degrades to 0 (via the NaN guard) rather than a
+    // crash. The decision table only uses `commits_ahead > 0` as a
+    // tie-breaker for open_pr vs none, so "develop" is a safe default
+    // until we wire per-repo base refs through the reconciler.
+    return "develop";
+  }
+
+  private buildSummary(reconciled: ReconciledWorkItem[], orphans: OrphanDetectionResult[]): ReconcileSummary {
+    const counts: Record<NextAction, number> = { ...EMPTY_NEXT_ACTION_COUNTS };
+    for (const item of reconciled) {
+      counts[item.next_action] += 1;
+    }
+    return {
+      total: reconciled.length,
+      orphans_rewritten: orphans.length,
+      next_actions: counts,
+      generated_at: new Date().toISOString(),
+    };
+  }
+}
+
+/* ── Pure decision table — exported for unit testing ───────────────────── */
+
+export interface DecisionInputs {
+  workItem: WorkItemRecord;
+  latestRun: ExecutionRunRecord | null;
+  worktree: ReconciledWorktree | null;
+  githubPr: ReconciledPullRequest | null;
+}
+
+export interface DecisionResult {
+  nextAction: NextAction;
+  rationale: string;
+}
+
+/**
+ * Apply the #176 decision table in the exact order specified in the
+ * issue. Each branch produces a rationale string explaining which
+ * inputs drove the verdict, so operators can trace "why did the
+ * reconciler say this?" without re-running the pipeline.
+ *
+ * Row order (earliest match wins):
+ *   1. completed run + merged PR           → close_out
+ *   2. completed run + open PR             → awaiting_review
+ *   3. completed run + closed (not merged) → abandon
+ *   4. completed run + no PR + commits ahead → open_pr
+ *   5. completed run + no PR + no commits  → none
+ *   6. error run                           → investigate
+ *   7. non-terminal / missing run          → relaunch
+ */
+export function decideNextAction(inputs: DecisionInputs): DecisionResult {
+  const { latestRun, worktree, githubPr } = inputs;
+
+  if (!latestRun) {
+    const detail = worktree?.exists
+      ? `worktree exists on branch ${worktree.branch}; no run recorded on disk`
+      : "no run recorded on disk and no worktree present";
+    return {
+      nextAction: "relaunch",
+      rationale: `Work item is in_progress but ${detail}. Relaunch to create a fresh run.`,
+    };
+  }
+
+  if (latestRun.status === "completed") {
+    if (githubPr?.state === "MERGED" || githubPr?.merged_at) {
+      return {
+        nextAction: "close_out",
+        rationale: `Completed run ${latestRun.run_id} and PR #${githubPr.number} is merged. Hand off to close-out actions.`,
+      };
+    }
+    if (githubPr?.state === "OPEN") {
+      return {
+        nextAction: "awaiting_review",
+        rationale: `Completed run ${latestRun.run_id} and PR #${githubPr.number} is open. Waiting on review.`,
+      };
+    }
+    if (githubPr?.state === "CLOSED") {
+      return {
+        nextAction: "abandon",
+        rationale: `Completed run ${latestRun.run_id} but PR #${githubPr.number} was closed without merge. Investigate or abandon.`,
+      };
+    }
+    // No PR on GitHub yet.
+    const commitsAhead = worktree?.commits_ahead ?? 0;
+    if (commitsAhead > 0) {
+      return {
+        nextAction: "open_pr",
+        rationale: `Completed run ${latestRun.run_id}, no PR yet, ${commitsAhead} commit(s) ahead of base on branch ${latestRun.branch}. Ready to open PR.`,
+      };
+    }
+    return {
+      nextAction: "none",
+      rationale: `Completed run ${latestRun.run_id}, no PR, and no commits ahead of base. Nothing to do.`,
+    };
+  }
+
+  if (latestRun.status === "error" || latestRun.status === "blocked") {
+    return {
+      nextAction: "investigate",
+      rationale: `Latest run ${latestRun.run_id} ended in status "${latestRun.status}". ${latestRun.progress_message ?? "Investigate before relaunching."}`,
+    };
+  }
+
+  // Any remaining non-terminal status slips through orphan detection
+  // (e.g. a run produced by the currently-active server). Offer relaunch
+  // as the safest default — the user can inspect the live run first.
+  return {
+    nextAction: "relaunch",
+    rationale: `Latest run ${latestRun.run_id} is in status "${latestRun.status}" (non-terminal). If it is not actively running, relaunch.`,
+  };
+}

--- a/src/modules/execution/work-item-reconciler.types.ts
+++ b/src/modules/execution/work-item-reconciler.types.ts
@@ -1,0 +1,73 @@
+import type { ExecutionRunRecord } from "./types.js";
+import type { WorkItemState } from "../graph/types.js";
+
+/**
+ * Issue #176: pure derived view that joins graph state, run artifacts on
+ * disk, GitHub PR truth, and worktree state into a single "next action"
+ * verdict per work item. No new persistent schema — the reconciler loads
+ * each source on demand and the output is recomputed on every call.
+ *
+ * See docs/dev/cc-archive/.../SCRATCHPAD_studio_176.md for the decision
+ * table and orphan-detection rationale.
+ */
+export type NextAction =
+  | "open_pr" // completed run + commits ahead + no PR
+  | "awaiting_review" // completed run + open PR
+  | "close_out" // completed run + merged PR (hands off to #83-89)
+  | "relaunch" // orphaned mid-run or no run recorded
+  | "investigate" // failed run
+  | "abandon" // dead PR (closed without merge)
+  | "none"; // no action needed
+
+/** GitHub PR snapshot kept deliberately narrow — the reconciler only needs
+ * the fields that drive the decision table. Full PR details still come from
+ * `GitHubService.findPullRequestForBranch` / `readPullRequest`. */
+export interface ReconciledPullRequest {
+  number: number;
+  state: string; // "OPEN" | "CLOSED" | "MERGED" per gh
+  merged_at: string | null;
+  url: string;
+}
+
+/** Worktree probe result. `exists: false` means the directory is absent
+ * (e.g. cleaned up post-merge); in that case the other fields are
+ * reported as their empty defaults. */
+export interface ReconciledWorktree {
+  exists: boolean;
+  branch: string;
+  commits_ahead: number;
+  dirty: boolean;
+}
+
+/**
+ * Derived view of a single work item's post-run state. Pure function of
+ * the four input sources — recomputed on every `reconcile()` call.
+ *
+ * - `graph_state` mirrors `WorkItemRecord.state` at read time
+ * - `latest_run` is loaded from `runs/<id>/status.json` (disk), not from
+ *   `ExecutionService.recentRuns`; `null` when no matching run exists
+ * - `github_pr` is `null` when the work item has no branch, when the
+ *   underlying `gh` call fails, or when no PR exists for the branch
+ * - `worktree` is `null` only when no branch is known; otherwise it is a
+ *   probe result (may have `exists: false`)
+ * - `rationale` is a short human-readable string summarizing which inputs
+ *   drove the `next_action` verdict; used by the UI and startup log
+ */
+export interface ReconciledWorkItem {
+  work_item_id: string;
+  graph_state: WorkItemState;
+  latest_run: ExecutionRunRecord | null;
+  github_pr: ReconciledPullRequest | null;
+  worktree: ReconciledWorktree | null;
+  next_action: NextAction;
+  rationale: string;
+}
+
+/** Summary emitted by the startup reconcile pass. Used both by the Nest
+ * `Logger` output and, optionally, by tests that assert the log line. */
+export interface ReconcileSummary {
+  total: number;
+  orphans_rewritten: number;
+  next_actions: Record<NextAction, number>;
+  generated_at: string;
+}

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -6,6 +6,7 @@
     getRunScratchpad,
     launchExecutionRun,
     listExecutionRuns,
+    listReconciledWorkItems,
     openPullRequest,
     resolveDisambiguation,
     sendFollowUpMessage,
@@ -17,6 +18,12 @@
 
   let preview = null;
   let runs = [];
+  /**
+   * studio-176: map of work_item_id → ReconciledWorkItem (from
+   * /api/work-items/reconciled). Used to decorate run cards with a
+   * reconciled badge so post-restart cases surface prominently.
+   */
+  let reconciledByWorkItem = {};
   let loading = true;
   let refreshing = false;
   let connected = false;
@@ -124,9 +131,23 @@
     if (quiet) { refreshing = true; } else { loading = true; }
     error = "";
     try {
-      const [nextPreview, nextRuns] = await Promise.all([getExecutionPreview(), listExecutionRuns()]);
+      const [nextPreview, nextRuns, nextReconciled] = await Promise.all([
+        getExecutionPreview(),
+        listExecutionRuns(),
+        // Reconciled view is best-effort — a failure here should not take
+        // down the whole dispatch panel, so we fall back to an empty list.
+        listReconciledWorkItems().catch((err) => {
+          console.debug("listReconciledWorkItems failed", err);
+          return [];
+        }),
+      ]);
       preview = nextPreview;
       runs = nextRuns;
+      const nextMap = {};
+      for (const entry of nextReconciled || []) {
+        if (entry?.work_item_id) nextMap[entry.work_item_id] = entry;
+      }
+      reconciledByWorkItem = nextMap;
       for (const run of nextRuns) {
         if (["queued", "preparing", "running", "completed", "disambiguating"].includes(run.status) && !checklistData[run.run_id]) {
           loadChecklist(run.run_id);
@@ -433,14 +454,20 @@
         {#if runs.length > 0}
           <div class="run-pill-strip">
             {#each runs as run}
+              {@const reconciled = reconciledByWorkItem[run.work_item_id]}
+              {@const nextAction = reconciled?.next_action}
+              {@const showReconciledBadge = nextAction && ["open_pr", "relaunch", "investigate"].includes(nextAction)}
               <button
                 class="run-pill"
                 class:active={selectedRunId === run.run_id && activeSelection === "run"}
                 on:click={() => selectRun(run.run_id)}
-                title="{run.work_item_id} — {run.status}"
+                title={reconciled?.rationale || `${run.work_item_id} — ${run.status}`}
               >
                 <span class="run-pill-dot {runStatusTone(run.status)}"></span>
                 <span class="run-pill-label">{run.work_item_id}</span>
+                {#if showReconciledBadge}
+                  <span class="run-pill-next-action" data-next-action={nextAction}>{nextAction.replace("_", " ")}</span>
+                {/if}
               </button>
             {/each}
           </div>
@@ -724,6 +751,31 @@
   .run-pill-label {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  /* studio-176: reconciled next-action badge on the run pill */
+  .run-pill-next-action {
+    display: inline-flex;
+    padding: 0 5px;
+    border-radius: 2px;
+    background: rgba(37, 99, 235, 0.2);
+    color: #bfdbfe;
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+  }
+  .run-pill-next-action[data-next-action="open_pr"] {
+    background: rgba(63, 185, 80, 0.2);
+    color: #86efac;
+  }
+  .run-pill-next-action[data-next-action="investigate"] {
+    background: rgba(248, 81, 73, 0.2);
+    color: #fca5a5;
+  }
+  .run-pill-next-action[data-next-action="relaunch"] {
+    background: rgba(210, 153, 34, 0.2);
+    color: #facc15;
   }
 
   /* Workspace top (header + expandable sections, scrollable if tall) */

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -99,6 +99,19 @@ export function listExecutionRuns() {
   return request("/api/execution/runs");
 }
 
+/**
+ * studio-176: reconciled work-item view. Returns one entry per
+ * in_progress work item with a `next_action` derived from the graph,
+ * disk runs, GitHub PR state, and worktree status. Pass `work_item_id`
+ * to filter to a single item.
+ */
+export function listReconciledWorkItems({ workItemId } = {}) {
+  const query = new URLSearchParams();
+  if (workItemId) query.set("work_item_id", workItemId);
+  const search = query.toString();
+  return request(`/api/work-items/reconciled${search ? `?${search}` : ""}`);
+}
+
 export function getExecutionEligibility(params = {}) {
   const query = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {


### PR DESCRIPTION
## Summary
All tasks complete. Summary:

**Plan execution — studio-176 (Work item reconciler)**

All 8 implementation tasks checked off. Atomic commits:

1. `c9c56fd` — Reconciler types (ReconciledWorkItem, NextAction, etc.)
2. `61faa97` — `run-disk-store.ts`: pure `loadRunRecordsFromDisk` + `detectAndMarkOrphans` (13 tests)
3. `7b1eec5` — `WorkItemReconcilerService` + pure `decideNextAction` decision-table function (16 tests, one per row)
4. `a7bd176` — `WorkItemReconcilerController` registering `GET /api/work-items/reconciled` (3 tests)
5. `13e44cb` — `ExecutionService.onModuleInit` runs startup reconcile + rehydrates `recentRuns` from disk (6 tests)
6. `dc0aa10` — Web UI: dispatch panel fetches reconciled view and shows color-coded next-action badges on run pills; rationale surfaces as hover title

**Quality checks**
- `npx tsc --noEmit` — clean
- `npx vitest run src/modules/execution` — **165/165 passing** (38 new tests added across 4 new test files)
- `npx vite build --config web/vite.config.ts` — clean build
- Full-suite `npx vitest run` has 18 pre-existing failures in `graph-writer.service.test.ts` / `state-machine-allowlist.test.ts` caused by a broken better-sqlite3 native binding — verified unrelated by stashing changes and rerunning.

**Deviations from plan (documented in scratchpad work log)**
- Orphan terminal status is `error` (not `failed` — the latter isn't a valid `ExecutionRunStatus` value)
- `queued` included alongside `preparing`/`running`/`disambiguating` as non-terminal for orphan detection
- Worktree `commits_ahead` uses `develop` as a default base_ref; per-repo resolution flagged as follow-up

Ready for PR. Want me to invoke the `create-pr` skill?

## Context
- Work item: studio-176
- Issue: https://github.com/fusupo/escapement-studio/issues/176
- Base branch: develop
- Head branch: studio-176-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775849083743
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-176-branch
- Scope hint: Add a reconciler that derives next actions for work items by joining graph state, run artifacts on disk, GitHub PR/issue truth, and worktree status, including restart orphan detection.

## Changed files
- (not recorded)