### PR TITLE
[#183] Studio: invert planned-state graph striping so blocked planned items are striped instead of frontier planned items

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -241,8 +241,7 @@ a:hover {
   min-height: 0;
   border-radius: var(--radius-md);
   background: rgba(13, 17, 23, 0.9);
-  --graph-frontier-stripe-color: rgba(240, 246, 252, 0.24);
-  --graph-frontier-glow: rgba(240, 246, 252, 0.16);
+  --graph-blocked-planned-stripe-color: rgba(240, 246, 252, 0.24);
   --graph-in-progress-outline: rgba(255, 244, 214, 0.92);
   --graph-in-progress-shadow: rgba(210, 153, 34, 0.22);
   --graph-merged-pr-outline: rgba(230, 255, 248, 0.98);
@@ -281,8 +280,8 @@ a:hover {
 
 /* merged_pr styling uses a double-outline 'stamp' treatment (bold outer
    inset stroke + thinner inner inset stroke) so the 'landed' signal is
-   obvious at normal zoom independent of hue, and composes with frontier
-   stripes + the bottom-anchored ✓PR badge. */
+   obvious at normal zoom independent of hue, and composes with the
+   bottom-anchored ✓PR badge. */
 .graph-canvas .node.graph-node--merged-pr,
 .graph-canvas .node[data-state="merged_pr"] {
   filter: drop-shadow(0 0 0.32rem var(--graph-merged-pr-shadow));
@@ -332,50 +331,32 @@ a:hover {
   opacity: 0.95;
 }
 
-.graph-canvas .node.graph-node--frontier.graph-node--merged-pr,
-.graph-canvas .node.graph-node--frontier[data-state="merged_pr"],
-.graph-canvas .node[data-frontier="true"][data-state="merged_pr"] {
-  filter: drop-shadow(0 0 0.3rem var(--graph-frontier-glow)) drop-shadow(0 0 0.2rem var(--graph-merged-pr-shadow));
-}
-
-/* Frontier styling uses an interior overlay so it composes with the graph
-   renderer's existing state fill plus hover/selection stroke affordances. */
-.graph-canvas .node.graph-node--frontier,
-.graph-canvas .node.frontier,
-.graph-canvas .node[data-frontier="true"] {
-  filter: drop-shadow(0 0 0.35rem var(--graph-frontier-glow));
-}
-
-.graph-canvas .node.graph-node--frontier.graph-node--in-progress,
-.graph-canvas .node.graph-node--frontier[data-state="in_progress"],
-.graph-canvas .node[data-frontier="true"][data-state="in_progress"] {
-  filter: drop-shadow(0 0 0.3rem var(--graph-frontier-glow)) drop-shadow(0 0 0.18rem var(--graph-in-progress-shadow));
-}
-
-.graph-canvas .node.graph-node--frontier rect,
-.graph-canvas .node.frontier rect,
-.graph-canvas .node[data-frontier="true"] rect {
+/* Blocked-planned styling uses an interior diagonal stripe overlay to
+   signal 'planned but not yet executable' (i.e. planned items that are
+   not in the frontier set). Stripes decouple from frontier membership so
+   the visual weight reads as 'blocked / waiting on dependencies' rather
+   than 'ready to dispatch'. Frontier membership is still tracked via the
+   data-frontier attribute for tooltips and downstream consumers. */
+.graph-canvas .node.graph-node--blocked-planned rect,
+.graph-canvas .node[data-blocked-planned="true"] rect {
   shape-rendering: geometricPrecision;
 }
 
-.graph-canvas .node.graph-node--frontier .frontier-overlay,
-.graph-canvas .node.frontier .frontier-overlay,
-.graph-canvas .node[data-frontier="true"] .frontier-overlay {
-  fill: url("#graph-frontier-diagonal-stripes");
+.graph-canvas .node.graph-node--blocked-planned .blocked-planned-overlay,
+.graph-canvas .node[data-blocked-planned="true"] .blocked-planned-overlay {
+  fill: url("#graph-blocked-planned-diagonal-stripes");
   stroke: none;
   opacity: 0.34;
   pointer-events: none;
 }
 
-.graph-canvas .node.graph-node--frontier.selected .frontier-overlay,
-.graph-canvas .node.frontier.selected .frontier-overlay,
-.graph-canvas .node[data-frontier="true"].selected .frontier-overlay {
+.graph-canvas .node.graph-node--blocked-planned.selected .blocked-planned-overlay,
+.graph-canvas .node[data-blocked-planned="true"].selected .blocked-planned-overlay {
   opacity: 0.26;
 }
 
-.graph-canvas .node.graph-node--frontier:hover .frontier-overlay,
-.graph-canvas .node.frontier:hover .frontier-overlay,
-.graph-canvas .node[data-frontier="true"]:hover .frontier-overlay {
+.graph-canvas .node.graph-node--blocked-planned:hover .blocked-planned-overlay,
+.graph-canvas .node[data-blocked-planned="true"]:hover .blocked-planned-overlay {
   opacity: 0.4;
 }
 
@@ -417,12 +398,12 @@ a:hover {
   pointer-events: none;
 }
 
-.graph-legend .legend-swatch.frontier {
+.graph-legend .legend-swatch.blocked-planned {
   border: 1px solid rgba(240, 246, 252, 0.28);
   background-color: rgba(88, 166, 255, 0.24);
   background-image: repeating-linear-gradient(
     135deg,
-    var(--graph-frontier-stripe-color, rgba(240, 246, 252, 0.24)) 0 2px,
+    var(--graph-blocked-planned-stripe-color, rgba(240, 246, 252, 0.24)) 0 2px,
     transparent 2px 6px
   );
 }

--- a/web/src/components/GraphView.svelte
+++ b/web/src/components/GraphView.svelte
@@ -112,7 +112,7 @@
         <div class="legend-row"><span class="legend-swatch" style="background:#a371f7"></span><code>open_pr</code></div>
         <div class="legend-row"><span class="legend-swatch merged-pr" style="background:#39c2a6"></span><code>merged_pr</code><span class="legend-note">double inset</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#238636"></span><code>done</code></div>
-        <div class="legend-row"><span class="legend-swatch frontier"></span><code>frontier</code></div>
+        <div class="legend-row"><span class="legend-swatch blocked-planned"></span><code>planned · blocked</code><span class="legend-note">not yet runnable</span></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#8b949e"></span><code>deferred</code></div>
         <div class="legend-row"><span class="legend-swatch" style="background:#f85149"></span><code>cancelled</code></div>
       </div>

--- a/web/src/lib/graph.js
+++ b/web/src/lib/graph.js
@@ -136,6 +136,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     node._pr = extractPullRequest(node);
     node._prStatus = classifyPrStatus(node._pr);
     node._isFrontier = frontierIds.has(node.id);
+    node._isBlockedPlanned = node.state === "planned" && !frontierIds.has(node.id);
     return node;
   });
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
@@ -158,7 +159,7 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
     const color = STATE_COLORS[node.state] ?? "#484f58";
     const isSelected = node.id === selectedId;
     const classes = ["graph-node"];
-    if (node._isFrontier) classes.push("graph-node--frontier");
+    if (node._isBlockedPlanned) classes.push("graph-node--blocked-planned");
     if (node.state === "in_progress") classes.push("graph-node--in-progress");
     if (node.state === "merged_pr") classes.push("graph-node--merged-pr");
 
@@ -215,19 +216,19 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       .attr("opacity", 0.8);
   }
 
-  const frontierPattern = defs.append("pattern")
-    .attr("id", "graph-frontier-diagonal-stripes")
+  const blockedPlannedPattern = defs.append("pattern")
+    .attr("id", "graph-blocked-planned-diagonal-stripes")
     .attr("patternUnits", "userSpaceOnUse")
     .attr("width", 8)
     .attr("height", 8)
     .attr("patternTransform", "rotate(45)");
 
-  frontierPattern.append("rect")
+  blockedPlannedPattern.append("rect")
     .attr("width", 8)
     .attr("height", 8)
     .attr("fill", "transparent");
 
-  frontierPattern.append("line")
+  blockedPlannedPattern.append("line")
     .attr("x1", 0)
     .attr("y1", 0)
     .attr("x2", 0)
@@ -288,7 +289,9 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       .classed("selected", data.id === selectedId)
       .classed("graph-node--in-progress", data.state === "in_progress")
       .classed("graph-node--merged-pr", data.state === "merged_pr")
+      .classed("graph-node--blocked-planned", data._isBlockedPlanned)
       .attr("data-frontier", data._isFrontier ? "true" : "false")
+      .attr("data-blocked-planned", data._isBlockedPlanned ? "true" : "false")
       .attr("data-state", data.state ?? "unknown");
 
     const baseRect = nodeGroup.select("rect");
@@ -301,17 +304,17 @@ export function renderGraph(svgElement, graph, selectedId, onSelect, options = {
       const rx = Number(baseRect.attr("rx") || 0);
       const ry = Number(baseRect.attr("ry") || 0);
 
-      if (data._isFrontier) {
-        const frontierInset = Math.min(1.5, width / 6, height / 6);
+      if (data._isBlockedPlanned) {
+        const blockedInset = Math.min(1.5, width / 6, height / 6);
         nodeGroup.insert("rect", "g.label")
-          .attr("class", "frontier-overlay")
-          .attr("fill", "url(#graph-frontier-diagonal-stripes)")
-          .attr("x", x + frontierInset)
-          .attr("y", y + frontierInset)
-          .attr("width", Math.max(0, width - frontierInset * 2))
-          .attr("height", Math.max(0, height - frontierInset * 2))
-          .attr("rx", Math.max(0, rx - frontierInset / 2))
-          .attr("ry", Math.max(0, ry - frontierInset / 2));
+          .attr("class", "blocked-planned-overlay")
+          .attr("fill", "url(#graph-blocked-planned-diagonal-stripes)")
+          .attr("x", x + blockedInset)
+          .attr("y", y + blockedInset)
+          .attr("width", Math.max(0, width - blockedInset * 2))
+          .attr("height", Math.max(0, height - blockedInset * 2))
+          .attr("rx", Math.max(0, rx - blockedInset / 2))
+          .attr("ry", Math.max(0, ry - blockedInset / 2));
       }
 
       if (data.state === "in_progress") {


### PR DESCRIPTION
## Summary
Implementation complete. Final summary:

## Summary

### What changed
Inverted the Studio graph's planned-state stripe semantics so diagonal stripes now mark **planned but not yet executable** (blocked) items instead of frontier/dispatchable ones. Landed as a single atomic commit `f490dce` across three files:

- **`web/src/lib/graph.js`**: added `_isBlockedPlanned = state === 'planned' && !frontierIds.has(id)` derivation; renamed SVG pattern `graph-frontier-diagonal-stripes` → `graph-blocked-planned-diagonal-stripes`; renamed dagre node class `graph-node--frontier` → `graph-node--blocked-planned`; renamed overlay class `frontier-overlay` → `blocked-planned-overlay`; swapped stripe overlay insertion guard from `_isFrontier` to `_isBlockedPlanned`; added `data-blocked-planned` attribute. `_isFrontier`, `data-frontier`, and the tooltip "Frontier: dispatchable" line preserved.

- **`web/src/app.css`**: renamed `--graph-frontier-stripe-color` → `--graph-blocked-planned-stripe-color` and every `.frontier`/`.graph-node--frontier`/`[data-frontier="true"]` stripe selector (+ `.frontier-overlay`, `.legend-swatch.frontier`, pattern URL) to the blocked-planned form. Per the plan's Option C assumption, removed `--graph-frontier-glow` and all associated `filter: drop-shadow(...)` rules (base + in_progress + merged_pr compounds).

- **`web/src/components/GraphView.svelte`**: replaced the `frontier` legend row with `planned · blocked` using the renamed swatch plus a "not yet runnable" `legend-note`. `frontierIds` plumbing untouched.

### Quality checks
- ✅ `npm run check` (tsc --noEmit) — clean
- ✅ `npm run build:web` — succeeds (pre-existing unrelated "unused CSS selector" warnings in `ExecutionDispatchPanel.svelte`)
- ⚠️ `npm test` — 18 pre-existing failures in backend `graph-writer.service.test.ts` and `state-machine-allowlist.test.ts` due to better-sqlite3 native binding load errors; unrelated to this frontend-only change (357 tests still pass)

### Follow-up / notes
- Verification is manual (no vitest/playwright coverage for the graph renderer). Reviewer should visually confirm in the Studio graph: stripes only on planned+non-frontier nodes, plain fill on planned+frontier, tooltip still shows "Frontier: dispatchable", selection/hover/in_progress dashed inset/merged_pr double-inset all still compose correctly.
- Questions in the scratchpad re: exact legend wording and whether to keep any frontier glow for non-planned items were resolved by taking Option C (remove glow entirely) and the label "planned · blocked" + "not yet runnable"; reviewer can override in PR review if they prefer different wording.
- No blockers.

actual_files synced: 0 file(s).

## Context
- Work item: studio-183
- Issue: https://github.com/fusupo/escapement-studio/issues/183
- Base branch: develop
- Head branch: studio-183-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775859235073
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-183-branch
- Scope hint: Invert planned-node striping so stripes indicate planned items that are not yet executable rather than frontier-ready planned items.

## Changed files
- (not recorded)