### PR TITLE
[#85] Studio: gate run close actions on merged PR and open GitHub issue state

### DIFF
--- a/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
@@ -10,6 +10,7 @@ function makeReconciled(id: string): ReconciledWorkItem {
     latest_run: null,
     github_pr: null,
     worktree: null,
+    github_issue_state: null,
     next_action: "relaunch",
     rationale: "stub",
   };

--- a/src/modules/execution/__tests__/work-item-reconciler.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler.test.ts
@@ -171,6 +171,7 @@ describe("WorkItemReconcilerService.reconcile", () => {
     pr?: { state: string; number: number; url: string; merged_at: string | null } | null;
     git?: Partial<Record<"count" | "status", string>>;
     worktreeExists?: boolean;
+    issueState?: string | null;
   }) {
     const service = Object.create(WorkItemReconcilerService.prototype) as WorkItemReconcilerService;
     const diskStore: ReconcilerDiskStore = {
@@ -199,6 +200,7 @@ describe("WorkItemReconcilerService.reconcile", () => {
     };
     const githubService = {
       findPullRequestForBranch: vi.fn(async () => stubs.pr ?? null),
+      readIssue: vi.fn(async () => ({ state: stubs.issueState ?? "open" })),
     };
 
     (service as any).logger = { log: vi.fn(), warn: vi.fn() };
@@ -245,6 +247,89 @@ describe("WorkItemReconcilerService.reconcile", () => {
     expect(reconciled[0].github_pr).toMatchObject({ number: 200, state: "MERGED" });
     expect(reconciled[0].next_action).toBe("close_out");
     expect(githubService.findPullRequestForBranch).not.toHaveBeenCalled();
+    // Issue #85: merged PR triggers the readIssue probe and populates
+    // github_issue_state.
+    expect(githubService.readIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 176);
+    expect(reconciled[0].github_issue_state).toBe("open");
+  });
+
+  it("populates github_issue_state from readIssue when PR is merged", async () => {
+    const run = makeRun({
+      pull_request: {
+        number: 200,
+        url: "https://github.com/x/y/pull/200",
+        title: "t",
+        body: "b",
+        base_ref: "develop",
+        head_ref: "studio-176-branch",
+        is_draft: false,
+        created_at: "2026-04-10T00:00:00.000Z",
+        state: "MERGED",
+        merged_at: "2026-04-10T01:00:00.000Z",
+        merge_commit_sha: "deadbeef",
+      },
+    });
+    const { service } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [run],
+      worktreeExists: true,
+      issueState: "CLOSED",
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].github_issue_state).toBe("closed");
+  });
+
+  it("does not call readIssue when PR is open (skip optimization)", async () => {
+    const { service, githubService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+      pr: { number: 201, state: "OPEN", merged_at: null, url: "https://github.com/x/y/pull/201" },
+      git: { count: "2\n" },
+      worktreeExists: true,
+    });
+    const reconciled = await service.reconcile();
+    expect(githubService.readIssue).not.toHaveBeenCalled();
+    expect(reconciled[0].github_issue_state).toBeNull();
+  });
+
+  it("does not call readIssue when PR is absent", async () => {
+    const { service, githubService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+      git: { count: "2\n" },
+      worktreeExists: true,
+    });
+    const reconciled = await service.reconcile();
+    expect(githubService.readIssue).not.toHaveBeenCalled();
+    expect(reconciled[0].github_issue_state).toBeNull();
+  });
+
+  it("degrades gracefully when readIssue throws", async () => {
+    const run = makeRun({
+      pull_request: {
+        number: 200,
+        url: "https://github.com/x/y/pull/200",
+        title: "t",
+        body: "b",
+        base_ref: "develop",
+        head_ref: "studio-176-branch",
+        is_draft: false,
+        created_at: "2026-04-10T00:00:00.000Z",
+        state: "MERGED",
+        merged_at: "2026-04-10T01:00:00.000Z",
+        merge_commit_sha: "deadbeef",
+      },
+    });
+    const { service, githubService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [run],
+      worktreeExists: true,
+    });
+    (githubService.readIssue as any).mockRejectedValueOnce(new Error("gh rate limited"));
+
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].github_issue_state).toBeNull();
+    expect(((service as any).logger.warn as any).mock.calls.length).toBeGreaterThan(0);
   });
 
   it("calls GitHubService.findPullRequestForBranch when no stored PR", async () => {
@@ -317,7 +402,7 @@ describe("WorkItemReconcilerService.runStartupReconcile", () => {
     (service as any).logger = logger;
     (service as any).runsDir = "/tmp/runs";
     (service as any).workItemsService = { list: vi.fn(() => []), get: vi.fn() };
-    (service as any).githubService = { findPullRequestForBranch: vi.fn() };
+    (service as any).githubService = { findPullRequestForBranch: vi.fn(), readIssue: vi.fn() };
     service.diskStore = diskStore;
     service.gitRunner = { run: vi.fn(() => "") };
     service.pathExists = () => false;

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -138,6 +138,12 @@ export class WorkItemReconcilerService {
       const latestRun = this.pickLatestRun(runsByWorkItem.get(workItem.id) ?? []);
       const worktree = this.probeWorktree(workItem, latestRun);
       const githubPr = await this.probePullRequest(workItem, latestRun);
+      // Issue #85: only probe issue state when the PR is merged —
+      // non-close_out rows never consume `github_issue_state`, and
+      // `gh issue view` is rate-limited, so skip the call otherwise.
+      const githubIssueState = this.shouldProbeIssueState(githubPr)
+        ? await this.probeIssueState(workItem)
+        : null;
       const { nextAction, rationale } = decideNextAction({ workItem, latestRun, worktree, githubPr });
 
       out.push({
@@ -146,12 +152,48 @@ export class WorkItemReconcilerService {
         latest_run: latestRun,
         github_pr: githubPr,
         worktree,
+        github_issue_state: githubIssueState,
         next_action: nextAction,
         rationale,
       });
     }
 
     return out;
+  }
+
+  /**
+   * Issue #85: only fetch GitHub issue state when the reconciled PR is
+   * merged. The Execution tab's Close / Archive-and-close gate only
+   * consumes `github_issue_state` for close_out rows, so skipping the
+   * `gh issue view` call on every in-progress reconcile keeps the
+   * common case cheap.
+   */
+  private shouldProbeIssueState(githubPr: ReconciledPullRequest | null): boolean {
+    if (!githubPr) return false;
+    return githubPr.state === "MERGED" || Boolean(githubPr.merged_at);
+  }
+
+  /**
+   * Issue #85: probe the linked GitHub issue and return its normalized
+   * state ("open" | "closed"). Mirrors `probePullRequest`'s graceful
+   * degradation — a failing `gh issue view` logs a warning and returns
+   * `null` so the UI can render a safe default (no disposition action).
+   */
+  private async probeIssueState(workItem: WorkItemRecord): Promise<"open" | "closed" | null> {
+    if (!workItem.repo || !Number.isInteger(workItem.issue_number)) {
+      return null;
+    }
+    try {
+      const issue = await this.githubService.readIssue(workItem.repo, workItem.issue_number);
+      const raw = (issue?.state ?? "").toString().toLowerCase();
+      if (raw === "open" || raw === "closed") return raw;
+      return null;
+    } catch (error) {
+      this.logger.warn(
+        `readIssue failed for ${workItem.repo}#${workItem.issue_number}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -180,7 +180,7 @@ export class WorkItemReconcilerService {
    * `null` so the UI can render a safe default (no disposition action).
    */
   private async probeIssueState(workItem: WorkItemRecord): Promise<"open" | "closed" | null> {
-    if (!workItem.repo || !Number.isInteger(workItem.issue_number)) {
+    if (!workItem.repo || typeof workItem.issue_number !== "number" || !Number.isInteger(workItem.issue_number)) {
       return null;
     }
     try {

--- a/src/modules/execution/work-item-reconciler.types.ts
+++ b/src/modules/execution/work-item-reconciler.types.ts
@@ -50,6 +50,12 @@ export interface ReconciledWorktree {
  *   underlying `gh` call fails, or when no PR exists for the branch
  * - `worktree` is `null` only when no branch is known; otherwise it is a
  *   probe result (may have `exists: false`)
+ * - `github_issue_state` is the lowercased GitHub issue state ("open" |
+ *   "closed") when the work item has a linked issue and the probe
+ *   succeeded; `null` when the work item has no linked issue or when the
+ *   probe failed / was skipped (see #85). Used by the Execution tab to
+ *   gate merged-run disposition actions — the UI only shows Close /
+ *   Archive-and-close buttons when this field is `"open"`.
  * - `rationale` is a short human-readable string summarizing which inputs
  *   drove the `next_action` verdict; used by the UI and startup log
  */
@@ -59,6 +65,7 @@ export interface ReconciledWorkItem {
   latest_run: ExecutionRunRecord | null;
   github_pr: ReconciledPullRequest | null;
   worktree: ReconciledWorktree | null;
+  github_issue_state: "open" | "closed" | null;
   next_action: NextAction;
   rationale: string;
 }


### PR DESCRIPTION
## Summary
Execution run completed.

actual_files synced: 3 file(s).

## Context
- Work item: studio-85
- Issue: https://github.com/fusupo/escapement-studio/issues/85
- Base branch: develop
- Head branch: studio-85-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775887175061
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-85-branch
- Scope hint: Make execution run disposition actions PR-aware and issue-state-aware so they only appear when a run is truly ready to close.

## Changed files
- `src/modules/execution/__tests__/work-item-reconciler.test.ts`
- `src/modules/execution/work-item-reconciler.service.ts`
- `src/modules/execution/work-item-reconciler.types.ts`