### PR TITLE
[#84] Studio: add merged-run disposition actions in Recent execution runs

### DIFF
--- a/web/src/components/ExecutionDetailPane.svelte
+++ b/web/src/components/ExecutionDetailPane.svelte
@@ -11,6 +11,13 @@
   export let validationPolicy = null;
   export let scratchpadContent = undefined;
   export let scratchpadLoading = false;
+  // studio-84: merged-PR disposition props. The parent computes
+  // `canDispose` from the reconciled feed (next_action === 'close_out')
+  // and sets `disposing` while a Close or Archive-and-close request is
+  // in flight so both buttons can be disabled together.
+  export let canDispose = false;
+  export let disposing = false;
+  export let dispositionError = "";
 
   const dispatch = createEventDispatcher();
 
@@ -84,6 +91,29 @@
         <p class="muted">Available after completion.</p>
       {/if}
     </div>
+
+    <!-- studio-84: merged-PR disposition actions. Only rendered when the
+         parent says the run is ready (reconciled next_action === 'close_out'). -->
+    {#if canDispose}
+      <div class="detail-card">
+        <div class="detail-card-hdr">
+          <h3>DISPOSITION</h3>
+          <span class="status-pill healthy">ready to close</span>
+        </div>
+        <p class="muted">PR is merged. Close the run to mark the work item done, or archive the plan directory at the same time.</p>
+        <div class="detail-actions">
+          <button class="secondary small" on:click={() => dispatch("closeRun")} disabled={disposing}>
+            {disposing ? "Closing..." : "Close"}
+          </button>
+          <button on:click={() => dispatch("archiveAndCloseRun")} disabled={disposing}>
+            {disposing ? "Working..." : "Archive and close"}
+          </button>
+        </div>
+        {#if dispositionError}
+          <p class="muted disposition-hint">{dispositionError}</p>
+        {/if}
+      </div>
+    {/if}
 
     <!-- Scratchpad -->
     <div class="detail-card">
@@ -299,6 +329,14 @@
   .scratchpad-rendered :global(ol) { padding-left: 16px; }
 
   .scratchpad-rendered :global(code) { overflow-wrap: anywhere; }
+
+  /* studio-84: inline hint shown under the disposition buttons when the
+     backend blocks the call (e.g. cannot_dispose_work_item_active_run). */
+  .disposition-hint {
+    margin: 0;
+    font-size: 11px;
+    color: var(--yellow, #d29922);
+  }
 
   .detail-empty {
     padding: 16px 8px;

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -191,6 +191,45 @@
     }
   }
 
+  /**
+   * studio-84: disposition helpers. Both dispatch to the existing backend
+   * endpoints (REST /api/execution/close-merged and /archive-and-close-merged),
+   * then optimistically remove the run from the client-side Recent list and
+   * kick a quiet loadData() so the reconciled + preview state refreshes.
+   * On failure the error is surfaced via the existing `error` banner.
+   */
+  async function handleCloseRun(run) {
+    if (!run || disposingRunIds.includes(run.run_id)) return;
+    disposingRunIds = [...disposingRunIds, run.run_id];
+    error = "";
+    try {
+      await closeMergedPullRequest(run.work_item_id);
+      runs = runs.filter((r) => r.run_id !== run.run_id);
+      if (selectedRunId === run.run_id) selectedRunId = null;
+      await loadData({ quiet: true });
+    } catch (e) {
+      error = e.message;
+    } finally {
+      disposingRunIds = disposingRunIds.filter((id) => id !== run.run_id);
+    }
+  }
+
+  async function handleArchiveAndCloseRun(run) {
+    if (!run || disposingRunIds.includes(run.run_id)) return;
+    disposingRunIds = [...disposingRunIds, run.run_id];
+    error = "";
+    try {
+      await archiveAndCloseMergedPullRequest(run.work_item_id);
+      runs = runs.filter((r) => r.run_id !== run.run_id);
+      if (selectedRunId === run.run_id) selectedRunId = null;
+      await loadData({ quiet: true });
+    } catch (e) {
+      error = e.message;
+    } finally {
+      disposingRunIds = disposingRunIds.filter((id) => id !== run.run_id);
+    }
+  }
+
   function canSendFollowUp(run) {
     return ["running", "preparing", "completed", "disambiguating"].includes(run.status);
   }

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -1,6 +1,8 @@
 <script>
   import { onMount, afterUpdate } from "svelte";
   import {
+    archiveAndCloseMergedPullRequest,
+    closeMergedPullRequest,
     getExecutionPreview,
     getRunChecklist,
     getRunScratchpad,
@@ -33,6 +35,9 @@
   let stream;
   let launchingIds = [];
   let openingPrRunIds = [];
+  // studio-84: tracks in-flight Close / Archive-and-close disposition
+  // calls per run_id so we can disable buttons and prevent double-dispatch.
+  let disposingRunIds = [];
   let prResults = {};
   let followUpTexts = {};
   let sendingFollowUp = {};
@@ -75,6 +80,17 @@
       merge_order: group.merge_order || [],
     }))
   ) || [];
