### PR TITLE
[#179] Studio: show the currently selected model in Settings

### DIFF
--- a/web/src/components/SettingsPanel.svelte
+++ b/web/src/components/SettingsPanel.svelte
@@ -93,6 +93,16 @@
     return `${provider}::${id}`;
   }
 
+  // Build the visible label for an <option> in the grouped model <select>.
+  // Appends '(no auth)' for unavailable models and '— current' for the
+  // active selection so the dropdown clearly identifies the live value.
+  function modelLabel(m, activeKey) {
+    const parts = [m.name];
+    if (!m.available) parts.push("(no auth)");
+    if (modelKey(m.provider, m.id) === activeKey) parts.push("\u2014 current");
+    return parts.join(" ");
+  }
+
   function syncEditState() {
     if (!settings) return;
     editRepos = Object.entries(settings.repos ?? {})
@@ -268,7 +278,7 @@
               <optgroup label={provider}>
                 {#each models as m}
                   <option value={modelKey(m.provider, m.id)}>
-                    {m.name}{m.available ? "" : " (no auth)"}
+                    {modelLabel(m, selectedModelKey)}
                   </option>
                 {/each}
               </optgroup>

--- a/web/src/components/SettingsPanel.svelte
+++ b/web/src/components/SettingsPanel.svelte
@@ -243,18 +243,20 @@
           <div class="banner error inline-banner">Failed to load models: {modelsLoadError}</div>
         {/if}
         <div class="settings-row">
-          <span class="settings-label">Current</span>
+          <span class="settings-label">Active model</span>
           <span class="settings-value">
             {#if selectedModelInfo}
               <code>{selectedModelInfo.provider} / {selectedModelInfo.name}</code>
-              {#if !selectedModelInfo.available}
-                <span class="status-pill" style="margin-left: 0.5rem;">No auth configured</span>
+              {#if selectedModelInfo.available}
+                <span class="status-pill healthy" style="margin-left: 0.5rem;">Active</span>
+              {:else}
+                <span class="status-pill warn" style="margin-left: 0.5rem;">No auth configured</span>
               {/if}
             {:else if selectedModelMissing}
               <code>{editConfig.selectedModel?.provider} / {editConfig.selectedModel?.modelId}</code>
-              <span class="status-pill" style="margin-left: 0.5rem;">Not in registry</span>
+              <span class="status-pill warn" style="margin-left: 0.5rem;">Not in registry</span>
             {:else}
-              <em class="muted">Default (pi first-available)</em>
+              <span>Default &mdash; pi picks the first available model</span>
             {/if}
           </span>
         </div>

--- a/web/src/components/SettingsPanel.svelte
+++ b/web/src/components/SettingsPanel.svelte
@@ -29,24 +29,37 @@
   async function load() {
     loading = true;
     error = "";
+    modelsLoadError = "";
+    // Load settings and models in parallel so that `availableModels` is populated
+    // by the time we assign `selectedModelKey` via syncEditState(). Previously the
+    // sequential chain (settings → syncEditState → loadModels) set selectedModelKey
+    // before the grouped <option> list existed, so the <select> visually fell back
+    // to '— Use default —' even when a model was saved.
     try {
-      settings = await getSettings();
-      syncEditState();
-      await loadModels();
-    } catch (loadError) {
-      error = loadError.message;
+      const [settingsResult, modelsResult] = await Promise.allSettled([
+        getSettings(),
+        getAvailableModels(),
+      ]);
+
+      if (settingsResult.status === "fulfilled") {
+        settings = settingsResult.value;
+      } else {
+        error = settingsResult.reason?.message ?? String(settingsResult.reason);
+      }
+
+      if (modelsResult.status === "fulfilled") {
+        availableModels = modelsResult.value;
+      } else {
+        modelsLoadError =
+          modelsResult.reason?.message ?? String(modelsResult.reason);
+        availableModels = [];
+      }
+
+      // Sync edit state only after both fetches resolve so the <select>'s bound
+      // value is applied once the <option> children are ready to render.
+      if (settings) syncEditState();
     } finally {
       loading = false;
-    }
-  }
-
-  async function loadModels() {
-    modelsLoadError = "";
-    try {
-      availableModels = await getAvailableModels();
-    } catch (err) {
-      modelsLoadError = err.message;
-      availableModels = [];
     }
   }
 
@@ -91,16 +104,26 @@
       : "";
   }
 
-  function onModelChange(event) {
-    const value = event.target.value;
-    selectedModelKey = value;
-    if (!value) {
+  // Mirror `selectedModelKey` (driven by `bind:value` on the <select>) back into
+  // `editConfig.selectedModel` so dirty-detection and persistence keep working.
+  // Idempotent: no-op if editConfig already matches the key.
+  function applyModelSelection(key) {
+    const current = editConfig?.selectedModel
+      ? modelKey(
+          editConfig.selectedModel.provider,
+          editConfig.selectedModel.modelId,
+        )
+      : "";
+    if (current === key) return;
+    if (!key) {
       editConfig = { ...editConfig, selectedModel: null };
       return;
     }
-    const [provider, modelId] = value.split("::");
+    const [provider, modelId] = key.split("::");
     editConfig = { ...editConfig, selectedModel: { provider, modelId } };
   }
+
+  $: if (settings) applyModelSelection(selectedModelKey);
 
   async function save() {
     saving = true;
@@ -237,7 +260,7 @@
         </div>
         <label>
           Model
-          <select value={selectedModelKey} on:change={onModelChange} disabled={availableModels.length === 0}>
+          <select bind:value={selectedModelKey} disabled={availableModels.length === 0}>
             <option value="">— Use default —</option>
             {#each modelsByProvider as [provider, models]}
               <optgroup label={provider}>


### PR DESCRIPTION
## Summary
Work tree is clean (SCRATCHPAD is correctly untracked/not staged). Here is the final summary.

## Final Summary

### What changed

All work was scoped to a single file: **`web/src/components/SettingsPanel.svelte`**, across three commits.

| Commit | Purpose |
|---|---|
| `de4994d` 🐛🔧 `fix(web): load settings and models in parallel…` | **Task 1** — Fixes the load-order race. `load()` now fetches `getSettings()` + `getAvailableModels()` in parallel via `Promise.allSettled` and only calls `syncEditState()` after both resolve. The `<select>` switched from `value={…} on:change=…` to `bind:value={selectedModelKey}`; `onModelChange` was replaced by an idempotent reactive `applyModelSelection(key)` that mirrors `selectedModelKey` → `editConfig.selectedModel` without re-triggering itself, preserving `hasDrift` semantics. |
| `0aa4b67` 💄✨ `feat(web): promote settings 'Current' row to 'Active model'…` | **Task 2** — Renames the summary row label to **Active model** and gives each state an explicit treatment: selected+available → `.status-pill.healthy` “Active”; selected+no-auth → `.status-pill.warn` “No auth configured”; selected+missing → `.status-pill.warn` “Not in registry”; unset → plain prose “Default — pi picks the first available model”. Reuses existing pill variants; no new CSS. |
| `ef4b9aa` ✨💄 `feat(web): mark active option inside settings model dropdown` | **Task 3** — Adds a `modelLabel(m, activeKey)` helper that composes `name`, `(no auth)`, and `— current` suffixes and wires it into the `{#each modelsByProvider}` loop, so the active option is textually marked inside the open dropdown. |

### Quality checks

- ✅ `npm run check` (`tsc --noEmit`) — clean
- ✅ `npm run build:web` (`vite build`) — builds clean (only pre-existing a11y warnings from unrelated components)
- ⚠️ `npm test` (`vitest run`) — **18 failures, all pre-existing and unrelated**. Confirmed by checking out baseline `a521f66` and re-running: identical `18 failed | 357 passed` result, all in `src/modules/graph/__tests__/graph-writer.service.test.ts` (sqlite/better-sqlite3 init issue in `createTestSqliteService`). No frontend tests exist for Svelte components in this repo per the scratchpad assumptions.

### Acceptance criteria coverage

- ✅ Settings panel visibly shows the currently selected model on mount (parallel load + `bind:value`)
- ✅ Reloading preserves and displays the saved value in the `<select>`, not just the summary row
- ✅ Displayed value matches `config.selectedModel` from `GET /api/settings` (backend untouched)
- ✅ Active option is distinguished from available options via both the summary pill and the in-dropdown `— current` marker
- ✅ Four states each have an explicit treatment: unset / selected+available / selected+no-auth / selected+missing

### Remaining blockers / follow-ups

- **None for studio-179.** The pre-existing `graph-writer.service.test.ts` failures are out of scope for this frontend-only change and should be tracked separately if not already captured.
- Manual browser smoke test (switch model, save, reload, clear) is still advisable before merge since no Svelte component test harness exists, per the scratchpad’s assumptions.

actual_files synced: 0 file(s).

## Context
- Work item: studio-179
- Issue: https://github.com/fusupo/escapement-studio/issues/179
- Base branch: develop
- Head branch: studio-179-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775855711078
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-179-branch
- Scope hint: Make the Settings model selector reflect and display the currently saved active model value so users can see what Studio is actually configured to use.

## Changed files
- (not recorded)