### PR TITLE
[#89] Studio: expose archived execution run history after closeout

### DIFF
--- a/src/modules/execution/__tests__/archive-reader.test.ts
+++ b/src/modules/execution/__tests__/archive-reader.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { archiveDir } from "../../../lib/context-layout.js";
+import { listArchivedRunBundles, readArchivedRunBundle } from "../archive-reader.js";
+import { renderArchiveReadme } from "../run-archiver.js";
+import type { ExecutionRunRecord } from "../types.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-89",
+    name: "Archived execution history",
+    kind: "issue",
+    state: "done",
+    repo: "fusupo/escapement-studio",
+    issue_number: 89,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/89",
+    scope_hint: null,
+    branch: "studio-89-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "run-a",
+    run_type: "execution",
+    work_item_id: "studio-89",
+    work_item_name: "Archived execution history",
+    status: "completed",
+    created_at: "2026-04-11T09:00:00.000Z",
+    updated_at: "2026-04-11T10:00:00.000Z",
+    completed_at: "2026-04-11T10:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "studio-89-branch",
+    base_ref: "main",
+    worktree_path: "/tmp/worktree",
+    artifact_dir: "/tmp/run",
+    prompt: "",
+    result_summary: "short summary",
+    activity_log: [],
+    changed_files: ["a.ts", "b.ts"],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function seedArchivedRun(artifactRoot: string, workItemId: string, run: ExecutionRunRecord) {
+  const dir = join(archiveDir(artifactRoot, workItemId), "runs", run.run_id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+}
+
+function writeArchiveReadme(artifactRoot: string, workItem: WorkItemRecord, runs: ExecutionRunRecord[], archivedAt: string) {
+  const dir = archiveDir(artifactRoot, workItem.id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "README.md"),
+    renderArchiveReadme(workItem, runs, {
+      archivePath: dir,
+      archivedRunIds: runs.map((run) => run.run_id),
+      skippedRunIds: [],
+      archivedAt,
+      pullRequest: runs[0]?.pull_request ?? null,
+    }),
+    "utf8",
+  );
+}
+
+describe("archive-reader", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-89-archive-reader-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns [] when the archives root is missing", () => {
+    expect(listArchivedRunBundles(tmpRoot)).toEqual([]);
+  });
+
+  it("lists mixed bundles and sorts by newest archived_at descending", () => {
+    const newerWorkItem = makeWorkItem({ id: "studio-89", name: "Archived execution history" });
+    const olderWorkItem = makeWorkItem({ id: "studio-90", name: "Older bundle", issue_number: 90, issue_url: "https://github.com/fusupo/escapement-studio/issues/90" });
+
+    const newerRunA = makeRun({ run_id: "run-newer-a", completed_at: "2026-04-11T11:00:00.000Z", updated_at: "2026-04-11T11:00:00.000Z" });
+    const newerRunB = makeRun({ run_id: "run-newer-b", completed_at: "2026-04-11T12:00:00.000Z", updated_at: "2026-04-11T12:00:00.000Z", result_summary: "x".repeat(500) });
+    seedArchivedRun(tmpRoot, newerWorkItem.id, newerRunA);
+    seedArchivedRun(tmpRoot, newerWorkItem.id, newerRunB);
+    writeArchiveReadme(tmpRoot, newerWorkItem, [newerRunA, newerRunB], "2026-04-11T12:30:00.000Z");
+
+    const olderRun = makeRun({
+      run_id: "run-older",
+      work_item_id: "studio-90",
+      work_item_name: "Older bundle",
+      completed_at: "2026-04-10T10:00:00.000Z",
+      updated_at: "2026-04-10T10:00:00.000Z",
+      branch: "studio-90-branch",
+    });
+    seedArchivedRun(tmpRoot, olderWorkItem.id, olderRun);
+    writeArchiveReadme(tmpRoot, olderWorkItem, [olderRun], "2026-04-10T10:30:00.000Z");
+
+    const bundles = listArchivedRunBundles(tmpRoot);
+    expect(bundles.map((bundle) => bundle.work_item_id)).toEqual(["studio-89", "studio-90"]);
+    expect(bundles[0].readme_exists).toBe(true);
+    expect(bundles[0].runs.map((run) => run.run_id)).toEqual(["run-newer-b", "run-newer-a"]);
+    expect(bundles[0].runs[0].result_summary?.length).toBeLessThan(500);
+  });
+
+  it("surfaces preserved plan artifacts for a plan-dir-only archive", () => {
+    const dir = archiveDir(tmpRoot, "studio-91");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "metadata.json"), JSON.stringify({ work_item_id: "studio-91" }, null, 2), "utf8");
+    writeFileSync(join(dir, "SCRATCHPAD_studio_91.md"), "# plan", "utf8");
+
+    const bundles = listArchivedRunBundles(tmpRoot);
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].work_item_id).toBe("studio-91");
+    expect(bundles[0].readme_exists).toBe(false);
+    expect(bundles[0].runs).toEqual([]);
+    expect(bundles[0].plan_artifacts).toEqual({
+      scratchpad_filename: "SCRATCHPAD_studio_91.md",
+      metadata_filename: "metadata.json",
+    });
+  });
+
+  it("warns and skips malformed archived status.json entries", () => {
+    const warn = vi.fn();
+    const dir = join(archiveDir(tmpRoot, "studio-92"), "runs", "run-bad");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "status.json"), "{not-json", "utf8");
+    writeFileSync(join(archiveDir(tmpRoot, "studio-92"), "metadata.json"), JSON.stringify({ work_item_id: "studio-92" }), "utf8");
+
+    const bundles = listArchivedRunBundles(tmpRoot, { onWarn: warn });
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0].runs).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("malformed JSON"));
+  });
+
+  it("returns README content verbatim from the detail reader and null when missing", () => {
+    const workItem = makeWorkItem({ id: "studio-93", name: "Readme detail" });
+    const run = makeRun({ run_id: "run-detail", work_item_id: "studio-93", work_item_name: "Readme detail" });
+    seedArchivedRun(tmpRoot, workItem.id, run);
+    writeArchiveReadme(tmpRoot, workItem, [run], "2026-04-11T13:00:00.000Z");
+
+    const detail = readArchivedRunBundle(tmpRoot, "studio-93");
+    expect(detail?.readme_content).toContain("# Archive: studio-93");
+
+    const dir = archiveDir(tmpRoot, "studio-94");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "metadata.json"), JSON.stringify({ work_item_id: "studio-94" }), "utf8");
+    const missingReadme = readArchivedRunBundle(tmpRoot, "studio-94");
+    expect(missingReadme?.readme_content).toBeNull();
+  });
+});

