### PR TITLE
[#86] Studio: archive execution run artifacts and summaries for completed work

### DIFF
--- a/docs/contracts/run-artifacts.md
+++ b/docs/contracts/run-artifacts.md
@@ -95,6 +95,101 @@ Follow-up interactions append to the existing `events.jsonl`:
 - `follow_up_sent` — when a steer/followUp message is accepted by an active session
 - `follow_up_turn_completed` — when a new-turn follow-up finishes
 
+## Archive bundle layout
+
+Issue #86 introduces the run-archive bundle produced by
+`archiveRunArtifactsForWorkItem` (see `src/modules/execution/run-archiver.ts`).
+The bundle is a single directory under the context root that preserves
+every terminal execution run for a completed work item, together with
+the canonical plan dir (when it has already been archived by
+`archiveAndCloseMergedPullRequest`) and a human-readable `README.md`.
+
+### Directory tree
+
+```text
+<context-root>/archives/<slug>/
+  README.md                       # generated summary (issue #86)
+  metadata.json                   # plan metadata, preserved from plans/<slug>/ (optional)
+  SCRATCHPAD_<slug>.md            # canonical scratchpad, preserved from plans/<slug>/ (optional)
+  runs/
+    <run_id>/                     # moved verbatim from runs/<run_id>/
+      status.json
+      events.jsonl
+      summary.md
+      outputs/
+        response.json
+        pull-request.json
+```
+
+`<slug>` is the work item slug derived by `workItemSlug(workItemId)` —
+the same helper used for `plans/<slug>/` and `archives/<slug>/` elsewhere
+(see `src/lib/context-layout.ts`).
+
+### Move semantics
+
+- **Runs:** each `runs/<run_id>/` is moved into
+  `archives/<slug>/runs/<run_id>/` via `fs.renameSync`. Mirrors the plan
+  dir archival path used by `movePlanDirToArchives` (ADR 014 step 7).
+- **Plan dir artifacts:** `README.md` cross-links any
+  `SCRATCHPAD_<slug>.md` / `metadata.json` / other files already present
+  in `archives/<slug>/` when the archiver runs. In the common path #88
+  will call `archiveAndCloseMergedPullRequest` first, so those files
+  will exist before the run archiver starts.
+- **Atomicity:** archival is NOT transactional. Earlier moves are not
+  rolled back if a later move hits a collision — the archiver fails fast
+  and operators must resolve the partial state manually (see the
+  `archive_already_exists_run` error below).
+
+### Guards and errors
+
+- **Active-run guard:** runs in `queued`, `preparing`, `disambiguating`,
+  or `running` cause the archiver to raise `archive_run_active` BEFORE
+  any filesystem mutation. The wrapper
+  (`ExecutionService.archiveRunArtifacts`) additionally uses
+  `assertNoActiveRunForWorkItem` so the HTTP surface sees a
+  `BadRequestException` with a `cannot_dispose_work_item_active_run`
+  message identical to the other disposition guards.
+- **Destination collisions:** if `archives/<slug>/runs/<run_id>/`
+  already exists, the archiver raises `archive_already_exists_run` with
+  the conflicting path. `archives/<slug>/README.md` is always
+  overwritten — it is a pure function of the work item + archived runs
+  so regenerating it is safe.
+- **Missing source:** if a terminal run record references a missing
+  `runs/<run_id>/` source dir (e.g. operator deleted it manually), the
+  archiver logs a warning and records
+  `{ run_id, reason: "source_missing" }` in `skipped_run_ids` instead of
+  raising.
+
+### `README.md` fields
+
+The generated `README.md` is plain Markdown with the following sections,
+in order:
+
+| Section | Contents |
+|---------|----------|
+| Title | `# Archive: <work_item_id> — <work_item_name>` |
+| Work item | id, name, kind, state, repo, issue link, branch, `archived_at`, `archive_path` |
+| Pull request | number, url, title, base_ref, head_ref, state, merged_at, merge_commit_sha — sourced from `work_item.meta.studio_post_merge_sync.pull_request` (omitted when absent) |
+| Archived runs | per-run block: run_id, status, branch, base_ref, timestamps, changed-file count, optional pull_request link, archive path under `runs/<run_id>/`, truncated `result_summary` |
+| Skipped runs | optional — run_id + reason for any run not moved (`not_terminal:<status>` or `source_missing`) |
+| Plan artifacts | optional cross-links to `SCRATCHPAD_<slug>.md` and `metadata.json` when plan-dir archival ran first |
+| Notes | Move-semantics reminder and links to ADR 014 + this contract document |
+
+### Wiring (as of issue #86)
+
+`ExecutionService.archiveRunArtifacts(workItemId)` is the Nest-level
+entry point. It is NOT yet invoked by
+`archiveAndCloseMergedPullRequest` — that wiring lands in issue #88 as
+part of the `Archive and close` disposition flow. Until then the
+helper is directly callable from tests and can be wired into future
+operator tooling, but the end-user “Archive and close” button still
+only archives the plan dir.
+
+See:
+- [ADR 014: plans/runs state model](../adr/014-plans-runs-state-model.md) (step 7: `merged_pr → done` disposition)
+- [Issue #83](https://github.com/fusupo/escapement-studio/issues/83) — merged execution-run disposition epic
+- [Issue #88](https://github.com/fusupo/escapement-studio/issues/88) — disposition wiring that will call this helper
+
 ## Notes
 
 - `status.json` and SSE serve different purposes: current durable snapshot vs live browser transport

--- a/src/modules/execution/__tests__/archive-run-artifacts.test.ts
+++ b/src/modules/execution/__tests__/archive-run-artifacts.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { ExecutionService } from "../execution.service.js";
+import { archiveDir, runsRoot } from "../../../lib/context-layout.js";
+import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+/**
+ * Issue #86: tests for the thin `ExecutionService.archiveRunArtifacts`
+ * wrapper. Uses the same prototype-harness pattern as
+ * `disposition.test.ts` \u2014 real filesystem root via `mkdtempSync`, mocked
+ * `workItemsService`, stubbed `listRecentRuns`, and the service instance
+ * built via `Object.create(ExecutionService.prototype)`.
+ */
+
+interface HarnessService {
+  artifactRoot: string;
+  logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+  workItemsService: {
+    get: (id: string) => WorkItemRecord;
+    update: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
+  };
+  listRecentRuns: () => ExecutionRunRecord[];
+  archiveRunArtifacts: ExecutionService["archiveRunArtifacts"];
+  assertNoActiveRunForWorkItem: (id: string) => void;
+  getErrorMessage: (err: unknown) => string;
+}
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-86",
+    name: "Studio: archive execution run artifacts",
+    kind: "issue",
+    state: "merged_pr",
+    repo: "fusupo/escapement-studio",
+    issue_number: 86,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/86",
+    scope_hint: null,
+    branch: "studio-86-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_wrap",
+    run_type: "execution",
+    work_item_id: "studio-86",
+    work_item_name: "Studio: archive execution run artifacts",
+    status: "completed",
+    created_at: "2026-04-10T10:00:00.000Z",
+    updated_at: "2026-04-10T12:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "studio-86-branch",
+    base_ref: "develop",
+    worktree_path: "",
+    artifact_dir: "",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function seedRunDir(artifactRoot: string, run: ExecutionRunRecord): string {
+  const dir = join(runsRoot(artifactRoot), run.run_id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+  writeFileSync(join(dir, "events.jsonl"), `{"type":"run_completed"}\n`, "utf8");
+  return dir;
+}
+
+function makeService(params: {
+  artifactRoot: string;
+  workItem?: WorkItemRecord;
+  runs?: ExecutionRunRecord[];
+}): HarnessService {
+  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  const workItem = params.workItem ?? makeWorkItem();
+
+  service.artifactRoot = params.artifactRoot;
+  service.logger = { log: vi.fn(), warn: vi.fn() };
+  service.workItemsService = {
+    get: (id: string) => {
+      if (id !== workItem.id) throw new NotFoundException(`not found: ${id}`);
+      return workItem;
+    },
+    update: (_id, _patch) => workItem,
+  };
+  service.listRecentRuns = () => params.runs ?? [];
+  return service;
+}
+
+describe("ExecutionService.archiveRunArtifacts", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-86-wrap-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("archives terminal runs loaded from the in-memory buffer", () => {
+    const run = makeRun({ run_id: "exec_from_memory", status: "completed" });
+    seedRunDir(tmpRoot, run);
+
+    const service = makeService({ artifactRoot: tmpRoot, runs: [run] });
+    const result = service.archiveRunArtifacts("studio-86");
+
+    expect(result.work_item_id).toBe("studio-86");
+    expect(result.archive_path).toBe(archiveDir(tmpRoot, "studio-86"));
+    expect(result.archived_run_ids).toEqual(["exec_from_memory"]);
+    expect(result.readme_path).toBe(join(archiveDir(tmpRoot, "studio-86"), "README.md"));
+    expect(existsSync(result.readme_path!)).toBe(true);
+
+    const readme = readFileSync(result.readme_path!, "utf8");
+    expect(readme).toContain("studio-86");
+    expect(readme).toContain("exec_from_memory");
+  });
+
+  it("falls back to the disk scan when recentRuns is empty (post-restart case)", () => {
+    const run = makeRun({ run_id: "exec_from_disk", status: "completed" });
+    seedRunDir(tmpRoot, run);
+
+    // recentRuns empty — mimics a fresh server after restart
+    const service = makeService({ artifactRoot: tmpRoot, runs: [] });
+    const result = service.archiveRunArtifacts("studio-86");
+
+    expect(result.archived_run_ids).toEqual(["exec_from_disk"]);
+    expect(existsSync(join(archiveDir(tmpRoot, "studio-86"), "runs", "exec_from_disk"))).toBe(true);
+  });
+
+  it.each<ExecutionRunStatus>(["queued", "preparing", "disambiguating", "running"])(
+    "refuses with BadRequestException when an active run (status=%s) exists",
+    (status) => {
+      const activeRun = makeRun({ run_id: "exec_active", status });
+      const service = makeService({ artifactRoot: tmpRoot, runs: [activeRun] });
+
+      expect(() => service.archiveRunArtifacts("studio-86")).toThrow(BadRequestException);
+      expect(() => service.archiveRunArtifacts("studio-86")).toThrow(
+        /cannot_dispose_work_item_active_run/,
+      );
+      // Archive dir not created
+      expect(existsSync(archiveDir(tmpRoot, "studio-86"))).toBe(false);
+    },
+  );
+
+  it("translates archiver collision errors into BadRequestException", () => {
+    const run = makeRun({ run_id: "exec_collide" });
+    seedRunDir(tmpRoot, run);
+
+    // Pre-create destination
+    const destDir = join(archiveDir(tmpRoot, "studio-86"), "runs", "exec_collide");
+    mkdirSync(destDir, { recursive: true });
+    writeFileSync(join(destDir, "stale.json"), "{}", "utf8");
+
+    const service = makeService({ artifactRoot: tmpRoot, runs: [run] });
+    expect(() => service.archiveRunArtifacts("studio-86")).toThrow(BadRequestException);
+    expect(() => service.archiveRunArtifacts("studio-86")).toThrow(/archive_already_exists_run/);
+  });
+
+  it("requires a non-empty work_item_id", () => {
+    const service = makeService({ artifactRoot: tmpRoot });
+    expect(() => service.archiveRunArtifacts("")).toThrow(BadRequestException);
+    expect(() => service.archiveRunArtifacts("   ")).toThrow(BadRequestException);
+  });
+
+  it("propagates NotFoundException when the work item does not exist", () => {
+    const service = makeService({ artifactRoot: tmpRoot });
+    expect(() => service.archiveRunArtifacts("studio-missing")).toThrow(NotFoundException);
+  });
+
+  it("dedupes runs present in both in-memory and disk sources", () => {
+    const run = makeRun({ run_id: "exec_dup", status: "completed" });
+    seedRunDir(tmpRoot, run);
+
+    // Same run appears in recentRuns too — shared source of truth
+    const service = makeService({ artifactRoot: tmpRoot, runs: [run] });
+    const result = service.archiveRunArtifacts("studio-86");
+
+    expect(result.archived_run_ids).toEqual(["exec_dup"]);
+  });
+});

--- a/src/modules/execution/__tests__/run-archiver.test.ts
+++ b/src/modules/execution/__tests__/run-archiver.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { archiveDir, archivesRoot, runsRoot } from "../../../lib/context-layout.js";
+import { archiveRunArtifactsForWorkItem, renderArchiveReadme } from "../run-archiver.js";
+import type { ExecutionPullRequestRecord, ExecutionRunRecord } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+/**
+ * Issue #86: tests use real `mkdtempSync` context roots so the archiver
+ * exercises actual filesystem semantics (`renameSync`, `existsSync`,
+ * `readdirSync`, `writeFileSync`). Harness pattern matches
+ * `disposition.test.ts` and `scratchpad-canonical.test.ts`.
+ */
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-86",
+    name: "Studio: archive execution run artifacts",
+    kind: "issue",
+    state: "merged_pr",
+    repo: "fusupo/escapement-studio",
+    issue_number: 86,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/86",
+    scope_hint: null,
+    branch: "studio-86-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_alpha",
+    run_type: "execution",
+    work_item_id: "studio-86",
+    work_item_name: "Studio: archive execution run artifacts",
+    status: "completed",
+    created_at: "2026-04-10T10:00:00.000Z",
+    updated_at: "2026-04-10T12:00:00.000Z",
+    started_at: "2026-04-10T10:05:00.000Z",
+    completed_at: "2026-04-10T12:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "studio-86-branch",
+    base_ref: "develop",
+    worktree_path: "",
+    artifact_dir: "",
+    prompt: "do the thing",
+    result_summary: "All tasks complete.",
+    activity_log: [],
+    changed_files: ["src/modules/execution/run-archiver.ts"],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Materialize a run dir under `runs/<run_id>/` with a minimal but
+ * archiver-compatible file set: `status.json`, `events.jsonl`, and an
+ * `outputs/` directory. Mirrors what `ExecutionService` writes during a
+ * real run so the move semantics exercise realistic trees.
+ */
+function seedRunDir(artifactRoot: string, run: ExecutionRunRecord): string {
+  const dir = join(runsRoot(artifactRoot), run.run_id);
+  mkdirSync(join(dir, "outputs"), { recursive: true });
+  writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+  writeFileSync(join(dir, "events.jsonl"), `{"type":"run_completed","run_id":"${run.run_id}"}\n`, "utf8");
+  writeFileSync(join(dir, "outputs", "response.json"), `{"assistant_text":"done"}`, "utf8");
+  return dir;
+}
+
+describe("archiveRunArtifactsForWorkItem", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-86-archiver-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("archives every terminal run into archives/<slug>/runs/<run_id>/", () => {
+    const runA = makeRun({ run_id: "exec_alpha", status: "completed" });
+    const runB = makeRun({ run_id: "exec_beta", status: "error", result_summary: "Failed at step 2." });
+    const srcA = seedRunDir(tmpRoot, runA);
+    const srcB = seedRunDir(tmpRoot, runB);
+
+    const workItem = makeWorkItem();
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem, {
+      runs: [runA, runB],
+      now: () => "2026-04-11T13:00:00.000Z",
+    });
+
+    expect(result.work_item_id).toBe("studio-86");
+    expect(result.archive_path).toBe(archiveDir(tmpRoot, "studio-86"));
+    expect(result.archived_run_ids).toEqual(["exec_alpha", "exec_beta"]);
+    expect(result.skipped_run_ids).toEqual([]);
+
+    // Sources gone
+    expect(existsSync(srcA)).toBe(false);
+    expect(existsSync(srcB)).toBe(false);
+
+    // Dests present with original files
+    const destA = join(archiveDir(tmpRoot, "studio-86"), "runs", "exec_alpha");
+    const destB = join(archiveDir(tmpRoot, "studio-86"), "runs", "exec_beta");
+    expect(existsSync(join(destA, "status.json"))).toBe(true);
+    expect(existsSync(join(destA, "events.jsonl"))).toBe(true);
+    expect(existsSync(join(destA, "outputs", "response.json"))).toBe(true);
+    expect(existsSync(join(destB, "status.json"))).toBe(true);
+
+    // README written and result.readme_path matches
+    expect(result.readme_path).toBe(join(archiveDir(tmpRoot, "studio-86"), "README.md"));
+    const readme = readFileSync(result.readme_path!, "utf8");
+    expect(readme).toContain("studio-86");
+    expect(readme).toContain("exec_alpha");
+    expect(readme).toContain("exec_beta");
+    expect(readme).toContain("2026-04-11T13:00:00.000Z");
+    expect(readme).toContain("Failed at step 2.");
+  });
+
+  it("refuses BEFORE any filesystem mutation when an active run exists", () => {
+    const active = makeRun({ run_id: "exec_running", status: "running" });
+    const completed = makeRun({ run_id: "exec_done", status: "completed" });
+    const srcCompleted = seedRunDir(tmpRoot, completed);
+
+    const workItem = makeWorkItem();
+    expect(() =>
+      archiveRunArtifactsForWorkItem(tmpRoot, workItem, { runs: [active, completed] }),
+    ).toThrow(/archive_run_active.*exec_running/);
+
+    // Source still there — guard ran before any mutation
+    expect(existsSync(srcCompleted)).toBe(true);
+    expect(existsSync(archivesRoot(tmpRoot))).toBe(false);
+  });
+
+  it("raises archive_already_exists_run on destination collision", () => {
+    const run = makeRun({ run_id: "exec_collide" });
+    const src = seedRunDir(tmpRoot, run);
+
+    // Pre-create the destination so the move collides
+    const destDir = join(archiveDir(tmpRoot, "studio-86"), "runs", "exec_collide");
+    mkdirSync(destDir, { recursive: true });
+    writeFileSync(join(destDir, "stale.json"), "{}", "utf8");
+
+    const workItem = makeWorkItem();
+    expect(() =>
+      archiveRunArtifactsForWorkItem(tmpRoot, workItem, { runs: [run] }),
+    ).toThrow(/archive_already_exists_run.*exec_collide/);
+
+    // Source still present — fail-fast before move
+    expect(existsSync(src)).toBe(true);
+  });
+
+  it("missing runs tree is a warn-and-README-only bundle (no-op move)", () => {
+    const warnings: string[] = [];
+    const workItem = makeWorkItem();
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem, {
+      runs: [],
+      onWarn: (message) => warnings.push(message),
+      now: () => "2026-04-11T13:00:00.000Z",
+    });
+
+    expect(result.archived_run_ids).toEqual([]);
+    expect(result.skipped_run_ids).toEqual([]);
+    expect(result.readme_path).toBe(join(archiveDir(tmpRoot, "studio-86"), "README.md"));
+    expect(existsSync(result.readme_path!)).toBe(true);
+    expect(warnings.join("\n")).toContain("no runs found for work item studio-86");
+
+    const readme = readFileSync(result.readme_path!, "utf8");
+    expect(readme).toContain("No terminal runs on disk");
+  });
+
+  it("records skipped_run_ids[reason=source_missing] when a terminal run's source dir vanished", () => {
+    const runWithSource = makeRun({ run_id: "exec_present", status: "completed" });
+    const runMissing = makeRun({ run_id: "exec_ghost", status: "completed" });
+    seedRunDir(tmpRoot, runWithSource);
+    // Intentionally do NOT seed runMissing's source dir
+
+    const workItem = makeWorkItem();
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem, {
+      runs: [runWithSource, runMissing],
+    });
+
+    expect(result.archived_run_ids).toEqual(["exec_present"]);
+    expect(result.skipped_run_ids).toEqual([{ run_id: "exec_ghost", reason: "source_missing" }]);
+  });
+
+  it("README includes a Pull request block when work_item.meta.studio_post_merge_sync.pull_request is present", () => {
+    const run = makeRun({ run_id: "exec_pr" });
+    seedRunDir(tmpRoot, run);
+    const workItem = makeWorkItem({
+      meta: {
+        studio_post_merge_sync: {
+          pull_request: {
+            number: 184,
+            url: "https://github.com/fusupo/escapement-studio/pull/184",
+            title: "feat(execution): archiver",
+            base_ref: "develop",
+            head_ref: "studio-86-branch",
+            is_draft: false,
+            created_at: "2026-04-10T09:00:00.000Z",
+            state: "merged",
+            merged_at: "2026-04-11T10:00:00.000Z",
+            merge_commit_sha: "abc123def",
+          },
+        },
+      },
+    });
+
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem, { runs: [run] });
+    const readme = readFileSync(result.readme_path!, "utf8");
+
+    expect(readme).toContain("## Pull request");
+    expect(readme).toContain("#184");
+    expect(readme).toContain("https://github.com/fusupo/escapement-studio/pull/184");
+    expect(readme).toContain("abc123def");
+  });
+
+  it("cross-links preserved plan dir artifacts when plan-dir archival ran first", () => {
+    // Simulate: archiveAndCloseMergedPullRequest already moved plans/<slug>/ here
+    const targetArchive = archiveDir(tmpRoot, "studio-86");
+    mkdirSync(targetArchive, { recursive: true });
+    writeFileSync(join(targetArchive, "SCRATCHPAD_studio_86.md"), "plan content", "utf8");
+    writeFileSync(join(targetArchive, "metadata.json"), "{}", "utf8");
+
+    const run = makeRun({ run_id: "exec_after_plan_archive" });
+    seedRunDir(tmpRoot, run);
+
+    const workItem = makeWorkItem();
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem, { runs: [run] });
+    const readme = readFileSync(result.readme_path!, "utf8");
+
+    expect(readme).toContain("## Plan artifacts");
+    expect(readme).toContain("SCRATCHPAD_studio_86.md");
+    expect(readme).toContain("metadata.json");
+  });
+
+  it("falls back to disk scan when options.runs is not supplied", () => {
+    const run = makeRun({ run_id: "exec_disk_scan" });
+    seedRunDir(tmpRoot, run);
+    // Also seed a run for a different work item — archiver must ignore it
+    seedRunDir(tmpRoot, makeRun({ run_id: "exec_other", work_item_id: "studio-999" }));
+
+    const workItem = makeWorkItem();
+    const result = archiveRunArtifactsForWorkItem(tmpRoot, workItem);
+
+    expect(result.archived_run_ids).toEqual(["exec_disk_scan"]);
+    // Other work item's run left alone
+    expect(existsSync(join(runsRoot(tmpRoot), "exec_other"))).toBe(true);
+  });
+});
+
+describe("renderArchiveReadme", () => {
+  it("renders core work item fields and archive metadata", () => {
+    const workItem = makeWorkItem();
+    const run = makeRun({ run_id: "exec_render", result_summary: "ok" });
+    const readme = renderArchiveReadme(workItem, [run], {
+      archivePath: "/tmp/archives/studio_86",
+      archivedRunIds: ["exec_render"],
+      skippedRunIds: [],
+      archivedAt: "2026-04-11T13:00:00.000Z",
+      pullRequest: null,
+    });
+
+    expect(readme).toContain("# Archive: studio-86");
+    expect(readme).toContain("Studio: archive execution run artifacts");
+    expect(readme).toContain("- **state:** merged_pr");
+    expect(readme).toContain("- **archived_at:** 2026-04-11T13:00:00.000Z");
+    expect(readme).toContain("/tmp/archives/studio_86");
+    expect(readme).toContain("### Run `exec_render`");
+    expect(readme).toContain("runs/exec_render/");
+  });
+
+  it("lists skipped runs when supplied", () => {
+    const workItem = makeWorkItem();
+    const readme = renderArchiveReadme(workItem, [], {
+      archivePath: "/tmp/archives/studio_86",
+      archivedRunIds: [],
+      skippedRunIds: [{ run_id: "exec_skipped", reason: "not_terminal:running" }],
+      archivedAt: "2026-04-11T13:00:00.000Z",
+      pullRequest: null,
+    });
+
+    expect(readme).toContain("## Skipped runs");
+    expect(readme).toContain("exec_skipped");
+    expect(readme).toContain("not_terminal:running");
+  });
+
+  it("truncates long result summaries", () => {
+    const workItem = makeWorkItem();
+    const longSummary = "x".repeat(1000);
+    const run = makeRun({ run_id: "exec_long", result_summary: longSummary });
+    const readme = renderArchiveReadme(workItem, [run], {
+      archivePath: "/tmp/archives/studio_86",
+      archivedRunIds: ["exec_long"],
+      skippedRunIds: [],
+      archivedAt: "2026-04-11T13:00:00.000Z",
+      pullRequest: null,
+    });
+
+    // Truncated to 480 chars plus ellipsis
+    expect(readme).not.toContain("x".repeat(1000));
+    expect(readme).toContain("x".repeat(480) + "\u2026");
+  });
+});

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -19,7 +19,8 @@ import {
 } from "../../lib/context-layout.js";
 import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
