### PR TITLE
[#193] Studio: add 'closed' and 'archived' work item states + 'done' migration

### DIFF
--- a/scripts/migrate-done-to-archived.ts
+++ b/scripts/migrate-done-to-archived.ts
@@ -1,0 +1,76 @@
+import Database from "better-sqlite3";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { getConfig } from "../src/config.js";
+import { archiveBundleExists } from "../src/lib/context-layout.js";
+
+export interface DoneToArchivedMigrationResult {
+  promoted: string[];
+  untouched: string[];
+  warnings: string[];
+}
+
+export interface DoneToArchivedMigrationOptions {
+  manifestPath?: string;
+  artifactRoot?: string;
+  log?: (message: string) => void;
+}
+
+export function detectManifestConcurrencyWarnings(manifestPath: string): string[] {
+  const warnings: string[] = [];
+  for (const suffix of ["-wal", "-shm"]) {
+    const file = `${manifestPath}${suffix}`;
+    if (existsSync(file)) {
+      warnings.push(`Warning: detected live SQLite sidecar ${file}; run only when no Nest server process is active.`);
+    }
+  }
+  return warnings;
+}
+
+export function migrateDoneToArchived(
+  options: DoneToArchivedMigrationOptions = {},
+): DoneToArchivedMigrationResult {
+  const manifestPath = resolve(options.manifestPath ?? getConfig().manifestPath);
+  const artifactRoot = resolve(options.artifactRoot ?? getConfig().artifactRoot);
+  const log = options.log ?? (() => {});
+  const warnings = detectManifestConcurrencyWarnings(manifestPath);
+  for (const warning of warnings) {
+    log(warning);
+  }
+
+  const db = new Database(manifestPath);
+  try {
+    const rows = db
+      .prepare("SELECT id FROM work_items WHERE state = 'done' ORDER BY id")
+      .all() as Array<{ id: string }>;
+
+    const promote = db.prepare("UPDATE work_items SET state = 'archived' WHERE id = ? AND state = 'done'");
+    const promoted: string[] = [];
+    const untouched: string[] = [];
+
+    for (const row of rows) {
+      if (archiveBundleExists(artifactRoot, row.id)) {
+        promote.run(row.id);
+        promoted.push(row.id);
+        log(`Promoted ${row.id}: done -> archived`);
+      } else {
+        untouched.push(row.id);
+        log(`Left ${row.id} as done: archive bundle missing`);
+      }
+    }
+
+    return { promoted, untouched, warnings };
+  } finally {
+    db.close();
+  }
+}
+
+export function main(): DoneToArchivedMigrationResult {
+  const result = migrateDoneToArchived({ log: (message) => console.log(message) });
+  console.log(`Promotion summary: promoted=${result.promoted.length} untouched=${result.untouched.length}`);
+  return result;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/__tests__/state-machine-allowlist.test.ts
+++ b/src/__tests__/state-machine-allowlist.test.ts
@@ -8,9 +8,9 @@ import type { WorkItemState } from "../modules/graph/types.js";
 /**
  * ADR 014 step 3 state-machine allowlist.
  *
- * This test enforces a single source of truth: the 9 canonical
+ * This test enforces a single source of truth: the 12 canonical
  * WorkItemState values. It asserts:
- *  1. All 9 states are accepted by the SQLite CHECK constraint
+ *  1. All 12 states are accepted by the SQLite CHECK constraint
  *  2. An invalid state is rejected by the constraint
  *  3. VALID_HUMAN_TRANSITIONS has an entry for every state (no
  *     accidentally-missing rows)
@@ -24,10 +24,13 @@ const ALL_STATES: WorkItemState[] = [
   "drafting",
   "ready",
   "in_progress",
+  "run_errored",
   "open_pr",
   "merged_pr",
-  "done",
+  "closed",
   "deferred",
+  "done",
+  "archived",
   "cancelled",
 ];
 
@@ -109,8 +112,11 @@ describe("state-machine allowlist", () => {
       }
     });
 
-    it("terminal states (done, cancelled, merged_pr) have no human-triggered outbound transitions", () => {
+    it("terminal and placeholder states have no human-triggered outbound transitions", () => {
+      expect(VALID_HUMAN_TRANSITIONS.run_errored).toEqual([]);
+      expect(VALID_HUMAN_TRANSITIONS.closed).toEqual([]);
       expect(VALID_HUMAN_TRANSITIONS.done).toEqual([]);
+      expect(VALID_HUMAN_TRANSITIONS.archived).toEqual([]);
       expect(VALID_HUMAN_TRANSITIONS.cancelled).toEqual([]);
       // merged_pr → done is triggered by the disposition endpoints
       // (POST /api/execution/close-merged, POST /api/execution/archive-and-close-merged)

--- a/src/__tests__/state-machine-allowlist.test.ts
+++ b/src/__tests__/state-machine-allowlist.test.ts
@@ -80,6 +80,13 @@ describe("state-machine allowlist", () => {
       db.close();
     });
 
+    it("accepts dotted compatibility forms that end in a canonical leaf state", () => {
+      const db = createMigratedDb();
+      expect(() => insertWorkItemWithState(db, "item-dotted", "pre_pr.in_progress")).not.toThrow();
+      expect(() => insertWorkItemWithState(db, "item-dotted-archived", "post_pr.archived")).not.toThrow();
+      db.close();
+    });
+
     it("rejects a state that is not in the canonical set", () => {
       const db = createMigratedDb();
       expect(() => insertWorkItemWithState(db, "item-bad", "totally_made_up")).toThrow();
@@ -90,6 +97,12 @@ describe("state-machine allowlist", () => {
       const db = createMigratedDb();
       // "blocked" was never a canonical state — it is a derived view per ADR 014
       expect(() => insertWorkItemWithState(db, "item-blocked", "blocked")).toThrow();
+      db.close();
+    });
+
+    it("rejects dotted compatibility forms whose leaf state is unknown", () => {
+      const db = createMigratedDb();
+      expect(() => insertWorkItemWithState(db, "item-bad-dotted", "pre_pr.blocked")).toThrow();
       db.close();
     });
   });

--- a/src/lib/context-layout.ts
+++ b/src/lib/context-layout.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -97,6 +97,12 @@ export function worktreeDir(artifactRoot: string, branch: string): string {
 /** Path to an archive directory for a work item. */
 export function archiveDir(artifactRoot: string, workItemId: string): string {
   return join(archivesRoot(artifactRoot), workItemSlug(workItemId));
+}
+
+/** Return true when the canonical `archives/<slug>/` bundle exists on disk. */
+export function archiveBundleExists(artifactRoot: string, workItemId: string): boolean {
+  const path = archiveDir(artifactRoot, workItemId);
+  return existsSync(path) && statSync(path).isDirectory();
 }
 
 /**

--- a/src/modules/execution/__tests__/work-item-reconciler.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler.test.ts
@@ -225,10 +225,9 @@ describe("WorkItemReconcilerService.reconcile", () => {
   });
 
   // Regression: ADR 014 split in_progress into in_progress → open_pr →
-  // merged_pr → done. Before this fix, selectWorkItems only picked
-  // in_progress, so a work item sitting at merged_pr (with a completed run
-  // and a merged PR) never produced a close_out row and the disposition UI
-  // stayed hidden. The reconciler must now include open_pr and merged_pr.
+  // merged_pr → done, and issue #193 widens the reconcilable set further
+  // to include run_errored and closed. Before this fix, selectWorkItems
+  // only picked in_progress, so downstream operator rows stayed hidden.
   it("includes merged_pr work items and surfaces close_out rows", async () => {
     const run = makeRun({
       pull_request: {
@@ -282,9 +281,52 @@ describe("WorkItemReconcilerService.reconcile", () => {
     expect(reconciled[0].next_action).toBe("awaiting_review");
   });
 
-  it("excludes done work items from the reconciled feed", async () => {
+  it("includes run_errored work items in the reconciled feed", async () => {
     const { service } = makeService({
-      workItems: [makeWorkItem({ state: "done" })],
+      workItems: [makeWorkItem({ state: "run_errored" })],
+      runs: [makeRun({ status: "error", progress_message: "boom" })],
+      worktreeExists: true,
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0].graph_state).toBe("run_errored");
+    expect(reconciled[0].next_action).toBe("investigate");
+  });
+
+  it("includes closed work items in the reconciled feed", async () => {
+    const run = makeRun({
+      pull_request: {
+        number: 192,
+        url: "https://github.com/x/y/pull/192",
+        title: "t",
+        body: "b",
+        base_ref: "develop",
+        head_ref: "studio-176-branch",
+        is_draft: false,
+        created_at: "2026-04-10T00:00:00.000Z",
+        state: "CLOSED",
+        merged_at: null,
+      },
+    });
+    const { service } = makeService({
+      workItems: [makeWorkItem({ state: "closed" })],
+      runs: [run],
+      worktreeExists: true,
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0].graph_state).toBe("closed");
+    expect(reconciled[0].next_action).toBe("abandon");
+  });
+
+  it("excludes done, archived, cancelled, and deferred work items from the reconciled feed", async () => {
+    const { service } = makeService({
+      workItems: [
+        makeWorkItem({ id: "studio-done", state: "done" }),
+        makeWorkItem({ id: "studio-archived", state: "archived" }),
+        makeWorkItem({ id: "studio-cancelled", state: "cancelled" }),
+        makeWorkItem({ id: "studio-deferred", state: "deferred" }),
+      ],
       runs: [makeRun()],
     });
     expect(await service.reconcile()).toEqual([]);

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -293,6 +293,28 @@ export interface ClosedGitHubIssueSummary {
   state: string;
 }
 
+export interface StudioOpenPrSync {
+  at: string;
+  pull_request: ExecutionPullRequestRecord;
+}
+
+export interface StudioIssueCloseSync {
+  at: string;
+  issue: {
+    number: number;
+    state: "closed";
+    closed_at: string | null;
+    url: string;
+  };
+}
+
+export interface StudioPostMergeSync {
+  synced_at: string;
+  run_id: string | null;
+  actual_files_source: "input" | "work_item" | "run";
+  pull_request: ExecutionPullRequestRecord;
+}
+
 /**
  * studio-87: result envelope for `POST /api/execution/close-merged`.
  *

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -64,16 +64,18 @@ export interface ReconcilerOptions {
 /**
  * Work item states that the reconciler surfaces rows for. Originally only
  * `in_progress`, but ADR 014 split that into `in_progress → open_pr →
- * merged_pr → done`, and the disposition UI needs `merged_pr` rows to be
- * reconciled so `next_action === "close_out"` can fire. `open_pr` is
- * included so rows waiting on review still appear in the feed with
- * `next_action === "awaiting_review"`. `done` is excluded — those work
- * items are finalized and have no further action.
+ * merged_pr → closed/done/archived` and the expanded HSM vocabulary also
+ * introduces `run_errored`. The reconciler should surface everything that
+ * may still need operator attention while excluding finalized/deferred
+ * rows. `open_pr` is included so rows waiting on review still appear in
+ * the feed with `next_action === "awaiting_review"`.
  */
 const RECONCILABLE_STATES: ReadonlySet<WorkItemState> = new Set([
   "in_progress",
+  "run_errored",
   "open_pr",
   "merged_pr",
+  "closed",
 ]);
 
 const EMPTY_NEXT_ACTION_COUNTS: Record<NextAction, number> = {
@@ -128,7 +130,8 @@ export class WorkItemReconcilerService {
   /**
    * Join graph + disk + GitHub + worktree and produce a
    * `ReconciledWorkItem` per work item in a reconcilable state
-   * (`in_progress`, `open_pr`, `merged_pr`), or just the one matching
+   * (`in_progress`, `run_errored`, `open_pr`, `merged_pr`, `closed`), or
+   * just the one matching
    * `options.work_item_id`.
    *
    * The decision table row order is preserved: earlier rows win when

--- a/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
+++ b/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
@@ -81,6 +81,14 @@ describe("migrateDoneToArchived", () => {
     const db = createMigratedDb(manifestPath);
     seedWorkItem(db, "studio-196", "done");
     mkdirSync(archiveDir(artifactRoot, "studio-196"), { recursive: true });
+
+    // Close the seeded connection before creating fake sidecars. If we leave
+    // the real WAL connection open and then overwrite its -wal/-shm files with
+    // sentinel contents, a fresh connection can legitimately fail to see the
+    // schema that still lives in the live WAL. The behavior under test is that
+    // the migration logs warnings for sidecars but still processes a valid
+    // manifest, not that it can recover from a deliberately corrupted live WAL.
+    db.close();
     writeFileSync(`${manifestPath}-wal`, "wal", "utf8");
     writeFileSync(`${manifestPath}-shm`, "shm", "utf8");
 
@@ -95,7 +103,5 @@ describe("migrateDoneToArchived", () => {
     expect(result.warnings).toHaveLength(2);
     expect(logs.some((line) => line.includes("-wal"))).toBe(true);
     expect(logs.some((line) => line.includes("-shm"))).toBe(true);
-
-    db.close();
   });
 });

--- a/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
+++ b/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { initManifest } from "../../../lib/manifest-core.js";
+import { archiveDir } from "../../../lib/context-layout.js";
+import { SQLiteService } from "../sqlite.service.js";
+import { migrateDoneToArchived } from "../../../../scripts/migrate-done-to-archived.js";
+
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "studio-193-"));
+  tempRoots.push(root);
+  return root;
+}
+
+function createMigratedDb(manifestPath: string) {
+  const db = initManifest(manifestPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS studio_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0');
+  `);
+
+  const service = Object.create(SQLiteService.prototype) as SQLiteService;
+  Object.defineProperty(service, "db", { value: db, writable: false });
+  (SQLiteService.prototype as unknown as { migrateWorkItemStates: () => void }).migrateWorkItemStates.call(service);
+  return db;
+}
+
+function seedWorkItem(db: ReturnType<typeof createMigratedDb>, id: string, state: string) {
+  db.prepare(
+    `INSERT INTO work_items (id, name, kind, state, predicted_files, actual_files, meta)
+     VALUES (?, ?, 'issue', ?, '[]', '[]', '{}')`,
+  ).run(id, id, state);
+}
+
+describe("migrateDoneToArchived", () => {
+  it("promotes done items with archive bundles and leaves others untouched", () => {
+    const root = makeTempRoot();
+    const artifactRoot = join(root, "artifacts");
+    const manifestPath = join(root, "manifest.db");
+    const db = createMigratedDb(manifestPath);
+
+    seedWorkItem(db, "studio-193", "done");
+    seedWorkItem(db, "studio-194", "done");
+    seedWorkItem(db, "studio-195", "archived");
+    mkdirSync(archiveDir(artifactRoot, "studio-193"), { recursive: true });
+
+    const first = migrateDoneToArchived({ manifestPath, artifactRoot });
+    expect(first.promoted).toEqual(["studio-193"]);
+    expect(first.untouched).toEqual(["studio-194"]);
+
+    const states = db.prepare("SELECT id, state FROM work_items ORDER BY id").all() as Array<{ id: string; state: string }>;
+    expect(states).toEqual([
+      { id: "studio-193", state: "archived" },
+      { id: "studio-194", state: "done" },
+      { id: "studio-195", state: "archived" },
+    ]);
+
+    const second = migrateDoneToArchived({ manifestPath, artifactRoot });
+    expect(second.promoted).toEqual([]);
+    expect(second.untouched).toEqual(["studio-194"]);
+
+    db.close();
+  });
+
+  it("warns on WAL/SHM sidecars without aborting", () => {
+    const root = makeTempRoot();
+    const artifactRoot = join(root, "artifacts");
+    const manifestPath = join(root, "manifest.db");
+    const db = createMigratedDb(manifestPath);
+    seedWorkItem(db, "studio-196", "done");
+    mkdirSync(archiveDir(artifactRoot, "studio-196"), { recursive: true });
+    writeFileSync(`${manifestPath}-wal`, "wal", "utf8");
+    writeFileSync(`${manifestPath}-shm`, "shm", "utf8");
+
+    const logs: string[] = [];
+    const result = migrateDoneToArchived({
+      manifestPath,
+      artifactRoot,
+      log: (message) => logs.push(message),
+    });
+
+    expect(result.promoted).toEqual(["studio-196"]);
+    expect(result.warnings).toHaveLength(2);
+    expect(logs.some((line) => line.includes("-wal"))).toBe(true);
+    expect(logs.some((line) => line.includes("-shm"))).toBe(true);
+
+    db.close();
+  });
+});

--- a/src/modules/graph/__tests__/work-item-state-persistence.test.ts
+++ b/src/modules/graph/__tests__/work-item-state-persistence.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { initManifest } from "../../../lib/manifest-core.js";
+import { GraphService } from "../graph.service.js";
+import { GraphWriterService } from "../graph-writer.service.js";
+import { SQLiteService } from "../sqlite.service.js";
+import type { WorkItemState } from "../types.js";
+import { WorkItemsService } from "../work-items.service.js";
+
+const SUPPORTED_STATES: WorkItemState[] = [
+  "planned",
+  "drafting",
+  "ready",
+  "in_progress",
+  "run_errored",
+  "open_pr",
+  "merged_pr",
+  "closed",
+  "deferred",
+  "done",
+  "archived",
+  "cancelled",
+];
+
+function createServices() {
+  const db = initManifest(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS studio_metadata (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0');
+  `);
+
+  const sqlite = Object.create(SQLiteService.prototype) as SQLiteService;
+  Object.defineProperty(sqlite, "db", { value: db, writable: false });
+  (SQLiteService.prototype as unknown as { migrateWorkItemStates: () => void }).migrateWorkItemStates.call(sqlite);
+
+  const graphWriter = Object.create(GraphWriterService.prototype) as GraphWriterService;
+  Object.defineProperty(graphWriter, "sqlite", { value: sqlite, writable: false });
+
+  const workItems = Object.create(WorkItemsService.prototype) as WorkItemsService;
+  Object.defineProperty(workItems, "sqlite", { value: sqlite, writable: false });
+  Object.defineProperty(workItems, "graphWriter", { value: graphWriter, writable: false });
+
+  const graph = Object.create(GraphService.prototype) as GraphService;
+  Object.defineProperty(graph, "sqlite", { value: sqlite, writable: false });
+  Object.defineProperty(graph, "workItems", { value: workItems, writable: false });
+
+  return { db, sqlite, graphWriter, workItems, graph };
+}
+
+describe("work item state persistence", () => {
+  it("round-trips every supported state through WorkItemsService.create/update", () => {
+    const { db, workItems } = createServices();
+
+    for (const [index, state] of SUPPORTED_STATES.entries()) {
+      const id = `studio-${100 + index}`;
+      const created = workItems.create({
+        id,
+        name: `Item ${state}`,
+        kind: "issue",
+        issue_number: 100 + index,
+        state,
+      });
+      expect(created.state).toBe(state);
+
+      const updated = workItems.update(id, {
+        state: SUPPORTED_STATES[(index + 1) % SUPPORTED_STATES.length],
+      });
+      expect(updated.state).toBe(SUPPORTED_STATES[(index + 1) % SUPPORTED_STATES.length]);
+    }
+
+    db.close();
+  });
+
+  it("rejects invalid bare and dotted states through the normal write path", () => {
+    const { db, workItems } = createServices();
+
+    expect(() =>
+      workItems.create({
+        id: "studio-300",
+        name: "Invalid state",
+        kind: "issue",
+        issue_number: 300,
+        state: "blocked" as WorkItemState,
+      }),
+    ).toThrow(/CHECK constraint failed|Graph write failed|work item/i);
+
+    const created = workItems.create({
+      id: "studio-301",
+      name: "Valid baseline",
+      kind: "issue",
+      issue_number: 301,
+      state: "planned",
+    });
+    expect(created.state).toBe("planned");
+
+    expect(() =>
+      workItems.update("studio-301", {
+        state: "pre_pr.blocked" as WorkItemState,
+      }),
+    ).toThrow(/CHECK constraint failed|Graph write failed|work item/i);
+
+    db.close();
+  });
+
+  it("treats archived dependencies as satisfied in frontier queries", () => {
+    const { db, graphWriter, graph } = createServices();
+
+    const applied = graphWriter.apply({
+      mutations: [
+        {
+          kind: "create_work_item",
+          work_item: {
+            id: "studio-400",
+            name: "Dependency",
+            kind: "issue",
+            issue_number: 400,
+            state: "archived",
+          },
+        },
+        {
+          kind: "create_work_item",
+          work_item: {
+            id: "studio-401",
+            name: "Dependent",
+            kind: "issue",
+            issue_number: 401,
+            state: "planned",
+          },
+        },
+        {
+          kind: "create_edge",
+          edge: {
+            from_id: "studio-401",
+            rel: "depends_on",
+            to_id: "studio-400",
+          },
+        },
+      ],
+    });
+
+    expect(applied.status).toBe("applied");
+    expect(graph.getFrontier().map((item) => item.id)).toContain("studio-401");
+
+    db.close();
+  });
+});

--- a/src/modules/graph/__tests__/work-item-transitions.test.ts
+++ b/src/modules/graph/__tests__/work-item-transitions.test.ts
@@ -136,8 +136,11 @@ describe("WorkItemsController.transition", () => {
     const disallowed: Array<[WorkItemState, WorkItemState]> = [
       ["planned", "in_progress"], // must launch, not manually set
       ["planned", "done"],
+      ["run_errored", "ready"],
+      ["closed", "done"],
       ["done", "planned"],
       ["merged_pr", "done"], // disposition flow (step 7) uses dedicated endpoints, not this allowlist
+      ["archived", "planned"],
       ["cancelled", "planned"],
       ["ready", "in_progress"], // must launch, not manually set
     ];
@@ -175,8 +178,11 @@ describe("state-transitions helpers", () => {
     expect(isValidHumanTransition("merged_pr", "done")).toBe(false);
   });
 
-  it("VALID_HUMAN_TRANSITIONS has no entries for terminal states", () => {
+  it("VALID_HUMAN_TRANSITIONS has no entries for terminal and placeholder states", () => {
+    expect(VALID_HUMAN_TRANSITIONS.run_errored).toHaveLength(0);
+    expect(VALID_HUMAN_TRANSITIONS.closed).toHaveLength(0);
     expect(VALID_HUMAN_TRANSITIONS.done).toHaveLength(0);
+    expect(VALID_HUMAN_TRANSITIONS.archived).toHaveLength(0);
     expect(VALID_HUMAN_TRANSITIONS.cancelled).toHaveLength(0);
     expect(VALID_HUMAN_TRANSITIONS.merged_pr).toHaveLength(0);
   });

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -42,7 +42,7 @@ function queryStudioFrontier(db: DatabaseType): FrontierItem[] {
         JOIN work_items dep ON dep.id = e.to_id
         WHERE e.rel = 'depends_on'
           AND e.from_id = w.id
-          AND dep.state != 'done'
+          AND dep.state NOT IN ('done', 'archived')
       )
     ORDER BY w.id
   `;

--- a/src/modules/graph/sqlite.service.ts
+++ b/src/modules/graph/sqlite.service.ts
@@ -58,17 +58,15 @@ export class SQLiteService {
       .prepare("INSERT OR IGNORE INTO studio_metadata (key, value) VALUES ('graph_version', '0')")
       .run();
 
-    // Extend upstream CHECK constraint to include expanded ADR 014 state set
+    // Extend upstream CHECK constraint to include the HSM-aligned state set.
     this.migrateWorkItemStates();
   }
 
   private migrateWorkItemStates() {
-    // Guard sentinel is merged_pr (ADR 014 step 3). If already present, the
-    // expanded state set is in place and the migration is a no-op. Instances
-    // that have the step-1/2 schema with open_pr but not merged_pr will fall
-    // through and run the recreate.
+    // Guard sentinel is `archived`. Older Studio schemas already include
+    // `merged_pr`, so that earlier sentinel would skip this broader migration.
     const tableInfo = this.db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='work_items'").get() as { sql: string } | undefined;
-    if (!tableInfo?.sql || tableInfo.sql.includes("merged_pr")) {
+    if (!tableInfo?.sql || tableInfo.sql.includes("'archived'")) {
       return; // already migrated or no table
     }
 
@@ -82,17 +80,40 @@ export class SQLiteService {
         kind        TEXT NOT NULL DEFAULT 'issue'
                     CHECK (kind IN ('issue','capability','phase','track')),
         state       TEXT NOT NULL DEFAULT 'planned'
-                    CHECK (state IN (
-                      'planned',
-                      'drafting',
-                      'ready',
-                      'in_progress',
-                      'open_pr',
-                      'merged_pr',
-                      'done',
-                      'deferred',
-                      'cancelled'
-                    )),
+                    CHECK (
+                      state IN (
+                        'planned',
+                        'drafting',
+                        'ready',
+                        'in_progress',
+                        'run_errored',
+                        'open_pr',
+                        'merged_pr',
+                        'closed',
+                        'deferred',
+                        'done',
+                        'archived',
+                        'cancelled'
+                      )
+                      OR (
+                        instr(state, '.') > 1
+                        AND instr(substr(state, instr(state, '.') + 1), '.') = 0
+                        AND substr(state, instr(state, '.') + 1) IN (
+                          'planned',
+                          'drafting',
+                          'ready',
+                          'in_progress',
+                          'run_errored',
+                          'open_pr',
+                          'merged_pr',
+                          'closed',
+                          'deferred',
+                          'done',
+                          'archived',
+                          'cancelled'
+                        )
+                      )
+                    ),
         repo            TEXT,
         issue_number    INTEGER,
         issue_url       TEXT,

--- a/src/modules/graph/state-transitions.ts
+++ b/src/modules/graph/state-transitions.ts
@@ -17,10 +17,13 @@ export const VALID_HUMAN_TRANSITIONS: Record<WorkItemState, WorkItemState[]> = {
   drafting: ["ready", "deferred", "cancelled"],
   ready: ["drafting", "deferred", "cancelled"],
   in_progress: ["ready", "drafting", "deferred", "cancelled"],
+  run_errored: [],
   open_pr: ["deferred", "cancelled"],
   merged_pr: [],
-  done: [],
+  closed: [],
   deferred: ["planned"],
+  done: [],
+  archived: [],
   cancelled: [],
 };
 

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -33,10 +33,13 @@ export type WorkItemState =
   | "drafting"
   | "ready"
   | "in_progress"
+  | "run_errored"
   | "open_pr"
   | "merged_pr"
-  | "done"
+  | "closed"
   | "deferred"
+  | "done"
+  | "archived"
   | "cancelled";
 export type EdgeRel = "depends_on" | "is_part_of" | "implemented_by";
 export type EdgeConfidence = "certain" | "inferred" | "ambiguous";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "outDir": "dist",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
Got it.

These choices match the implementation I landed:

- `archived` and `done` both unblock dependencies
  - implemented in `src/modules/graph/graph.service.ts`

- Option A for new human transitions
  - `run_errored`, `closed`, and `archived` currently have conservative empty transition rows
  - implemented in `src/modules/graph/state-transitions.ts`

- Option A for dotted-path CHECK behavior
  - SQLite accepts bare canonical states plus narrowly compatible one-dot forms ending in a known leaf
  - implemented in `src/modules/graph/sqlite.service.ts`

So no follow-up code change is needed for those clarifications. The remaining blocker is still just the local `better-sqlite3` binding issue preventing `npm test` from running in this worktree.

actual_files synced: 0 file(s).

## Context
- Work item: studio-193
- Issue: https://github.com/fusupo/escapement-studio/issues/193
- Base branch: develop
- Head branch: studio-193-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775948532680
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-193-branch
- Scope hint: Add explicit closed and archived work item states and migrate existing done semantics accordingly.

## Changed files
- (not recorded)