--- a/src/modules/execution/__tests__/execution-archived-bundles.test.ts
+++ b/src/modules/execution/__tests__/execution-archived-bundles.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NotFoundException } from "@nestjs/common";
+import { ExecutionService } from "../execution.service.js";
+import { ExecutionController } from "../execution.controller.js";
+import { archiveDir } from "../../../lib/context-layout.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+import type { ExecutionRunRecord } from "../types.js";
+
+interface HarnessService {
+  artifactRoot: string;
+  logger: { warn: ReturnType<typeof vi.fn> };
+  workItemsService: { get: (id: string) => WorkItemRecord };
+  listArchivedRunBundles: ExecutionService["listArchivedRunBundles"];
+  getArchivedRunBundle: ExecutionService["getArchivedRunBundle"];
+}
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-89",
+    name: "Archived execution history",
+    kind: "issue",
+    state: "done",
+    repo: "fusupo/escapement-studio",
+    issue_number: 89,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/89",
+    scope_hint: null,
+    branch: "studio-89-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "run-89",
+    run_type: "execution",
+    work_item_id: "studio-89",
+    work_item_name: "Archived execution history",
+    status: "completed",
+    created_at: "2026-04-11T09:00:00.000Z",
+    updated_at: "2026-04-11T10:00:00.000Z",
+    completed_at: "2026-04-11T10:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "studio-89-branch",
+    base_ref: "main",
+    worktree_path: "/tmp/worktree",
+    artifact_dir: "/tmp/run",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    result_summary: "summary",
+    changed_files: ["src/a.ts"],
+    ...overrides,
+  };
+}
+
+function seedArchive(artifactRoot: string, workItem: WorkItemRecord, run: ExecutionRunRecord) {
+  const dir = join(archiveDir(artifactRoot, workItem.id), "runs", run.run_id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
+  writeFileSync(join(archiveDir(artifactRoot, workItem.id), "README.md"), `# Archive: ${workItem.id} — ${workItem.name}\n\n- **archived_at:** 2026-04-11T11:00:00.000Z\n`, "utf8");
+}
+
+function makeService(tmpRoot: string, workItem = makeWorkItem()): HarnessService {
+  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  service.artifactRoot = tmpRoot;
+  service.logger = { warn: vi.fn() };
+  service.workItemsService = {
+    get: (id: string) => {
+      if (id !== workItem.id) throw new NotFoundException(`not found: ${id}`);
+      return workItem;
+    },
+  };
+  return service;
+}
+
+describe("ExecutionService archived bundles", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-89-service-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("lists archived bundles and returns bundle detail including README content", () => {
+    const workItem = makeWorkItem();
+    seedArchive(tmpRoot, workItem, makeRun());
+    const service = makeService(tmpRoot, workItem);
+
+    const list = service.listArchivedRunBundles();
+    expect(list).toHaveLength(1);
+    expect(list[0].work_item_id).toBe("studio-89");
+    expect(list[0].readme_content).toBeUndefined();
+
+    const detail = service.getArchivedRunBundle("studio-89");
+    expect(detail.readme_content).toContain("# Archive: studio-89");
+    expect(detail.runs[0].run_id).toBe("run-89");
+  });
+
+  it("throws NotFoundException when the work item exists but has no archive dir", () => {
+    const service = makeService(tmpRoot, makeWorkItem());
+    expect(() => service.getArchivedRunBundle("studio-89")).toThrow(NotFoundException);
+  });
+});
+
+describe("ExecutionController archived bundle routes", () => {
+  it("forwards list/detail calls to the execution service", () => {
+    const executionService = {
+      listArchivedRunBundles: vi.fn(() => [{ work_item_id: "studio-89" }]),
+      getArchivedRunBundle: vi.fn(() => ({ work_item_id: "studio-89", readme_content: "# Archive" })),
+    } as unknown as ExecutionService;
+
+    const controller = new ExecutionController(executionService);
+    expect(controller.getArchivedRunBundles()).toEqual([{ work_item_id: "studio-89" }]);
+    expect(controller.getArchivedRunBundle("studio-89")).toEqual({ work_item_id: "studio-89", readme_content: "# Archive" });
+  });
+});