-import { loadRunRecordsFromDisk } from "./run-disk-store.js";
+import { loadRunRecordsForArtifactRoot, loadRunRecordsFromDisk } from "./run-disk-store.js";
+import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -29,6 +30,7 @@ import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
   ActivityLogEntry,
   ActivityLogEntryKind,
+  ArchiveRunArtifactsResult,
   ChecklistItem,
   CreateExecutionPullRequestDto,
   CreateExecutionPullRequestResult,
@@ -2266,6 +2268,65 @@ export class ExecutionService implements OnModuleInit {
    * Called by `archiveAndCloseMergedPullRequest` and (eventually) the
    * `cancelled` disposition path.
    */
+  /**
+   * Issue #86: archive execution run artifacts + a generated README for a
+   * completed work item.
+   *
+   * Thin wrapper around `archiveRunArtifactsForWorkItem` — loads the work
+   * item, re-uses `assertNoActiveRunForWorkItem` as the pre-archive guard
+   * (which provides a `BadRequestException` for a consistent HTTP surface),
+   * hands the disk-scanned run list to the helper so the archiver and the
+   * active-run guard share the same source of truth, and returns the
+   * helper's `ArchiveRunArtifactsResult` unchanged.
+   *
+   * Deliberately NOT yet called from `archiveAndCloseMergedPullRequest` —
+   * that wiring belongs to issue #88's disposition flow so #86 can land
+   * and be reviewed as a self-contained backend slice.
+   */
+  archiveRunArtifacts(workItemId: string): ArchiveRunArtifactsResult {
+    const normalized = workItemId?.trim();
+    if (!normalized) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    const workItem = this.workItemsService.get(normalized);
+    this.assertNoActiveRunForWorkItem(normalized);
+
+    // Merge in-memory `recentRuns` with the disk scan so the archiver sees
+    // runs that exist only on disk (post-restart) and in-memory runs that
+    // haven't been flushed. Dedupe by run_id — in-memory wins because it
+    // carries the freshest activity log.
+    const diskRuns = loadRunRecordsForArtifactRoot(this.artifactRoot);
+    const seen = new Set<string>();
+    const merged: ExecutionRunRecord[] = [];
+    for (const run of this.listRecentRuns()) {
+      if (run.work_item_id !== normalized) continue;
+      if (seen.has(run.run_id)) continue;
+      merged.push(run);
+      seen.add(run.run_id);
+    }
+    for (const run of diskRuns) {
+      if (run.work_item_id !== normalized) continue;
+      if (seen.has(run.run_id)) continue;
+      merged.push(run);
+      seen.add(run.run_id);
+    }
+
+    try {
+      return archiveRunArtifactsForWorkItem(this.artifactRoot, workItem, {
+        runs: merged,
+        onWarn: (message) => this.logger.warn(message),
+      });
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      // Translate the archiver's raw Error codes into BadRequestException
+      // so the HTTP surface matches the other disposition guards.
+      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
+        throw new BadRequestException(message);
+      }
+      throw error;
+    }
+  }
+
   private movePlanDirToArchives(workItemId: string): { moved: boolean; archive_path: string | null } {
     const src = planDir(this.artifactRoot, workItemId);
     const dest = archiveDir(this.artifactRoot, workItemId);

--- a/src/modules/execution/run-archiver.ts
+++ b/src/modules/execution/run-archiver.ts
@@ -1,0 +1,379 @@
+import { existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { archiveDir, archivesRoot, runsRoot } from "../../lib/context-layout.js";
+import { loadRunRecordsFromDisk } from "./run-disk-store.js";
+import type {
+  ArchivableRunStatus,
+  ArchiveRunArtifactsResult,
+  ExecutionPullRequestRecord,
+  ExecutionRunRecord,
+  ExecutionRunStatus,
+} from "./types.js";
+import type { WorkItemRecord } from "../graph/types.js";
+
+/**
+ * Issue #86: pure filesystem helpers for archiving completed execution run
+ * artifacts + a generated README for a work item.
+ *
+ * Mirrors `run-disk-store.ts`: no Nest imports, trivially unit-testable with
+ * a real `mkdtempSync` context root. The helper is imported by
+ * `ExecutionService.archiveRunArtifacts` (the thin Nest wrapper used by
+ * #88's disposition wiring) and by the dedicated test file.
+ *
+ * Path construction flows through `archiveDir` / `archivesRoot` / `runsRoot`
+ * in `src/lib/context-layout.ts` \u2014 the single source of truth for context-
+ * root layout per ADR 014 step 1. Run discovery uses
+ * `loadRunRecordsFromDisk` so archival is not capped at the 16-entry
+ * in-memory `recentRuns` buffer on `ExecutionService`.
+ */
+
+const TERMINAL_STATUSES: ReadonlySet<ExecutionRunStatus> = new Set<ExecutionRunStatus>([
+  "completed",
+  "error",
+  "blocked",
+]);
+
+const ACTIVE_STATUSES: ReadonlySet<ExecutionRunStatus> = new Set<ExecutionRunStatus>([
+  "queued",
+  "preparing",
+  "disambiguating",
+  "running",
+]);
+
+function isTerminal(status: ExecutionRunStatus): status is ArchivableRunStatus {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export interface ArchiveRunArtifactsOptions {
+  /**
+   * Optional injected logger hook. Defaults to `console.warn` with a
+   * `[run-archiver]` prefix so tests can assert without real IO.
+   */
+  onWarn?: (message: string) => void;
+  /**
+   * Optional clock hook so tests can pin the archive timestamp written to
+   * the README. Defaults to `new Date().toISOString()`.
+   */
+  now?: () => string;
+  /**
+   * Optional pre-loaded run records for the work item. Supplied by the
+   * `ExecutionService` wrapper so it can reuse the same disk scan the
+   * active-run guard consumed. When absent the archiver re-reads disk via
+   * `loadRunRecordsFromDisk(runsRoot(artifactRoot))` and filters to the
+   * target work item.
+   */
+  runs?: ExecutionRunRecord[];
+  /**
+   * Optional pull request metadata to include in the README preamble.
+   * Defaults to `work_item.meta.studio_post_merge_sync.pull_request` when
+   * that shape is present.
+   */
+  pullRequest?: ExecutionPullRequestRecord | null;
+}
+
+/**
+ * Core archival entry point.
+ *
+ * Order of operations (matches the #86 acceptance criteria):
+ *
+ *   1. Short-circuit if any run for the work item is non-terminal \u2014 the
+ *      guard runs BEFORE any filesystem mutation so a refused archive
+ *      leaves the context root untouched. Raises `archive_run_active` with
+ *      the offending run id.
+ *   2. Ensure `archives/<slug>/runs/` exists (creating `archivesRoot`,
+ *      `archives/<slug>/`, and `archives/<slug>/runs/` as needed).
+ *   3. Iterate terminal runs in `updated_at`-descending order and
+ *      `renameSync` each `runs/<run_id>/` into
+ *      `archives/<slug>/runs/<run_id>/`. A destination collision raises
+ *      `archive_already_exists_run` \u2014 earlier moves are NOT rolled back
+ *      (operators must resolve the partial archive manually).
+ *   4. Render the README from the in-memory run records captured BEFORE
+ *      the move so the metadata survives the source dir vanishing.
+ *
+ * Returns an `ArchiveRunArtifactsResult` so callers can persist / report
+ * the outcome. A no-op (no runs on disk for the work item) still writes a
+ * README describing the empty bundle so future forensic readers have a
+ * landing point.
+ */
+export function archiveRunArtifactsForWorkItem(
+  artifactRoot: string,
+  workItem: WorkItemRecord,
+  options: ArchiveRunArtifactsOptions = {},
+): ArchiveRunArtifactsResult {
+  const warn = options.onWarn ?? ((message) => console.warn(`[run-archiver] ${message}`));
+  const now = options.now ?? (() => new Date().toISOString());
+
+  // Gather candidate runs. Prefer the caller-supplied list so a single
+  // disk scan can be shared between the active-run guard and the archiver.
+  const allRuns = options.runs ?? loadRunRecordsFromDisk(runsRoot(artifactRoot), { onWarn: warn });
+  const workItemRuns = allRuns.filter((run) => run.work_item_id === workItem.id);
+
+  // Guard 1: active run short-circuit. Raised BEFORE any filesystem
+  // mutation so a refused archive leaves the context root untouched.
+  for (const run of workItemRuns) {
+    if (ACTIVE_STATUSES.has(run.status)) {
+      throw new Error(
+        `archive_run_active: refusing to archive work item ${workItem.id} \u2014 run ${run.run_id} is ${run.status}. ` +
+          `Wait for it to finish or clean it up before archiving.`,
+      );
+    }
+  }
+
+  const targetArchiveDir = archiveDir(artifactRoot, workItem.id);
+  const targetRunsDir = join(targetArchiveDir, "runs");
+  const terminalRuns = workItemRuns.filter((run) => isTerminal(run.status));
+  const skippedNonTerminal = workItemRuns.filter((run) => !isTerminal(run.status));
+
+  if (workItemRuns.length === 0) {
+    warn(
+      `no runs found for work item ${workItem.id}; writing README-only archive bundle at ${targetArchiveDir}`,
+    );
+  }
+
+  // Ensure `archives/`, `archives/<slug>/`, and `archives/<slug>/runs/`
+  // exist before the first move. `mkdirSync({ recursive: true })` is a
+  // no-op when the dirs already exist (e.g. a prior plan-dir archive
+  // already populated `archives/<slug>/`).
+  mkdirSync(archivesRoot(artifactRoot), { recursive: true });
+  mkdirSync(targetArchiveDir, { recursive: true });
+  mkdirSync(targetRunsDir, { recursive: true });
+
+  const archivedRunIds: string[] = [];
+  const skippedRunIds: Array<{ run_id: string; reason: string }> = skippedNonTerminal.map((run) => ({
+    run_id: run.run_id,
+    reason: `not_terminal:${run.status}`,
+  }));
+
+  for (const run of terminalRuns) {
+    const sourceDir = join(runsRoot(artifactRoot), run.run_id);
+    const destDir = join(targetRunsDir, run.run_id);
+
+    if (!existsSync(sourceDir)) {
+      warn(
+        `archiveRunArtifactsForWorkItem: source ${sourceDir} missing for run ${run.run_id}; skipping move`,
+      );
+      skippedRunIds.push({ run_id: run.run_id, reason: "source_missing" });
+      continue;
+    }
+
+    if (existsSync(destDir)) {
+      throw new Error(
+        `archive_already_exists_run: refusing to move run ${run.run_id} \u2014 destination ${destDir} already exists. ` +
+          `Resolve the collision manually before retrying.`,
+      );
+    }
+
+    renameSync(sourceDir, destDir);
+    archivedRunIds.push(run.run_id);
+  }
+
+  // Render README AFTER the moves so the `archives/<slug>/runs/<run_id>/`
+  // paths in the markdown reflect the final on-disk layout. Metadata
+  // comes from the in-memory run records captured before the move.
+  const readmePath = join(targetArchiveDir, "README.md");
+  const readme = renderArchiveReadme(workItem, terminalRuns, {
+    archivePath: targetArchiveDir,
+    archivedRunIds,
+    skippedRunIds,
+    archivedAt: now(),
+    pullRequest: options.pullRequest ?? extractPullRequestFromWorkItemMeta(workItem),
+  });
+  writeFileSync(readmePath, readme, "utf8");
+
+  return {
+    work_item_id: workItem.id,
+    archive_path: targetArchiveDir,
+    readme_path: readmePath,
+    archived_run_ids: archivedRunIds,
+    skipped_run_ids: skippedRunIds,
+  };
+}
+
+export interface RenderArchiveReadmeContext {
+  archivePath: string;
+  archivedRunIds: string[];
+  skippedRunIds: Array<{ run_id: string; reason: string }>;
+  archivedAt: string;
+  pullRequest: ExecutionPullRequestRecord | null;
+}
+
+/**
+ * Render the `archives/<slug>/README.md` body.
+ *
+ * Content (in order):
+ *   1. Title + work item id / name / kind / repo / issue link
+ *   2. Final state + archive timestamp + archive path
+ *   3. Optional PR block (number / url / state / merged_at / merge_commit_sha)
+ *   4. Per-run section with run_id, status, branch, base_ref, timestamps,
+ *      changed-file count, truncated result_summary, and the archived
+ *      path under `runs/<run_id>/`.
+ *   5. Optional skipped-runs section for non-terminal or collision-skipped runs.
+ *   6. Cross-links to the archived scratchpad + metadata.json if they exist
+ *      in the archive dir (plan-dir archival may have run first).
+ */
+export function renderArchiveReadme(
+  workItem: WorkItemRecord,
+  runs: ExecutionRunRecord[],
+  ctx: RenderArchiveReadmeContext,
+): string {
+  const lines: string[] = [];
+  const issueLink = workItem.issue_url ? `[#${workItem.issue_number ?? "?"}](${workItem.issue_url})` : "n/a";
+
+  lines.push(`# Archive: ${workItem.id} \u2014 ${workItem.name}`);
+  lines.push("");
+  lines.push(`> Auto-generated by \`archiveRunArtifactsForWorkItem\` (issue #86).`);
+  lines.push("");
+  lines.push("## Work item");
+  lines.push("");
+  lines.push(`- **id:** \`${workItem.id}\``);
+  lines.push(`- **name:** ${workItem.name}`);
+  lines.push(`- **kind:** ${workItem.kind}`);
+  lines.push(`- **state:** ${workItem.state}`);
+  lines.push(`- **repo:** ${workItem.repo ?? "n/a"}`);
+  lines.push(`- **issue:** ${issueLink}`);
+  lines.push(`- **branch:** ${workItem.branch ?? "n/a"}`);
+  lines.push(`- **archived_at:** ${ctx.archivedAt}`);
+  lines.push(`- **archive_path:** \`${ctx.archivePath}\``);
+  lines.push("");
+
+  if (ctx.pullRequest) {
+    lines.push("## Pull request");
+    lines.push("");
+    lines.push(`- **number:** #${ctx.pullRequest.number}`);
+    lines.push(`- **url:** ${ctx.pullRequest.url}`);
+    lines.push(`- **title:** ${ctx.pullRequest.title}`);
+    lines.push(`- **base_ref:** ${ctx.pullRequest.base_ref}`);
+    lines.push(`- **head_ref:** ${ctx.pullRequest.head_ref}`);
+    if (ctx.pullRequest.state) lines.push(`- **state:** ${ctx.pullRequest.state}`);
+    if (ctx.pullRequest.merged_at) lines.push(`- **merged_at:** ${ctx.pullRequest.merged_at}`);
+    if (ctx.pullRequest.merge_commit_sha) lines.push(`- **merge_commit_sha:** \`${ctx.pullRequest.merge_commit_sha}\``);
+    lines.push("");
+  }
+
+  lines.push("## Archived runs");
+  lines.push("");
+  if (runs.length === 0) {
+    lines.push("_No terminal runs on disk when this archive was created._");
+    lines.push("");
+  } else {
+    for (const run of runs) {
+      const archivedHere = ctx.archivedRunIds.includes(run.run_id);
+      lines.push(`### Run \`${run.run_id}\``);
+      lines.push("");
+      lines.push(`- **status:** ${run.status}`);
+      lines.push(`- **branch:** ${run.branch}`);
+      lines.push(`- **base_ref:** ${run.base_ref}`);
+      lines.push(`- **created_at:** ${run.created_at}`);
+      if (run.started_at) lines.push(`- **started_at:** ${run.started_at}`);
+      if (run.completed_at) lines.push(`- **completed_at:** ${run.completed_at}`);
+      lines.push(`- **changed_file_count:** ${run.changed_files?.length ?? 0}`);
+      if (run.pull_request) {
+        lines.push(`- **pull_request:** #${run.pull_request.number} (${run.pull_request.url})`);
+      }
+      lines.push(
+        archivedHere
+          ? `- **archived_at:** \`runs/${run.run_id}/\` (moved into this bundle)`
+          : `- **archived_at:** _source missing at archive time_`,
+      );
+      if (run.result_summary) {
+        const truncated = run.result_summary.length > 480
+          ? `${run.result_summary.slice(0, 480)}\u2026`
+          : run.result_summary;
+        lines.push("");
+        lines.push("**Result summary:**");
+        lines.push("");
+        lines.push("```");
+        lines.push(truncated);
+        lines.push("```");
+      }
+      lines.push("");
+    }
+  }
+
+  if (ctx.skippedRunIds.length > 0) {
+    lines.push("## Skipped runs");
+    lines.push("");
+    for (const skipped of ctx.skippedRunIds) {
+      lines.push(`- \`${skipped.run_id}\` \u2014 ${skipped.reason}`);
+    }
+    lines.push("");
+  }
+
+  const planDirNotes = describePreservedPlanDir(ctx.archivePath);
+  if (planDirNotes.length > 0) {
+    lines.push("## Plan artifacts");
+    lines.push("");
+    for (const note of planDirNotes) lines.push(note);
+    lines.push("");
+  }
+
+  lines.push("## Notes");
+  lines.push("");
+  lines.push("- Move semantics: run dirs are `fs.renameSync`\u2019d from `runs/<run_id>/` into this bundle; source dirs no longer exist after archival.");
+  lines.push("- See [ADR 014](../../docs/adr/014-plans-runs-state-model.md) and [docs/contracts/run-artifacts.md](../../docs/contracts/run-artifacts.md) for the archive layout contract.");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * If plan-dir archival ran first (common path via
+ * `archiveAndCloseMergedPullRequest`), the archive dir will already
+ * contain `SCRATCHPAD_<slug>.md` and `metadata.json`. Surface them as
+ * cross-links in the README so forensic readers can find them.
+ *
+ * Silent no-op when the archive dir is empty apart from `runs/`.
+ */
+function describePreservedPlanDir(archivePathAbs: string): string[] {
+  const notes: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(archivePathAbs);
+  } catch {
+    return notes;
+  }
+  for (const entry of entries) {
+    if (entry === "runs" || entry === "README.md") continue;
+    if (entry === "metadata.json") {
+      notes.push("- `metadata.json` \u2014 plan metadata preserved from the `plans/<slug>/` archival.");
+      continue;
+    }
+    if (entry.startsWith("SCRATCHPAD_") && entry.endsWith(".md")) {
+      notes.push(`- \`${entry}\` \u2014 canonical scratchpad preserved from the \`plans/<slug>/\` archival.`);
+      continue;
+    }
+    notes.push(`- \`${entry}\` \u2014 preserved from an earlier archive step.`);
+  }
+  return notes;
+}
+
+/**
+ * Pull the `pull_request` block out of
+ * `work_item.meta.studio_post_merge_sync.pull_request` when present. That
+ * shape is written by `ExecutionService.syncMergedPullRequest` during the
+ * `open_pr \u2192 merged_pr` transition. Returns `null` when the shape is
+ * missing or malformed \u2014 the README simply omits the PR section in that
+ * case.
+ */
+function extractPullRequestFromWorkItemMeta(workItem: WorkItemRecord): ExecutionPullRequestRecord | null {
+  const meta = workItem.meta ?? {};
+  const sync = (meta as Record<string, unknown>).studio_post_merge_sync;
+  if (!sync || typeof sync !== "object") return null;
+  const pr = (sync as Record<string, unknown>).pull_request;
+  if (!pr || typeof pr !== "object") return null;
+  const candidate = pr as Partial<ExecutionPullRequestRecord>;
+  if (typeof candidate.number !== "number" || typeof candidate.url !== "string") return null;
+  return {
+    number: candidate.number,
+    url: candidate.url,
+    title: typeof candidate.title === "string" ? candidate.title : "",
+    body: typeof candidate.body === "string" ? candidate.body : "",
+    base_ref: typeof candidate.base_ref === "string" ? candidate.base_ref : "",
+    head_ref: typeof candidate.head_ref === "string" ? candidate.head_ref : "",
+    is_draft: Boolean(candidate.is_draft),
+    created_at: typeof candidate.created_at === "string" ? candidate.created_at : "",
+    state: typeof candidate.state === "string" ? candidate.state : undefined,
+    merged_at: typeof candidate.merged_at === "string" ? candidate.merged_at : null,
+    merge_commit_sha: typeof candidate.merge_commit_sha === "string" ? candidate.merge_commit_sha : null,
+  };
+}

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -270,3 +270,41 @@ export interface ResolveDisambiguationResult {
 export interface TransitionWorkItemDto {
   work_item_id: string;
 }
+
+/**
+ * Issue #86: result of archiving execution run artifacts + generated
+ * summary for a completed work item.
+ *
+ * Produced by `archiveRunArtifactsForWorkItem` and surfaced through the
+ * thin `ExecutionService.archiveRunArtifacts` wrapper. Callers (currently
+ * #88's disposition wiring) persist `archive_path` onto the work item and
+ * report `archived_run_ids` / `skipped_run_ids` back to operators.
+ *
+ * - `archive_path` is the `archives/<slug>/` directory that contains the
+ *   moved run dirs and the generated `README.md`.
+ * - `readme_path` is the absolute path to the written README (may equal
+ *   `<archive_path>/README.md`). `null` when no README was written — e.g.
+ *   a no-op archive with zero runs to move.
+ * - `archived_run_ids` lists every run successfully moved into the
+ *   archive bundle, in the order they were processed.
+ * - `skipped_run_ids` records per-run reasons for runs the helper chose
+ *   not to move (currently only `not_terminal` — the active-run guard
+ *   short-circuits before any run is inspected, so active runs never
+ *   show up here).
+ */
+export interface ArchiveRunArtifactsResult {
+  work_item_id: string;
+  archive_path: string;
+  readme_path: string | null;
+  archived_run_ids: string[];
+  skipped_run_ids: Array<{ run_id: string; reason: string }>;
+}
+
+/**
+ * Issue #86: the terminal execution run statuses eligible for archival.
+ *
+ * `completed`, `error`, and `blocked` are the three terminal statuses
+ * `ExecutionRunStatus` can reach. `queued | preparing | disambiguating
+ * | running` runs are refused by the pre-archive active-run guard.
+ */
+export type ArchivableRunStatus = Extract<ExecutionRunStatus, "completed" | "error" | "blocked">;


### PR DESCRIPTION
## Summary
Good — the scratchpad is gitignored, so my updates are preserved locally but not committed. Everything is clean.

## Final Summary

**What I changed:**

1. **`src/modules/execution/types.ts`** — added `ArchiveRunArtifactsResult` and `ArchivableRunStatus` types (commit b5a9b5f).
2. **`src/modules/execution/run-archiver.ts`** (new) — pure filesystem archiver `archiveRunArtifactsForWorkItem` + `renderArchiveReadme`. Active-run guard before any mutation, `fs.renameSync` move semantics, destination collision detection, disk-scan fallback via `loadRunRecordsFromDisk`, README with work item / PR / per-run sections + plan-dir cross-links (commit 7701579).
3. **`src/modules/execution/__tests__/run-archiver.test.ts`** (new) — 11 tests: happy path, active-run refusal, collision, no-op bundle, source-missing skip, PR block rendering, plan-dir cross-linking, disk-scan fallback, README render edge cases (commit 9406090).
4. **`src/modules/execution/execution.service.ts`** — added `archiveRunArtifacts(workItemId)` wrapper that re-uses `assertNoActiveRunForWorkItem`, merges recent runs + disk scan, and translates archiver errors into `BadRequestException`. Not yet wired into `archiveAndCloseMergedPullRequest` (#88's scope). Plus **`src/modules/execution/__tests__/archive-run-artifacts.test.ts`** (new) — 10 tests for the wrapper (commit e251b50).
5. **`docs/contracts/run-artifacts.md`** — added "Archive bundle layout" section documenting tree, move semantics, guards/errors, README fields table, and wiring status (commit 0031ddc).

**Quality checks:**

- `npx tsc --noEmit` — clean
- `npx vitest run run-archiver archive-run-artifacts disposition` — **50 tests passing** (11 new archiver + 10 new wrapper + 29 existing disposition)
- `npx vite build --config web/vite.config.ts` — builds successfully
- Full `npx vitest run` has 18 pre-existing failures in `graph-writer.service.test.ts` and `state-machine-allowlist.test.ts` (better-sqlite3 binding issue) that are unrelated to this branch — verified via `git stash` on the base.

**Follow-ups / blockers:**

- None for #86. The wrapper is intentionally not wired into `archiveAndCloseMergedPullRequest` — that is #88's scope. When #88 lands it should call `ExecutionService.archiveRunArtifacts(workItemId)` after `movePlanDirToArchives` completes.

actual_files synced: 0 file(s).

## Context
- Work item: studio-86
- Issue: https://github.com/fusupo/escapement-studio/issues/86
- Base branch: develop
- Head branch: studio-86-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775887822276
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-86-branch
- Scope hint: Archive execution run artifacts, logs, and a generated summary so completed runs can be preserved before they leave Recent execution runs.

## Changed files
- (not recorded)