### PR TITLE
[#109] Studio: add persistent status bar with graph/run stats

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1083,6 +1083,7 @@
   .status-sep {
     color: #3b4559;
     margin: 0 2px;
+    user-select: none;
   }
 
   /* ── Pane header (panel title bars) ── */

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -15,11 +15,14 @@
     createWorkItem,
     deleteEdge,
     getExecutionEligibility,
+    getFrontier,
     getGitHubIssueDetails,
     getGraph,
     getHealth,
     getPlan,
+    getReconciliationReports,
     launchExecutionRun,
+    listExecutionRuns,
     listWorkItems,
     preparePlan,
     syncMergedPullRequest,
@@ -45,6 +48,13 @@
   let launchEligibilityLoadingIds = {};
   let launchEligibilityRequestTokenById = {};
   let graphContextMenu = { open: false, x: 0, y: 0, item: null };
+
+  // Status bar data — frontier, execution runs, reconciliation reports
+  let frontierIds = [];
+  let executionRuns = [];
+  let reconciliationReports = [];
+  let lastExecutionFetchTab = null;
+  let lastReconciliationFetchTab = null;
 
   // ADR 014 step 8 — plan state + plan review modal
   let preparingPlan = false;
@@ -133,6 +143,55 @@
   };
 
   $: activeFilterCount = Object.values(filters).filter(Boolean).length;
+
+  // Status bar derived stats
+  $: frontierCount = frontierIds.length;
+  $: blockedCount = (() => {
+    const frontierSet = new Set(frontierIds);
+    return graph.items.filter((item) => item.state === "planned" && !frontierSet.has(item.id)).length;
+  })();
+
+  $: activeRunCount = executionRuns.filter(
+    (r) => ["queued", "preparing", "running", "disambiguating"].includes(r.status)
+  ).length;
+  $: completedTodayCount = (() => {
+    const todayPrefix = new Date().toISOString().slice(0, 10);
+    return executionRuns.filter(
+      (r) => r.status === "completed" && r.completed_at?.startsWith(todayPrefix)
+    ).length;
+  })();
+  $: successRate = (() => {
+    const completed = executionRuns.filter((r) => r.status === "completed").length;
+    const errored = executionRuns.filter((r) => r.status === "error").length;
+    const total = completed + errored;
+    return total > 0 ? Math.round((completed / total) * 100) : null;
+  })();
+
+  $: readyToMergeCount = Array.isArray(reconciliationReports)
+    ? reconciliationReports.filter((r) => {
+        const stats = r.stats || {};
+        return stats.missed_count === 0 && stats.unpredicted_count === 0;
+      }).length
+    : 0;
+  $: conflictsCount = Array.isArray(reconciliationReports)
+    ? reconciliationReports.filter((r) => (r.stats?.missed_count ?? 0) > 0 || (r.stats?.unpredicted_count ?? 0) > 0).length
+    : 0;
+  $: staleCount = Array.isArray(reconciliationReports)
+    ? reconciliationReports.filter((r) => (r.drift_patterns?.length ?? 0) > 0).length
+    : 0;
+
+  // Fetch tab-specific data when tab changes
+  $: if (activeTab === "planning") {
+    void loadFrontier();
+  }
+  $: if (activeTab === "execute" && lastExecutionFetchTab !== "execute") {
+    lastExecutionFetchTab = "execute";
+    void loadExecutionStats();
+  }
+  $: if (activeTab === "reconciliation" && lastReconciliationFetchTab !== "reconciliation") {
+    lastReconciliationFetchTab = "reconciliation";
+    void loadReconciliationStats();
+  }
   $: if (selectedItem?.id) {
     void ensureLaunchEligibility(selectedItem.id);
   }
@@ -256,8 +315,37 @@
     }
   }
 