+
+  /**
+   * studio-84: returns true iff the reconciled feed marks this run's work
+   * item as ready for merged-PR disposition (next_action === 'close_out').
+   * This is the single source of truth for showing the Close /
+   * Archive-and-close buttons and the 'ready to close' pill badge.
+   */
+  function canDisposeRun(run) {
+    if (!run) return false;
+    return reconciledByWorkItem[run.work_item_id]?.next_action === "close_out";
+  }
 
   $: selectedRun = selectedRunId ? runs.find((r) => r.run_id === selectedRunId) ?? null : null;
   $: selectedDispatch = selectedDispatchId ? dispatchNodes.find((n) => n.id === selectedDispatchId) ?? null : null;

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -511,7 +511,7 @@
             {#each runs as run}
               {@const reconciled = reconciledByWorkItem[run.work_item_id]}
               {@const nextAction = reconciled?.next_action}
-              {@const showReconciledBadge = nextAction && ["open_pr", "relaunch", "investigate"].includes(nextAction)}
+              {@const showReconciledBadge = nextAction && ["open_pr", "relaunch", "investigate", "close_out"].includes(nextAction)}
               <button
                 class="run-pill"
                 class:active={selectedRunId === run.run_id && activeSelection === "run"}
@@ -831,6 +831,11 @@
   .run-pill-next-action[data-next-action="relaunch"] {
     background: rgba(210, 153, 34, 0.2);
     color: #facc15;
+  }
+  /* studio-84: merged-PR disposition ready state */
+  .run-pill-next-action[data-next-action="close_out"] {
+    background: rgba(63, 185, 80, 0.25);
+    color: #86efac;
   }
 
   /* Workspace top (header + expandable sections, scrollable if tall) */

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -485,6 +485,8 @@
           dispatchNode={activeSelection === "dispatch" ? selectedDispatch : null}
           pullRequest={selectedPullRequest}
           openingPr={selectedRun ? openingPrRunIds.includes(selectedRun.run_id) : false}
+          canDispose={selectedRun ? canDisposeRun(selectedRun) : false}
+          disposing={selectedRun ? disposingRunIds.includes(selectedRun.run_id) : false}
           assumptions={preview.assumptions || []}
           validationPolicy={preview.validation_policy}
           on:copybranch={() => {
@@ -496,6 +498,8 @@
             else if (activeSelection === "dispatch" && selectedDispatch) copyValue(selectedDispatch.worktree_path, `Copied worktree`);
           }}
           on:openpr={() => selectedRun && handleOpenPR(selectedRun)}
+          on:closeRun={() => selectedRun && handleCloseRun(selectedRun)}
+          on:archiveAndCloseRun={() => selectedRun && handleArchiveAndCloseRun(selectedRun)}
           on:launch={() => selectedDispatch && launchNode(selectedDispatch)}
           scratchpadContent={selectedRun ? scratchpadContent[selectedRun.run_id] : undefined}
           scratchpadLoading={selectedRun ? !!scratchpadLoading[selectedRun.run_id] : false}

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -38,6 +38,11 @@
   // studio-84: tracks in-flight Close / Archive-and-close disposition
   // calls per run_id so we can disable buttons and prevent double-dispatch.
   let disposingRunIds = [];
+  // studio-84: per-run last disposition error, shown inline under the
+  // DISPOSITION buttons in addition to the top error banner. Primarily
+  // targets the `cannot_dispose_work_item_active_run` guard so operators
+  // see why the action was blocked without reading the toast.
+  let dispositionErrors = {};
   let prResults = {};
   let followUpTexts = {};
   let sendingFollowUp = {};
@@ -198,17 +203,30 @@
    * kick a quiet loadData() so the reconciled + preview state refreshes.
    * On failure the error is surfaced via the existing `error` banner.
    */
+  function dispositionHintFor(message) {
+    if (!message) return "";
+    // The backend guard (execution.service.ts assertNoActiveRunForWorkItem)
+    // prefixes with this code; surface a compact inline hint for it.
+    if (message.includes("cannot_dispose_work_item_active_run")) {
+      return "Blocked: another run for this work item is still active. Wait for it to finish, then retry.";
+    }
+    return message;
+  }
+
   async function handleCloseRun(run) {
     if (!run || disposingRunIds.includes(run.run_id)) return;
     disposingRunIds = [...disposingRunIds, run.run_id];
     error = "";
+    dispositionErrors = { ...dispositionErrors, [run.run_id]: "" };
     try {
       await closeMergedPullRequest(run.work_item_id);
       runs = runs.filter((r) => r.run_id !== run.run_id);
       if (selectedRunId === run.run_id) selectedRunId = null;
+      dispositionErrors = { ...dispositionErrors, [run.run_id]: "" };
       await loadData({ quiet: true });
     } catch (e) {
       error = e.message;
+      dispositionErrors = { ...dispositionErrors, [run.run_id]: dispositionHintFor(e.message) };
     } finally {
       disposingRunIds = disposingRunIds.filter((id) => id !== run.run_id);
     }
@@ -218,13 +236,16 @@
     if (!run || disposingRunIds.includes(run.run_id)) return;
     disposingRunIds = [...disposingRunIds, run.run_id];
     error = "";
+    dispositionErrors = { ...dispositionErrors, [run.run_id]: "" };
     try {
       await archiveAndCloseMergedPullRequest(run.work_item_id);
       runs = runs.filter((r) => r.run_id !== run.run_id);
       if (selectedRunId === run.run_id) selectedRunId = null;
+      dispositionErrors = { ...dispositionErrors, [run.run_id]: "" };
       await loadData({ quiet: true });
     } catch (e) {
       error = e.message;
+      dispositionErrors = { ...dispositionErrors, [run.run_id]: dispositionHintFor(e.message) };
     } finally {
       disposingRunIds = disposingRunIds.filter((id) => id !== run.run_id);
     }
@@ -487,6 +508,7 @@
           openingPr={selectedRun ? openingPrRunIds.includes(selectedRun.run_id) : false}
           canDispose={selectedRun ? canDisposeRun(selectedRun) : false}
           disposing={selectedRun ? disposingRunIds.includes(selectedRun.run_id) : false}
+          dispositionError={selectedRun ? (dispositionErrors[selectedRun.run_id] || "") : ""}
           assumptions={preview.assumptions || []}
           validationPolicy={preview.validation_policy}
           on:copybranch={() => {


### PR DESCRIPTION
## Summary
All six commits on branch, tree clean. Final summary:

## Summary

### What I changed

All six tasks from the implementation plan are done across two files:

**`web/src/components/ExecutionDispatchPanel.svelte`**
- Imported `closeMergedPullRequest` / `archiveAndCloseMergedPullRequest` from `../lib/api.js`.
- Added `disposingRunIds` (in-flight tracker) and `dispositionErrors` (per-run hint state).
- Added `canDisposeRun(run)` helper reading `reconciledByWorkItem[run.work_item_id]?.next_action === 'close_out'`.
- Added `handleCloseRun` / `handleArchiveAndCloseRun` handlers: dispatch to the backend, optimistically `runs = runs.filter(...)`, clear `selectedRunId` if needed, quiet-reload, and surface errors via both the top banner and per-run inline hint.
- Added `dispositionHintFor(message)` that maps `cannot_dispose_work_item_active_run` to a compact operator-facing hint.
- Extended the run-pill reconciled-badge allowlist to include `close_out` plus a green `data-next-action="close_out"` style.
- Wired the new `canDispose`, `disposing`, `dispositionError` props into `<ExecutionDetailPane>` and bound `closeRun` / `archiveAndCloseRun` events to the handlers.

**`web/src/components/ExecutionDetailPane.svelte`**
- Added `canDispose`, `disposing`, `dispositionError` props.
- Added a new DISPOSITION detail card rendered only when `kind === 'run' && canDispose`. It contains a secondary "Close" and primary "Archive and close" button that emit `closeRun` / `archiveAndCloseRun` events (both disabled while `disposing`), plus a muted `.disposition-hint` paragraph for the inline blocked-by-active-run hint.

### Commits on `studio-84-branch`
1. `b8e0577` feat(web): add disposition plumbing to ExecutionDispatchPanel
2. `12e0e15` feat(web): add handleCloseRun and handleArchiveAndCloseRun handlers
3. `ac7da4b` feat(web): show 'close out' reconciled badge on run pill
4. `7c8069e` feat(web): add DISPOSITION card to ExecutionDetailPane
5. `9e94abb` feat(web): wire DISPOSITION card events to panel handlers
6. `f160382` feat(web): surface active-run block as inline DISPOSITION hint

### Quality checks
- **`npm run check` (tsc --noEmit)**: ✅ clean after every task.
- **`npm run build:web` (vite build)**: ✅ builds cleanly; only pre-existing unused-selector warnings on unrelated CSS (`.workspace-section-hdr h4`, `.workspace-expandable pre|ul`).
- **`npm test` (vitest run)**:
  - ✅ Directly relevant suite `src/modules/execution/__tests__/disposition.test.ts` → **29/29 pass**.
  - ⚠️ 18 pre-existing failures in graph-writer and related sqlite-backed tests — all due to the `better-sqlite3` native binding not being built in this worktree (`Could not locate the bindings file`), unrelated to this frontend-only change.

### Follow-ups / open items
- None blocking. Scope questions called out in the scratchpad (studio-85 open-issue gate, studio-87 GitHub issue close, studio-88 Archive-and-close, studio-86 run-artifact eviction) are intentionally deferred and should be revisited when those issues are picked up.
- The acceptance-criteria checklist items remain `- [ ]` because they describe behavior to verify manually against a real merged PR; the code paths are in place and the disposition backend suite is green.

actual_files synced: 0 file(s).

## Context
- Work item: studio-84
- Issue: https://github.com/fusupo/escapement-studio/issues/84
- Base branch: develop
- Head branch: studio-84-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775885609288
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-84-branch
- Scope hint: Add Close and Archive-and-close actions to Recent execution runs for merged PR work.

## Changed files
- (not recorded)