--- a/src/modules/execution/archive-reader.ts
+++ b/src/modules/execution/archive-reader.ts
@@ -1,0 +1,346 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { archivesRoot, workItemSlug } from "../../lib/context-layout.js";
+import { coerceRecord } from "./run-disk-store.js";
+import type { ArchivedRunBundle, ArchivedRunSummary, ExecutionPullRequestRecord, ExecutionRunRecord } from "./types.js";
+
+interface ArchiveReaderOptions {
+  onWarn?: (message: string) => void;
+}
+
+interface BundleParts {
+  readmeContent: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export function listArchivedRunBundles(
+  artifactRoot: string,
+  options: ArchiveReaderOptions = {},
+): ArchivedRunBundle[] {
+  const root = archivesRoot(artifactRoot);
+  const warn = options.onWarn ?? ((message) => console.warn(`[archive-reader] ${message}`));
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch (error) {
+    warn(`failed to read archives root ${root}: ${formatError(error)}`);
+    return [];
+  }
+
+  const bundles: ArchivedRunBundle[] = [];
+  for (const slug of entries) {
+    const archivePath = join(root, slug);
+    try {
+      if (!statSync(archivePath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const bundle = readBundleFromDir(archivePath, slug, { ...options, onWarn: warn }, false);
+    if (bundle) bundles.push(bundle);
+  }
+
+  bundles.sort((left, right) => right.archived_at.localeCompare(left.archived_at));
+  return bundles;
+}
+
+export function readArchivedRunBundle(
+  artifactRoot: string,
+  workItemId: string,
+  options: ArchiveReaderOptions = {},
+): ArchivedRunBundle | null {
+  const slug = workItemSlug(workItemId);
+  const archivePath = join(archivesRoot(artifactRoot), slug);
+  if (!existsSync(archivePath)) {
+    return null;
+  }
+  return readBundleFromDir(archivePath, slug, options, true);
+}
+
+function readBundleFromDir(
+  archivePath: string,
+  slug: string,
+  options: ArchiveReaderOptions,
+  includeReadmeContent: boolean,
+): ArchivedRunBundle | null {
+  const warn = options.onWarn ?? ((message) => console.warn(`[archive-reader] ${message}`));
+  const { readmeContent, metadata } = readBundleParts(archivePath, warn);
+  const runs = readArchivedRuns(archivePath, warn);
+  const stat = safeStat(archivePath);
+
+  const workItemId = inferWorkItemId({ slug, readmeContent, metadata, runs });
+  if (!workItemId) {
+    warn(`archive bundle ${archivePath} missing work item identity; skipping`);
+    return null;
+  }
+
+  const workItemName = inferWorkItemName({ readmeContent, metadata, runs, fallback: workItemId });
+  const readmePath = join(archivePath, "README.md");
+  const readmeExists = readmeContent !== null;
+  const archivedAt = inferArchivedAt({ readmeContent, statMtimeMs: stat?.mtimeMs ?? Date.now() });
+  const pullRequest = inferPullRequest({ readmeContent, metadata, runs });
+  const planArtifacts = inferPlanArtifacts(archivePath);
+
+  const bundle: ArchivedRunBundle = {
+    work_item_id: workItemId,
+    work_item_name: workItemName,
+    slug,
+    archive_path: archivePath,
+    readme_path: readmeExists ? readmePath : null,
+    readme_exists: readmeExists,
+    archived_at: archivedAt,
+    pull_request: pullRequest,
+    runs,
+    ...(planArtifacts ? { plan_artifacts: planArtifacts } : {}),
+    ...(includeReadmeContent ? { readme_content: readmeContent } : {}),
+  };
+
+  return bundle;
+}
+
+function readBundleParts(archivePath: string, warn: (message: string) => void): BundleParts {
+  const readmePath = join(archivePath, "README.md");
+  const metadataPath = join(archivePath, "metadata.json");
+
+  let readmeContent: string | null = null;
+  if (existsSync(readmePath)) {
+    try {
+      readmeContent = readFileSync(readmePath, "utf8");
+    } catch (error) {
+      warn(`failed to read ${readmePath}: ${formatError(error)}`);
+    }
+  }
+
+  let metadata: Record<string, unknown> | null = null;
+  if (existsSync(metadataPath)) {
+    try {
+      const parsed = JSON.parse(readFileSync(metadataPath, "utf8"));
+      if (parsed && typeof parsed === "object") {
+        metadata = parsed as Record<string, unknown>;
+      } else {
+        warn(`metadata.json at ${metadataPath} did not contain an object; ignoring`);
+      }
+    } catch (error) {
+      warn(`failed to parse ${metadataPath}: ${formatError(error)}`);
+    }
+  }
+
+  return { readmeContent, metadata };
+}
+
+function readArchivedRuns(archivePath: string, warn: (message: string) => void): ArchivedRunSummary[] {
+  const root = join(archivePath, "runs");
+  if (!existsSync(root)) return [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch (error) {
+    warn(`failed to read archived runs dir ${root}: ${formatError(error)}`);
+    return [];
+  }
+
+  const runs: ArchivedRunSummary[] = [];
+  for (const entry of entries) {
+    const runDir = join(root, entry);
+    const statusPath = join(runDir, "status.json");
+    try {
+      if (!statSync(runDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (!existsSync(statusPath)) continue;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(statusPath, "utf8"));
+    } catch (error) {
+      warn(`malformed JSON in ${statusPath}: ${formatError(error)}`);
+      continue;
+    }
+
+    const record = coerceRecord(parsed);
+    if (!record) {
+      warn(`status.json at ${statusPath} did not match ExecutionRunRecord shape; skipping archived run`);
+      continue;
+    }
+    runs.push(toArchivedRunSummary(record, runDir));
+  }
+
+  runs.sort(compareArchivedRuns);
+  return runs;
+}
+
+function toArchivedRunSummary(record: ExecutionRunRecord, archivedRunDir: string): ArchivedRunSummary {
+  return {
+    run_id: record.run_id,
+    status: record.status,
+    branch: record.branch,
+    base_ref: record.base_ref,
+    created_at: record.created_at,
+    completed_at: record.completed_at,
+    changed_file_count: record.changed_files?.length ?? 0,
+    result_summary: truncateResultSummary(record.result_summary),
+    pull_request: record.pull_request,
+    archived_run_dir: archivedRunDir,
+  };
+}
+
+function compareArchivedRuns(left: ArchivedRunSummary, right: ArchivedRunSummary): number {
+  const leftKey = left.completed_at ?? left.created_at ?? "";
+  const rightKey = right.completed_at ?? right.created_at ?? "";
+  return rightKey.localeCompare(leftKey);
+}
+
+function inferWorkItemId(input: {
+  slug: string;
+  readmeContent: string | null;
+  metadata: Record<string, unknown> | null;
+  runs: ArchivedRunSummary[];
+}): string | null {
+  const readmeTitle = input.readmeContent?.match(/^# Archive: (.+?) — /m)?.[1]?.trim();
+  if (readmeTitle) return readmeTitle;
+  const metadataId = typeof input.metadata?.work_item_id === "string" ? input.metadata.work_item_id : null;
+  if (metadataId) return metadataId;
+  const runId = input.runs[0]?.run_id;
+  if (runId) {
+    // identity comes from the archived status records; use the first full record if available
+    const statusPath = join(input.runs[0].archived_run_dir, "status.json");
+    try {
+      const parsed = JSON.parse(readFileSync(statusPath, "utf8"));
+      const record = coerceRecord(parsed);
+      if (record?.work_item_id) return record.work_item_id;
+    } catch {
+      // ignore; caller already validated during run scan
+    }
+  }
+  return input.metadata ? input.slug : null;
+}
+
+function inferWorkItemName(input: {
+  readmeContent: string | null;
+  metadata: Record<string, unknown> | null;
+  runs: ArchivedRunSummary[];
+  fallback: string;
+}): string {
+  const titleMatch = input.readmeContent?.match(/^# Archive: .+? — (.+)$/m)?.[1]?.trim();
+  if (titleMatch) return titleMatch;
+
+  if (input.runs[0]) {
+    const statusPath = join(input.runs[0].archived_run_dir, "status.json");
+    try {
+      const parsed = JSON.parse(readFileSync(statusPath, "utf8"));
+      const record = coerceRecord(parsed);
+      if (record?.work_item_name) return record.work_item_name;
+    } catch {
+      // ignore; caller already validated during run scan
+    }
+  }
+
+  return typeof input.metadata?.work_item_name === "string" ? input.metadata.work_item_name : input.fallback;
+}
+
+function inferArchivedAt(input: { readmeContent: string | null; statMtimeMs: number }): string {
+  const value = input.readmeContent?.match(/^- \*\*archived_at:\*\* (.+)$/m)?.[1]?.trim();
+  if (value) {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return new Date(parsed).toISOString();
+  }
+  return new Date(input.statMtimeMs).toISOString();
+}
+
+function inferPullRequest(input: {
+  readmeContent: string | null;
+  metadata: Record<string, unknown> | null;
+  runs: ArchivedRunSummary[];
+}): ExecutionPullRequestRecord | null {
+  for (const run of input.runs) {
+    if (run.pull_request) return run.pull_request;
+  }
+
+  const readmePr = parsePullRequestFromReadme(input.readmeContent);
+  if (readmePr) return readmePr;
+
+  const metadataPr = (input.metadata?.pull_request ?? input.metadata?.pr) as Record<string, unknown> | undefined;
+  if (metadataPr && typeof metadataPr === "object") {
+    return coercePullRequest(metadataPr);
+  }
+
+  return null;
+}
+
+function parsePullRequestFromReadme(readmeContent: string | null): ExecutionPullRequestRecord | null {
+  if (!readmeContent || !readmeContent.includes("## Pull request")) return null;
+  const block = readmeContent.split("## Pull request")[1]?.split("## ")[0] ?? "";
+  const numberMatch = block.match(/^- \*\*number:\*\* #?(\d+)/m);
+  const urlMatch = block.match(/^- \*\*url:\*\* (.+)$/m);
+  if (!numberMatch || !urlMatch) return null;
+  return {
+    number: Number(numberMatch[1]),
+    url: urlMatch[1].trim(),
+    title: block.match(/^- \*\*title:\*\* (.+)$/m)?.[1]?.trim() ?? "",
+    body: "",
+    base_ref: block.match(/^- \*\*base_ref:\*\* (.+)$/m)?.[1]?.trim() ?? "",
+    head_ref: block.match(/^- \*\*head_ref:\*\* (.+)$/m)?.[1]?.trim() ?? "",
+    is_draft: false,
+    created_at: "",
+    state: block.match(/^- \*\*state:\*\* (.+)$/m)?.[1]?.trim(),
+    merged_at: block.match(/^- \*\*merged_at:\*\* (.+)$/m)?.[1]?.trim() ?? null,
+    merge_commit_sha: block.match(/^- \*\*merge_commit_sha:\*\* `(.+)`$/m)?.[1]?.trim() ?? null,
+  };
+}
+
+function coercePullRequest(raw: Record<string, unknown>): ExecutionPullRequestRecord | null {
+  if (typeof raw.number !== "number" || typeof raw.url !== "string") return null;
+  return {
+    number: raw.number,
+    url: raw.url,
+    title: typeof raw.title === "string" ? raw.title : "",
+    body: typeof raw.body === "string" ? raw.body : "",
+    base_ref: typeof raw.base_ref === "string" ? raw.base_ref : "",
+    head_ref: typeof raw.head_ref === "string" ? raw.head_ref : "",
+    is_draft: Boolean(raw.is_draft),
+    created_at: typeof raw.created_at === "string" ? raw.created_at : "",
+    state: typeof raw.state === "string" ? raw.state : undefined,
+    merged_at: typeof raw.merged_at === "string" ? raw.merged_at : null,
+    merge_commit_sha: typeof raw.merge_commit_sha === "string" ? raw.merge_commit_sha : null,
+  };
+}
+
+function inferPlanArtifacts(archivePath: string): ArchivedRunBundle["plan_artifacts"] | undefined {
+  let entries: string[];
+  try {
+    entries = readdirSync(archivePath);
+  } catch {
+    return undefined;
+  }
+
+  const scratchpadFilename = entries.find((entry) => entry.startsWith("SCRATCHPAD_") && entry.endsWith(".md"));
+  const metadataFilename = entries.includes("metadata.json") ? "metadata.json" : undefined;
+  if (!scratchpadFilename && !metadataFilename) return undefined;
+  return {
+    ...(scratchpadFilename ? { scratchpad_filename: scratchpadFilename } : {}),
+    ...(metadataFilename ? { metadata_filename: metadataFilename } : {}),
+  };
+}
+
+function truncateResultSummary(value: string | undefined, max = 280): string | undefined {
+  if (!value) return value;
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function safeStat(path: string) {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -27,6 +27,16 @@ export class ExecutionController {
     return this.executionService.listRecentRuns();
   }
 
+  @Get("archived-runs")
+  getArchivedRunBundles() {
+    return this.executionService.listArchivedRunBundles();
+  }
+
+  @Get("archived-runs/:workItemId")
+  getArchivedRunBundle(@Param("workItemId") workItemId: string) {
+    return this.executionService.getArchivedRunBundle(workItemId);
+  }
+
   @Get("eligibility")
   getLaunchEligibility(@Query("work_item_id") workItemId?: string, @Query("base_ref") baseRef?: string) {
     return this.executionService.getLaunchEligibility(workItemId, baseRef);

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleInit } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent, NotFoundException, OnModuleInit } from "@nestjs/common";
 import { createAgentSession, createCodingTools, SessionManager, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -21,6 +21,7 @@ import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
 import { loadRunRecordsForArtifactRoot, loadRunRecordsFromDisk } from "./run-disk-store.js";
 import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
+import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -30,6 +31,7 @@ import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
   ActivityLogEntry,
   ActivityLogEntryKind,
+  ArchivedRunBundle,
   ArchiveRunArtifactsResult,
   ChecklistItem,
   ClosedGitHubIssueSummary,
@@ -1032,6 +1034,31 @@ export class ExecutionService implements OnModuleInit {
     }
 
     return { run_id: runId, content: null };
+  }
+
+  listArchivedRunBundles(): ArchivedRunBundle[] {
+    return listArchivedRunBundles(this.artifactRoot, {
+      onWarn: (message) => this.logger.warn(message),
+    });
+  }
+
+  getArchivedRunBundle(workItemId: string): ArchivedRunBundle {
+    const normalized = workItemId?.trim();
+    if (!normalized) {
+      throw new BadRequestException("work_item_id is required");
+    }
+
+    // Keep the detail endpoint aligned with the rest of the execution API:
+    // unknown work item ids are rejected before we look for archive files.
+    this.workItemsService.get(normalized);
+
+    const bundle = readArchivedRunBundle(this.artifactRoot, normalized, {
+      onWarn: (message) => this.logger.warn(message),
+    });
+    if (!bundle) {
+      throw new NotFoundException(`No archived run bundle found for ${normalized}`);
+    }
+    return bundle;
   }
 
   async sendFollowUp(input: FollowUpMessageDto): Promise<FollowUpMessageResult> {

--- a/src/modules/execution/run-disk-store.ts
+++ b/src/modules/execution/run-disk-store.ts
@@ -259,7 +259,12 @@ function atomicWriteJson(path: string, value: unknown): void {
  * filling them with safe defaults, but a missing `run_id` / `status` /
  * `updated_at` / `branch` / `artifact_dir` is treated as corruption.
  */
-function coerceRecord(raw: unknown): ExecutionRunRecord | null {
+/**
+ * Shared runtime guard for both live-run hydration and archived-run reads.
+ * Exported so issue #89's archive reader reuses the exact same validation
+ * semantics as `loadRunRecordsFromDisk`.
+ */
+export function coerceRecord(raw: unknown): ExecutionRunRecord | null {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
 

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -324,6 +324,8 @@ export interface CloseMergedPullRequestResult {
   removed_run_ids: string[];
   dispatch_preview: ExecutionDispatchPreview;
 }
+
+/**
  * Issue #86: result of archiving execution run artifacts + generated
  * summary for a completed work item.
  *
@@ -350,6 +352,50 @@ export interface ArchiveRunArtifactsResult {
   readme_path: string | null;
   archived_run_ids: string[];
   skipped_run_ids: Array<{ run_id: string; reason: string }>;
+}
+
+/**
+ * Issue #89: compact per-run summary surfaced from an archived bundle.
+ *
+ * Derived from archived `runs/<run_id>/status.json` files and narrowed to
+ * the fields the archived-runs UI needs. `result_summary` is truncated by
+ * the archive reader so list/detail payloads stay small.
+ */
+export interface ArchivedRunSummary {
+  run_id: string;
+  status: ExecutionRunStatus;
+  branch: string;
+  base_ref: string;
+  created_at: string;
+  completed_at?: string;
+  changed_file_count: number;
+  result_summary?: string;
+  pull_request?: ExecutionPullRequestRecord;
+  archived_run_dir: string;
+}
+
+/**
+ * Issue #89: read-only archived bundle surfaced by the execution archive
+ * list/detail endpoints.
+ *
+ * `readme_content` is omitted from list responses and included by the
+ * detail endpoint only.
+ */
+export interface ArchivedRunBundle {
+  work_item_id: string;
+  work_item_name: string;
+  slug: string;
+  archive_path: string;
+  readme_path: string | null;
+  readme_exists: boolean;
+  readme_content?: string | null;
+  archived_at: string;
+  pull_request?: ExecutionPullRequestRecord | null;
+  runs: ArchivedRunSummary[];
+  plan_artifacts?: {
+    scratchpad_filename?: string;
+    metadata_filename?: string;
+  };
 }
 
 /**

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -396,6 +396,7 @@ export interface ArchivedRunBundle {
     scratchpad_filename?: string;
     metadata_filename?: string;
   };
+ /**
  * studio-88: persisted audit trail written to `work_item.meta.studio_archive`
  * when `archiveAndCloseMergedPullRequest` completes successfully.
  *

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -460,6 +460,31 @@ export interface ArchiveAndCloseMergedPullRequestResult {
 }
 
 /**
+ * studio-88: persisted audit trail written to `work_item.meta.studio_archive`
+ * when `archiveAndCloseMergedPullRequest` completes successfully.
+ *
+ * Mirrors the shape of `work_item.meta.studio_post_merge_sync` so both
+ * blocks can be shallow-merged into `meta` without colliding. Downstream
+ * consumers (archived-run-history UIs, post-hoc forensics) read this
+ * block to recover `archives/<slug>/` pointers without re-scanning disk.
+ *
+ * Fields:
+ * - `archived_at` — ISO timestamp the archive orchestration completed.
+ * - `readme_path` — absolute path to the README written inside
+ *   `archives/<slug>/`, or `null` when no README was written.
+ */
+export interface ExecutionStudioArchiveRecord {
+  archived_at: string;
+  readme_path: string | null;
+  pull_request?: ExecutionPullRequestRecord | null;
+  runs: ArchivedRunSummary[];
+  plan_artifacts?: {
+    scratchpad_filename?: string;
+    metadata_filename?: string;
+  };
+}
+
+/**
  * Issue #86: the terminal execution run statuses eligible for archival.
  *
  * `completed`, `error`, and `blocked` are the three terminal statuses

--- a/web/src/components/ExecutionArchivedList.svelte
+++ b/web/src/components/ExecutionArchivedList.svelte
@@ -1,0 +1,254 @@
+<script>
+  import { getArchivedExecutionRunBundle } from "../lib/api.js";
+  import { renderMarkdown } from "../lib/markdown.js";
+
+  export let bundles = [];
+  export let loading = false;
+  export let error = "";
+  export let onCopy = async (_value, _message) => {};
+
+  let detailsByWorkItem = {};
+  let detailLoading = {};
+  let detailErrors = {};
+
+  async function ensureDetailLoaded(bundle) {
+    if (!bundle?.work_item_id) return;
+    if (Object.prototype.hasOwnProperty.call(detailsByWorkItem, bundle.work_item_id)) return;
+    detailLoading = { ...detailLoading, [bundle.work_item_id]: true };
+    detailErrors = { ...detailErrors, [bundle.work_item_id]: "" };
+    try {
+      const detail = await getArchivedExecutionRunBundle(bundle.work_item_id);
+      detailsByWorkItem = { ...detailsByWorkItem, [bundle.work_item_id]: detail };
+    } catch (e) {
+      detailErrors = { ...detailErrors, [bundle.work_item_id]: e.message };
+    } finally {
+      detailLoading = { ...detailLoading, [bundle.work_item_id]: false };
+    }
+  }
+
+  function formatTimestamp(value) {
+    if (!value) return "";
+    try { return new Date(value).toLocaleString(); } catch { return value; }
+  }
+
+  function prLabel(pullRequest) {
+    if (!pullRequest?.number) return "PR";
+    const suffix = pullRequest.state ? ` · ${String(pullRequest.state).toLowerCase()}` : "";
+    return `PR #${pullRequest.number}${suffix}`;
+  }
+</script>
+
+<div class="archived-list-root">
+  {#if loading}
+    <div class="workspace-empty muted">Loading archived bundles...</div>
+  {:else if error}
+    <div class="workspace-empty muted">{error}</div>
+  {:else if bundles.length === 0}
+    <div class="workspace-empty muted">No archived bundles yet.</div>
+  {:else}
+    <div class="archived-bundles">
+      {#each bundles as bundle}
+        <details class="workspace-expandable archived-bundle" on:toggle={(e) => e.currentTarget.open && ensureDetailLoaded(bundle)}>
+          <summary>
+            <span class="archived-summary-main">
+              <span class="archived-title">{bundle.work_item_id} — {bundle.work_item_name}</span>
+              <span class="archived-subtitle">{formatTimestamp(bundle.archived_at)}</span>
+            </span>
+            <span class="archived-summary-side">
+              <span class="status-pill">{bundle.runs.length} run{bundle.runs.length === 1 ? "" : "s"}</span>
+            </span>
+          </summary>
+
+          <div class="archived-body">
+            <div class="feed-pinned-card archived-meta">
+              <div class="archived-meta-row">
+                <span class="muted">Archive path</span>
+                <code>{bundle.archive_path}</code>
+                <button class="secondary small" on:click={() => onCopy(bundle.archive_path, `Copied archive path for ${bundle.work_item_id}`)}>Copy</button>
+              </div>
+              <div class="archived-meta-row">
+                <span class="muted">Archived</span>
+                <span>{formatTimestamp(bundle.archived_at)}</span>
+              </div>
+              {#if bundle.pull_request?.url}
+                <div class="archived-meta-row">
+                  <span class="muted">Pull request</span>
+                  <a class="detail-link" href={bundle.pull_request.url} target="_blank" rel="noreferrer">{prLabel(bundle.pull_request)}</a>
+                  {#if bundle.pull_request.merged_at}
+                    <span class="muted">merged {formatTimestamp(bundle.pull_request.merged_at)}</span>
+                  {/if}
+                </div>
+              {/if}
+              {#if bundle.plan_artifacts}
+                <div class="archived-meta-row plan-artifacts">
+                  <span class="muted">Plan artifacts</span>
+                  <span>{bundle.plan_artifacts.scratchpad_filename || ""}{bundle.plan_artifacts.scratchpad_filename && bundle.plan_artifacts.metadata_filename ? " · " : ""}{bundle.plan_artifacts.metadata_filename || ""}</span>
+                </div>
+              {/if}
+            </div>
+
+            <section class="workspace-section">
+              <div class="workspace-section-hdr">
+                <h4>Archived runs</h4>
+                <span class="muted">{bundle.runs.length}</span>
+              </div>
+              {#if bundle.runs.length > 0}
+                <div class="archived-runs-table">
+                  {#each bundle.runs as run}
+                    <div class="archived-run-row">
+                      <div class="archived-run-title-row">
+                        <strong>{run.run_id}</strong>
+                        <span class="status-pill">{run.status}</span>
+                      </div>
+                      <div class="archived-run-meta">
+                        <span><span class="muted">branch</span> <code>{run.branch}</code></span>
+                        <span><span class="muted">base</span> <code>{run.base_ref}</code></span>
+                        <span><span class="muted">completed</span> {formatTimestamp(run.completed_at || run.created_at)}</span>
+                        <span><span class="muted">changed files</span> {run.changed_file_count}</span>
+                      </div>
+                      {#if run.result_summary}
+                        <div class="archived-run-summary">{run.result_summary}</div>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              {:else}
+                <div class="workspace-empty muted">This archive contains no run snapshots.</div>
+              {/if}
+            </section>
+
+            <section class="workspace-section">
+              <div class="workspace-section-hdr"><h4>README</h4></div>
+              {#if detailLoading[bundle.work_item_id]}
+                <div class="workspace-empty muted">Loading README...</div>
+              {:else if detailErrors[bundle.work_item_id]}
+                <div class="workspace-empty muted">{detailErrors[bundle.work_item_id]}</div>
+              {:else if detailsByWorkItem[bundle.work_item_id]?.readme_content}
+                <div class="scratchpad-rendered archived-readme">{@html renderMarkdown(detailsByWorkItem[bundle.work_item_id].readme_content)}</div>
+              {:else}
+                <div class="workspace-empty muted">No README available.</div>
+              {/if}
+            </section>
+          </div>
+        </details>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .archived-list-root,
+  .archived-bundles {
+    display: grid;
+    gap: 8px;
+  }
+
+  .archived-bundle summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    list-style: none;
+  }
+
+  .archived-bundle summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .archived-summary-main {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .archived-title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .archived-subtitle {
+    font-size: 11px;
+    color: var(--text-muted, #566070);
+  }
+
+  .archived-body {
+    display: grid;
+    gap: 8px;
+    margin-top: 8px;
+  }
+
+  .feed-pinned-card {
+    padding: 8px;
+    border: 1px solid var(--border, #2b3245);
+    border-radius: var(--radius-sm, 3px);
+    background: var(--bg-base, #0d1117);
+  }
+
+  .archived-meta {
+    display: grid;
+    gap: 6px;
+  }
+
+  .archived-meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    font-size: 12px;
+  }
+
+  .archived-meta-row code {
+    overflow-wrap: anywhere;
+  }
+
+  .archived-runs-table {
+    display: grid;
+    gap: 8px;
+  }
+
+  .archived-run-row {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    border: 1px solid var(--border, #2b3245);
+    border-radius: var(--radius-sm, 3px);
+    background: var(--bg-base, #0d1117);
+  }
+
+  .archived-run-title-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .archived-run-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    font-size: 11px;
+  }
+
+  .archived-run-summary {
+    font-size: 12px;
+    white-space: pre-wrap;
+    color: var(--text-secondary, #8b95a5);
+  }
+
+  .archived-readme {
+    padding-top: 4px;
+  }
+
+  .archived-readme :global(h1),
+  .archived-readme :global(h2),
+  .archived-readme :global(h3) {
+    margin: 6px 0 4px;
+  }
+
+  .archived-readme :global(ul),
+  .archived-readme :global(ol) {
+    padding-left: 16px;
+  }
+</style>

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -7,6 +7,7 @@
     getRunChecklist,
     getRunScratchpad,
     launchExecutionRun,
+    listArchivedExecutionRuns,
     listExecutionRuns,
     listReconciledWorkItems,
     openPullRequest,
@@ -16,10 +17,14 @@
   import ExecutionDispatchList from "./ExecutionDispatchList.svelte";
   import ExecutionDetailPane from "./ExecutionDetailPane.svelte";
   import ExecutionChecklist from "./ExecutionChecklist.svelte";
+  import ExecutionArchivedList from "./ExecutionArchivedList.svelte";
   import { renderMarkdown } from "../lib/markdown.js";
 
   let preview = null;
   let runs = [];
+  let archivedBundles = [];
+  let archivedLoading = false;
+  let archivedError = "";
   /**
    * studio-176: map of work_item_id → ReconciledWorkItem (from
    * /api/work-items/reconciled). Used to decorate run cards with a
@@ -150,9 +155,11 @@
 
   async function loadData({ quiet = false } = {}) {
     if (quiet) { refreshing = true; } else { loading = true; }
+    archivedLoading = true;
     error = "";
+    archivedError = "";
     try {
-      const [nextPreview, nextRuns, nextReconciled] = await Promise.all([
+      const [nextPreview, nextRuns, nextReconciled, nextArchivedBundles] = await Promise.all([
         getExecutionPreview(),
         listExecutionRuns(),
         // Reconciled view is best-effort — a failure here should not take
@@ -161,9 +168,15 @@
           console.debug("listReconciledWorkItems failed", err);
           return [];
         }),
+        listArchivedExecutionRuns().catch((err) => {
+          console.debug("listArchivedExecutionRuns failed", err);
+          archivedError = err.message;
+          return [];
+        }),
       ]);
       preview = nextPreview;
       runs = nextRuns;
+      archivedBundles = nextArchivedBundles;
       const nextMap = {};
       for (const entry of nextReconciled || []) {
         if (entry?.work_item_id) nextMap[entry.work_item_id] = entry;
@@ -179,6 +192,7 @@
     } finally {
       loading = false;
       refreshing = false;
+      archivedLoading = false;
     }
   }
 
@@ -531,6 +545,11 @@
 
       <!-- Right: Workspace (run pills + active run content) -->
       <div class="exec-col-workspace">
+        <details class="workspace-expandable archived-section">
+          <summary>Archived runs</summary>
+          <ExecutionArchivedList bundles={archivedBundles} loading={archivedLoading} error={archivedError} onCopy={copyValue} />
+        </details>
+
         <!-- Run pill strip -->
         {#if runs.length > 0}
           <div class="run-pill-strip">
@@ -1050,6 +1069,11 @@
     border-radius: var(--radius-sm, 3px);
     background: var(--bg-surface, #13171f);
     font-size: 12px;
+  }
+
+  .archived-section {
+    margin: 8px 8px 0;
+    flex-shrink: 0;
   }
 
   .workspace-expandable summary {

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -99,6 +99,14 @@ export function listExecutionRuns() {
   return request("/api/execution/runs");
 }
 
+export function listArchivedExecutionRuns() {
+  return request("/api/execution/archived-runs");
+}
+
+export function getArchivedExecutionRunBundle(workItemId) {
+  return request(`/api/execution/archived-runs/${encodeURIComponent(workItemId)}`);
+}
+
 /**
  * studio-176: reconciled work-item view. Returns one entry per
  * in_progress work item with a `next_action` derived from the graph,


### PR DESCRIPTION
## Summary
Done.

Implemented:
- `src/modules/execution/archive-reader.ts`
- `src/modules/execution/types.ts`
- `src/modules/execution/run-disk-store.ts`
- `src/modules/execution/execution.service.ts`
- `src/modules/execution/execution.controller.ts`
- `web/src/lib/api.js`
- `web/src/components/ExecutionArchivedList.svelte`
- `web/src/components/ExecutionDispatchPanel.svelte`
- tests:
  - `src/modules/execution/__tests__/archive-reader.test.ts`
  - `src/modules/execution/__tests__/execution-archived-bundles.test.ts`

Disambiguation choices applied:
- separate surface = collapsed **Archived runs** section inside Execute panel
- render archived `README.md` as markdown
- include plan-dir-only/cancelled archives with `0` runs
- no pagination for v1

Validation:
- `npm run check` ✅
- targeted vitest for archive slice ✅
- `npm run build:web` ✅
- full `npm test` ⚠️ blocked by missing `better-sqlite3` native bindings in this worktree (pre-existing env issue)

Scratchpad updated:
- `SCRATCHPAD_studio_89.md`

If you want, I can next make a focused commit for this slice.

## Context
- Work item: studio-89
- Issue: https://github.com/fusupo/escapement-studio/issues/89
- Base branch: develop
- Head branch: studio-89-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775890160024
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-89-branch
- Scope hint: Expose archived execution run history in a separate surface so Recent execution runs can stay focused on unresolved work.

## Changed files
- `src/modules/execution/execution.controller.ts`
- `src/modules/execution/execution.service.ts`
- `src/modules/execution/run-disk-store.ts`
- `src/modules/execution/types.ts`
- `web/src/components/ExecutionDispatchPanel.svelte`
- `web/src/lib/api.js`
- `src/modules/execution/__tests__/archive-reader.test.ts`
- `src/modules/execution/__tests__/execution-archived-bundles.test.ts`
- `src/modules/execution/archive-reader.ts`
- `web/src/components/ExecutionArchivedList.svelte`