### PR TITLE
[#170] Execution: trigger disambiguation gate when approved plan has open questions

### DIFF
--- a/src/modules/execution/__tests__/parse-scratchpad-open-items.test.ts
+++ b/src/modules/execution/__tests__/parse-scratchpad-open-items.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { ExecutionService } from "../execution.service.js";
+
+/**
+ * Unit tests for the private `parseScratchpadOpenItems` helper.
+ *
+ * Uses the `Object.create(ExecutionService.prototype)` harness pattern
+ * from scratchpad-canonical.test.ts / build-scratchpad.test.ts so we can
+ * exercise the pure method without booting Nest DI.
+ */
+
+interface Harness {
+  parseScratchpadOpenItems: (
+    content: string,
+  ) => { questions: string[]; blockers: string[] };
+}
+
+function makeHarness(): Harness {
+  return Object.create(ExecutionService.prototype) as Harness;
+}
+
+describe("ExecutionService.parseScratchpadOpenItems", () => {
+  it("parses items from both sections when both are populated", () => {
+    const h = makeHarness();
+    const content = [
+      "# Plan: studio-999",
+      "",
+      "## Questions / Concerns",
+      "",
+      "### Clarifications Needed",
+      "",
+      "- First question",
+      "- Second question",
+      "",
+      "### Assumptions Made",
+      "",
+      "- some assumption",
+      "",
+      "## Blockers",
+      "",
+      "- Blocker one",
+      "- Blocker two",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual(["First question", "Second question"]);
+    expect(result.blockers).toEqual(["Blocker one", "Blocker two"]);
+  });
+
+  it("returns empty arrays when both sections are _(none)_", () => {
+    const h = makeHarness();
+    const content = [
+      "## Questions / Concerns",
+      "",
+      "### Clarifications Needed",
+      "",
+      "_(none)_",
+      "",
+      "### Assumptions Made",
+      "",
+      "_(none)_",
+      "",
+      "## Blockers",
+      "",
+      "_(none)_",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual([]);
+    expect(result.blockers).toEqual([]);
+  });
+
+  it("returns empty questions when the `### Clarifications Needed` heading is missing", () => {
+    const h = makeHarness();
+    const content = [
+      "# Plan: studio-999",
+      "",
+      "## Blockers",
+      "",
+      "- Only blocker",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual([]);
+    expect(result.blockers).toEqual(["Only blocker"]);
+  });
+
+  it("returns empty blockers when the `## Blockers` heading is missing", () => {
+    const h = makeHarness();
+    const content = [
+      "## Questions / Concerns",
+      "",
+      "### Clarifications Needed",
+      "",
+      "- The only question",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual(["The only question"]);
+    expect(result.blockers).toEqual([]);
+  });
+
+  it("tolerates leading/trailing whitespace and blank lines between bullets", () => {
+    const h = makeHarness();
+    const content = [
+      "### Clarifications Needed",
+      "",
+      "   - indented question   ",
+      "",
+      "- second question",
+      "",
+      "",
+      "## Blockers",
+      "",
+      "- spaced blocker   ",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual(["indented question", "second question"]);
+    expect(result.blockers).toEqual(["spaced blocker"]);
+  });
+
+  it("stops collecting at the next heading (e.g. ### Assumptions Made)", () => {
+    const h = makeHarness();
+    const content = [
+      "### Clarifications Needed",
+      "",
+      "- kept question",
+      "",
+      "### Assumptions Made",
+      "",
+      "- should not be collected as a question",
+      "",
+      "## Blockers",
+      "",
+      "- kept blocker",
+      "",
+      "## Work Log",
+      "",
+      "- should not be collected as a blocker",
+      "",
+    ].join("\n");
+
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual(["kept question"]);
+    expect(result.blockers).toEqual(["kept blocker"]);
+  });
+
+  it("returns empty arrays for an empty string", () => {
+    const h = makeHarness();
+    const result = h.parseScratchpadOpenItems("");
+    expect(result.questions).toEqual([]);
+    expect(result.blockers).toEqual([]);
+  });
+
+  it("handles CRLF line endings", () => {
+    const h = makeHarness();
+    const content =
+      "### Clarifications Needed\r\n\r\n- crlf question\r\n\r\n## Blockers\r\n\r\n- crlf blocker\r\n";
+    const result = h.parseScratchpadOpenItems(content);
+    expect(result.questions).toEqual(["crlf question"]);
+    expect(result.blockers).toEqual(["crlf blocker"]);
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -813,6 +813,73 @@ export class ExecutionService implements OnModuleInit {
           "Approved plan loaded from canonical — skipping setup phase.",
         );
         this.appendEvent(run, { type: "setup_phase_skipped" });
+
+        // studio-170: if the approved scratchpad still has open
+        // clarifications or blockers, trigger the existing
+        // disambiguation gate before entering the coding phase so the
+        // user can review and resolve them. Honors the `disambiguate`
+        // opt-out flag the same way `shouldRunSetupPhase` does.
+        if (disambiguate) {
+          let openItems: { questions: string[]; blockers: string[] } = {
+            questions: [],
+            blockers: [],
+          };
+          try {
+            const scratchpadContent = readFileSync(scratchpadPath, "utf8");
+            openItems = this.parseScratchpadOpenItems(scratchpadContent);
+          } catch (error) {
+            this.logger.warn(
+              `executeRun: failed to read approved scratchpad at ${scratchpadPath} ` +
+                `for disambiguation parse: ${this.getErrorMessage(error)}`,
+            );
+          }
+
+          const totalOpen = openItems.questions.length + openItems.blockers.length;
+          if (totalOpen > 0) {
+            const qLabel = `${openItems.questions.length} clarification${openItems.questions.length === 1 ? "" : "s"}`;
+            const bLabel = `${openItems.blockers.length} blocker${openItems.blockers.length === 1 ? "" : "s"}`;
+            const progressSummary = `${qLabel} and ${bLabel} open in approved plan — awaiting review.`;
+
+            this.pushActivity(
+              runId,
+              "info",
+              `Approved plan has open items (${qLabel}, ${bLabel}) — pausing for user review before coding.`,
+            );
+            this.appendEvent(run, { type: "setup_phase_started" });
+
+            run = this.updateRun(runId, {
+              status: "disambiguating",
+              progress_message: progressSummary,
+            })!;
+            this.appendEvent(run, { type: "setup_phase_complete" });
+            this.emitRun("execution_status", run);
+
+            // Block until the user resolves via
+            // POST /api/execution/resolve-disambiguation.
+            const additionalContext = await new Promise<string | undefined>((resolve) => {
+              this.disambiguationGates.set(runId, { resolve });
+            });
+            this.appendEvent(run, { type: "setup_approved" });
+
+            if (additionalContext) {
+              // The session has no prior orientation in the
+              // approved-plan codepath, so include a minimal prompt
+              // with the scratchpad filename and work item id.
+              await session.prompt(
+                `The approved plan for ${run.work_item_id} (${run.work_item_name}) had open items that the user just resolved with this additional context:\n\n${additionalContext}\n\nRead ${scratchpadName} in the current worktree, update the "### Clarifications Needed" and "## Blockers" sections to reflect the resolution, and make any other edits implied by the user's feedback. Then confirm you're ready to start coding.`,
+              );
+              this.syncScratchpadToCanonical(run);
+              this.emitChecklistIfChanged(run);
+            }
+
+            run = this.updateRun(runId, {
+              status: "running",
+              progress_message: "Plan approved — coding phase started.",
+            })!;
+            this.pushActivity(runId, "status_change", "Plan approved. Coding phase started.");
+            this.emitRun("execution_status", run);
+          }
+        }
       }
       if (shouldRunSetupPhase) {
         run = this.updateRun(runId, {

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1624,6 +1624,60 @@ export class ExecutionService implements OnModuleInit {
     }
   }
 
+  /**
+   * Parse a scratchpad's `### Clarifications Needed` and `## Blockers`
+   * sections into string arrays of open items.
+   *
+   * Contract: matches the shape written by `PlansService.prepare`
+   * (plans.service.ts ~lines 383–415) — flat top-level `- ` bullets,
+   * or a single `_(none)_` sentinel when the drafter surfaced no items.
+   *
+   * Behavior:
+   *   - Scans line-by-line for the two headings.
+   *   - Collects lines starting with `- ` as bullet items until the next
+   *     `#`-prefixed heading line (any level — keeps the parser simple
+   *     and matches the flat structure the drafter emits).
+   *   - Filters out blank lines and the `_(none)_` sentinel so an empty
+   *     section reads as an empty array.
+   *   - Missing heading → empty array for that section.
+   *
+   * Used by `executeRun` when an approved plan is loaded to decide
+   * whether the disambiguation gate should fire before coding starts.
+   */
+  private parseScratchpadOpenItems(content: string): {
+    questions: string[];
+    blockers: string[];
+  } {
+    const lines = content.split(/\r?\n/);
+    const collect = (headingMatch: (line: string) => boolean): string[] => {
+      const items: string[] = [];
+      let i = 0;
+      while (i < lines.length) {
+        if (headingMatch(lines[i])) {
+          i += 1;
+          while (i < lines.length) {
+            const line = lines[i];
+            if (/^\s*#/.test(line)) break;
+            const trimmed = line.trim();
+            if (trimmed.startsWith("- ")) {
+              const body = trimmed.slice(2).trim();
+              if (body && body !== "_(none)_") {
+                items.push(body);
+              }
+            }
+            i += 1;
+          }
+          break;
+        }
+        i += 1;
+      }
+      return items;
+    };
+    const questions = collect((line) => /^\s*###\s+Clarifications Needed\s*$/.test(line));
+    const blockers = collect((line) => /^\s*##\s+Blockers\s*$/.test(line));
+    return { questions, blockers };
+  }
+
   private syncScratchpadToCanonical(run: ExecutionRunRecord): void {
     const slug = workItemSlug(run.work_item_id);
     const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);


### PR DESCRIPTION
## Summary
## Final Summary

### What changed

**`src/modules/execution/execution.service.ts`** (+120 LOC across 2 commits)
- **Commit `72a037a`** — Added private `parseScratchpadOpenItems(content)` helper. A pure line-based parser that collects top-level `- ` bullets under `### Clarifications Needed` and `## Blockers`, stops at the next `#`-prefixed heading, and filters blank lines + the `_(none)_` sentinel that `PlansService.prepare` emits.
- **Commit `73b66a8`** — Wired the parser into `executeRun`. When `hasApprovedPlan === true` and the caller has not set `disambiguate: false`, read the worktree scratchpad, parse it, and if any open items remain enter the existing disambiguation gate. Reuses `disambiguationGates`, `resolveDisambiguation`, and the `setup_phase_started` / `setup_phase_complete` / `setup_approved` run events. On resolve with `additional_context`, prompts the session with a self-contained orientation (work item id/name, scratchpad filename, update instructions) since the approved-plan codepath never prompted the agent before, then calls `syncScratchpadToCanonical`. Happy path unchanged.

**`src/modules/execution/__tests__/parse-scratchpad-open-items.test.ts`** (new, +157 LOC)
- 8 vitest cases using the `Object.create(ExecutionService.prototype)` harness: both sections populated, both `_(none)_`, missing clarifications heading, missing blockers heading, whitespace/blank-line tolerance, next-heading boundary (`### Assumptions Made` / `## Work Log`), empty input, CRLF line endings.

### Checks run

- `npx tsc --noEmit` — clean ✅
- `npx vitest run src/modules/execution/` — **173/173 passed** (including all 8 new parser tests) ✅
- `npm run build:web` — built in 1.22s ✅
- Full `npx vitest run` has 18 failing tests in `graph-writer.service.test.ts` and `state-machine-allowlist.test.ts`, but these are **pre-existing environmental failures** (`better-sqlite3` native binding cannot load in this worktree) and reproduce on the base commit `72a037a`/`bb25066`. Unrelated to this work.

### Acceptance criteria coverage

| Criterion | Status |
|---|---|
| Private parser helper returning empty arrays on `_(none)_`/absent | ✅ `parseScratchpadOpenItems` |
| `executeRun` transitions to `disambiguating` with summary progress_message when open items exist | ✅ (`"N clarifications and M blockers open in approved plan — awaiting review."`) |
| Reuses `disambiguationGates` + existing `resolveDisambiguation` endpoint (no controller changes) | ✅ |
| On resolve with `additional_context`, session prompted + `syncScratchpadToCanonical` | ✅ (self-contained prompt with work item + scratchpad filename) |
| Gate resolves → transitions back to `running` → enters do-work | ✅ |
| Happy path (both sections `_(none)_` / absent) bypasses the gate | ✅ |
| Unit tests for all parser scenarios | ✅ 8 cases, all passing |
| `setup_phase_started` / `setup_phase_complete` / `setup_approved` events emitted | ✅ |

### Remaining blockers / follow-ups

None. Ready for PR.

actual_files synced: 0 file(s).

## Context
- Work item: studio-170
- Issue: https://github.com/fusupo/escapement-studio/issues/170
- Base branch: develop
- Head branch: studio-170-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775885045931
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-170-branch
- Scope hint: When an approved plan scratchpad still contains clarifications needed or blockers, enter the existing execution disambiguation gate before coding instead of skipping straight to do-work.

## Changed files
- (not recorded)