+  async function loadFrontier() {
+    try {
+      const repo = filters.repo || undefined;
+      const frontier = await getFrontier(repo ? { repo } : {});
+      frontierIds = Array.isArray(frontier) ? frontier.map((item) => item.id) : [];
+    } catch {
+      frontierIds = [];
+    }
+  }
+
+  async function loadExecutionStats() {
+    try {
+      executionRuns = await listExecutionRuns();
+    } catch {
+      executionRuns = [];
+    }
+  }
+
+  async function loadReconciliationStats() {
+    try {
+      reconciliationReports = await getReconciliationReports();
+    } catch {
+      reconciliationReports = [];
+    }
+  }
+
   async function refresh() {
     await loadGraph();
+    if (activeTab === "planning") void loadFrontier();
+    if (activeTab === "execute") void loadExecutionStats();
+    if (activeTab === "reconciliation") void loadReconciliationStats();
   }
 
   function mergeReconciledWorkItems(workItems = []) {
@@ -673,6 +761,7 @@
                   {selectedId}
                   onSelect={handleGraphSelect}
                   onContextMenu={handleGraphContextMenu}
+                  externalFrontierIds={frontierIds}
                 />
               {/if}
             </div>
@@ -816,11 +905,32 @@
         {#if activeTab === "planning"}
           <span class="status-sep">|</span>
           <span class="status-text">{graph.items.length} items</span>
+          <span class="status-sep">·</span>
           <span class="status-text">{graph.edges.length} edges</span>
+          <span class="status-sep">·</span>
+          <span class="status-text">{frontierCount} frontier</span>
+          <span class="status-sep">·</span>
+          <span class="status-text">{blockedCount} blocked</span>
           {#if activeFilterCount > 0}
             <span class="status-sep">|</span>
             <span class="status-text">{activeFilterCount} filter{activeFilterCount > 1 ? "s" : ""} active</span>
           {/if}
+        {:else if activeTab === "execute"}
+          <span class="status-sep">|</span>
+          <span class="status-text">{activeRunCount} active run{activeRunCount !== 1 ? "s" : ""}</span>
+          <span class="status-sep">·</span>
+          <span class="status-text">{completedTodayCount} completed today</span>
+          {#if successRate !== null}
+            <span class="status-sep">·</span>
+            <span class="status-text">{successRate}% success rate</span>
+          {/if}
+        {:else if activeTab === "reconciliation"}
+          <span class="status-sep">|</span>
+          <span class="status-text">{readyToMergeCount} ready to merge</span>
+          <span class="status-sep">·</span>
+          <span class="status-text">{conflictsCount} conflict{conflictsCount !== 1 ? "s" : ""}</span>
+          <span class="status-sep">·</span>
+          <span class="status-text">{staleCount} stale</span>
         {/if}
       </div>
       <div class="status-bar-right">

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -6,6 +6,7 @@
   export let selectedId = null;
   export let onSelect = () => {};
   export let onContextMenu = () => {};
+  export let externalFrontierIds = null; // optional: pass frontier IDs from parent to avoid duplicate fetch
 
   let svg;
   let handle = { cleanup() {}, updateSelection() {}, resize() {} };
@@ -25,6 +26,9 @@
   }
 
   async function loadFrontier(currentGraph) {
+    // Skip self-fetch when parent provides frontier IDs
+    if (externalFrontierIds !== null) return;
+
     const token = ++frontierLookupToken;
     frontierIds = [];
     frontierSignature = "";
@@ -55,7 +59,14 @@
     }
   }
 
-  $: void loadFrontier(graph);
+  // When parent provides frontier IDs, use those instead of self-fetching
+  $: if (externalFrontierIds !== null) {
+    const visibleIds = new Set(graph.items.map((item) => item.id));
+    frontierIds = externalFrontierIds.filter((id) => visibleIds.has(id)).sort();
+    frontierSignature = frontierIds.join("|");
+  }
+
+  $: if (externalFrontierIds === null) void loadFrontier(graph);
 
   // Mount + graph/frontier data changes → full re-layout
   $: if (svg && graph) {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -224,6 +224,18 @@ export function getReconciliationReports(params = {}) {
   return request(`/api/reconciliation/reports${search ? `?${search}` : ""}`);
 }
 
+export function getFrontier(params = {}) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value) {
+      query.set(key, value);
+    }
+  }
+
+  const search = query.toString();
+  return request(`/api/frontier${search ? `?${search}` : ""}`);
+}
+
 export function getGraph(filters = {}) {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(filters)) {


### PR DESCRIPTION
## Summary
## Final Summary

### What changed

| File | Purpose |
|------|---------|
| `web/src/lib/api.js` | Added `getFrontier()` API function for the `/api/frontier` endpoint |
| `web/src/App.svelte` | Imported new APIs; added frontier/execution/reconciliation state + reactive derivations; updated status bar with per-tab conditional stats; pass `externalFrontierIds` to GraphView; refresh reloads tab-specific data |
| `web/src/components/GraphView.svelte` | Added `externalFrontierIds` prop to accept parent-provided frontier IDs, eliminating duplicate fetch |

### Tests/checks results
- **TypeScript (`npm run check`)**: ✅ Pass
- **Build (`npm run build:web`)**: ✅ Pass (1407 modules, clean output)
- **Tests (`npm test`)**: 2 pre-existing test file failures (SQLite native module issues in graph-writer tests), 20/22 test files pass — no regressions from this change

### Commits
1. `feat(status-bar): add frontier/blocked counts and per-tab status bar stats` — main implementation
2. `style(status-bar): add user-select:none on separators` — minor style polish

### No blockers or follow-up items

actual_files synced: 0 file(s).

## Context
- Work item: studio-109
- Issue: https://github.com/fusupo/escapement-studio/issues/109
- Base branch: develop
- Head branch: studio-109-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775795552728
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-109-branch
- Scope hint: Add a persistent bottom status bar that shows compact graph, execution, or reconciliation stats depending on the active tab.

## Changed files
- (not recorded)