### PR TITLE
[#194] Studio: GitHubBatchCache service with write-through API

### DIFF
--- a/src/modules/execution/__tests__/github-batch-cache.service.test.ts
+++ b/src/modules/execution/__tests__/github-batch-cache.service.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubBatchCache } from "../github-batch-cache.service.js";
+
+describe("GitHubBatchCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-12T00:00:00.000Z"));
+  });
+
+  function makeCache() {
+    const githubService = {
+      normalizeRepo: vi.fn((repo: string) => repo.trim().replace(/^\/+|\/+$/g, "").toLowerCase()),
+      listPullRequests: vi.fn(async () => [
+        {
+          number: 12,
+          state: "MERGED" as const,
+          merged_at: "2026-04-11T12:00:00.000Z",
+          head_ref: "studio-194-branch",
+          base_ref: "develop",
+          url: "https://github.com/fusupo/escapement-studio/pull/12",
+          title: "Batch cache",
+          is_draft: false,
+        },
+      ]),
+      listIssues: vi.fn(async () => [
+        {
+          number: 194,
+          state: "closed" as const,
+          closed_at: "2026-04-11T13:00:00.000Z",
+          url: "https://github.com/fusupo/escapement-studio/issues/194",
+          title: "Batch cache issue",
+        },
+      ]),
+    };
+    const cache = new GitHubBatchCache(githubService as any);
+    (cache as any).logger = { warn: vi.fn() };
+    return { cache, githubService };
+  }
+
+  it("fetches PRs once and reuses the same Map within the TTL", async () => {
+    const { cache, githubService } = makeCache();
+
+    const first = await cache.listPullRequests("FUSUPO/ESCAPEMENT-STUDIO");
+    const second = await cache.listPullRequests("fusupo/escapement-studio");
+
+    expect(githubService.listPullRequests).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+    expect(first.get(12)?.state).toBe("MERGED");
+  });
+
+  it("refetches after the TTL expires", async () => {
+    const { cache, githubService } = makeCache();
+
+    const first = await cache.listPullRequests("fusupo/escapement-studio");
+    vi.advanceTimersByTime(60_001);
+    const second = await cache.listPullRequests("fusupo/escapement-studio");
+
+    expect(githubService.listPullRequests).toHaveBeenCalledTimes(2);
+    expect(second).not.toBe(first);
+  });
+
+  it("invalidate(repo) forces the next PR read to refetch", async () => {
+    const { cache, githubService } = makeCache();
+
+    await cache.listPullRequests("fusupo/escapement-studio");
+    cache.invalidate("fusupo/escapement-studio");
+    await cache.listPullRequests("fusupo/escapement-studio");
+
+    expect(githubService.listPullRequests).toHaveBeenCalledTimes(2);
+  });
+
+  it("supports write-through PR updates", async () => {
+    const { cache } = makeCache();
+
+    await cache.listPullRequests("fusupo/escapement-studio");
+    cache.upsertPullRequest("fusupo/escapement-studio", {
+      number: 77,
+      state: "OPEN",
+      merged_at: null,
+      head_ref: "feature-x",
+      base_ref: "develop",
+      url: "https://github.com/fusupo/escapement-studio/pull/77",
+      title: "Feature X",
+      is_draft: true,
+    });
+
+    const pulls = await cache.listPullRequests("fusupo/escapement-studio");
+    expect(pulls.get(77)).toMatchObject({ head_ref: "feature-x", is_draft: true });
+  });
+
+  it("deduplicates concurrent PR reads for the same repo", async () => {
+    const { cache, githubService } = makeCache();
+    let resolveFetch: ((value: any) => void) | undefined;
+    githubService.listPullRequests.mockReturnValueOnce(new Promise((resolve) => {
+      resolveFetch = resolve;
+    }));
+
+    const first = cache.listPullRequests("fusupo/escapement-studio");
+    const second = cache.listPullRequests("fusupo/escapement-studio");
+
+    expect(githubService.listPullRequests).toHaveBeenCalledTimes(1);
+
+    resolveFetch?.([
+      {
+        number: 12,
+        state: "OPEN",
+        merged_at: null,
+        head_ref: "studio-194-branch",
+        base_ref: "develop",
+        url: "https://github.com/fusupo/escapement-studio/pull/12",
+        title: "Batch cache",
+        is_draft: false,
+      },
+    ]);
+
+    const [left, right] = await Promise.all([first, second]);
+    expect(left).toBe(right);
+    expect(left.get(12)?.state).toBe("OPEN");
+  });
+
+  it("returns null when no PR matches the branch", async () => {
+    const { cache } = makeCache();
+    expect(await cache.findPullRequestForBranch("fusupo/escapement-studio", "missing-branch")).toBeNull();
+  });
+
+  it("finds PRs by branch from the cached PR map", async () => {
+    const { cache } = makeCache();
+    const found = await cache.findPullRequestForBranch("fusupo/escapement-studio", "studio-194-branch");
+    expect(found).toMatchObject({ number: 12, state: "MERGED" });
+  });
+
+  it("caches issues with TTL, invalidateAll, and write-through", async () => {
+    const { cache, githubService } = makeCache();
+
+    const first = await cache.listIssues("fusupo/escapement-studio");
+    const second = await cache.listIssues("fusupo/escapement-studio");
+    expect(first).toBe(second);
+    expect(githubService.listIssues).toHaveBeenCalledTimes(1);
+
+    cache.upsertIssue("fusupo/escapement-studio", {
+      number: 199,
+      state: "open",
+      closed_at: null,
+      url: "https://github.com/fusupo/escapement-studio/issues/199",
+      title: "New issue",
+    });
+    expect((await cache.listIssues("fusupo/escapement-studio")).get(199)?.state).toBe("open");
+
+    cache.invalidateAll();
+    await cache.listIssues("fusupo/escapement-studio");
+    expect(githubService.listIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces GitHub fetch failures", async () => {
+    const { cache, githubService } = makeCache();
+    githubService.listPullRequests.mockRejectedValueOnce(new Error("gh auth failed"));
+    await expect(cache.listPullRequests("fusupo/escapement-studio")).rejects.toThrow("gh auth failed");
+  });
+
+  it("preserves write-through updates made during an in-flight PR fetch", async () => {
+    const { cache, githubService } = makeCache();
+    let resolveFetch: ((value: any) => void) | undefined;
+    githubService.listPullRequests.mockReturnValueOnce(new Promise((resolve) => {
+      resolveFetch = resolve;
+    }));
+
+    const pending = cache.listPullRequests("fusupo/escapement-studio");
+    cache.upsertPullRequest("fusupo/escapement-studio", {
+      number: 88,
+      state: "OPEN",
+      merged_at: null,
+      head_ref: "hotfix",
+      base_ref: "develop",
+      url: "https://github.com/fusupo/escapement-studio/pull/88",
+      title: "Hotfix",
+      is_draft: false,
+    });
+
+    resolveFetch?.([
+      {
+        number: 12,
+        state: "CLOSED",
+        merged_at: null,
+        head_ref: "studio-194-branch",
+        base_ref: "develop",
+        url: "https://github.com/fusupo/escapement-studio/pull/12",
+        title: "Batch cache",
+        is_draft: false,
+      },
+    ]);
+
+    const pulls = await pending;
+    expect(pulls.get(88)).toMatchObject({ head_ref: "hotfix" });
+    expect(pulls.has(12)).toBe(false);
+  });
+
+  it("reports cache diagnostics", async () => {
+    const { cache } = makeCache();
+
+    await cache.listPullRequests("fusupo/escapement-studio");
+    await cache.listIssues("fusupo/escapement-studio");
+
+    expect(cache.getCacheInfo()).toEqual([
+      expect.objectContaining({
+        repo: "fusupo/escapement-studio",
+        pr_count: 1,
+        issue_count: 1,
+        prs_fetched_at: "2026-04-12T00:00:00.000Z",
+        issues_fetched_at: "2026-04-12T00:00:00.000Z",
+      }),
+    ]);
+  });
+});

--- a/src/modules/execution/__tests__/work-item-reconciler.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler.test.ts
@@ -198,9 +198,9 @@ describe("WorkItemReconcilerService.reconcile", () => {
         return match;
       }),
     };
-    const githubService = {
+    const githubBatchCache = {
       findPullRequestForBranch: vi.fn(async () => stubs.pr ?? null),
-      readIssue: vi.fn(async () => ({ state: stubs.issueState ?? "open" })),
+      listIssues: vi.fn(async () => new Map([[176, { state: (stubs.issueState ?? "open").toLowerCase() }]])),
     };
 
     (service as any).logger = { log: vi.fn(), warn: vi.fn() };
@@ -208,12 +208,12 @@ describe("WorkItemReconcilerService.reconcile", () => {
     (service as any).runsDir = "/tmp/artifact-root/runs";
     (service as any).worktreeRoot = "/tmp/artifact-root/worktrees";
     (service as any).workItemsService = workItemsService;
-    (service as any).githubService = githubService;
+    (service as any).githubBatchCache = githubBatchCache;
     service.diskStore = diskStore;
     service.gitRunner = gitRunner;
     service.pathExists = () => stubs.worktreeExists ?? false;
 
-    return { service, diskStore, gitRunner, workItemsService, githubService };
+    return { service, diskStore, gitRunner, workItemsService, githubBatchCache };
   }
 
   it("returns an empty array when no work items are in a reconcilable state", async () => {
@@ -306,20 +306,20 @@ describe("WorkItemReconcilerService.reconcile", () => {
         merge_commit_sha: "deadbeef",
       },
     });
-    const { service, githubService } = makeService({ workItems: [makeWorkItem()], runs: [run], worktreeExists: true });
+    const { service, githubBatchCache } = makeService({ workItems: [makeWorkItem()], runs: [run], worktreeExists: true });
 
     const reconciled = await service.reconcile();
     expect(reconciled).toHaveLength(1);
     expect(reconciled[0].github_pr).toMatchObject({ number: 200, state: "MERGED" });
     expect(reconciled[0].next_action).toBe("close_out");
-    expect(githubService.findPullRequestForBranch).not.toHaveBeenCalled();
-    // Issue #85: merged PR triggers the readIssue probe and populates
+    expect(githubBatchCache.findPullRequestForBranch).not.toHaveBeenCalled();
+    // Issue #85: merged PR triggers the issue-state probe and populates
     // github_issue_state.
-    expect(githubService.readIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 176);
+    expect(githubBatchCache.listIssues).toHaveBeenCalledWith("fusupo/escapement-studio");
     expect(reconciled[0].github_issue_state).toBe("open");
   });
 
-  it("populates github_issue_state from readIssue when PR is merged", async () => {
+  it("populates github_issue_state from the batch cache when PR is merged", async () => {
     const run = makeRun({
       pull_request: {
         number: 200,
@@ -345,8 +345,8 @@ describe("WorkItemReconcilerService.reconcile", () => {
     expect(reconciled[0].github_issue_state).toBe("closed");
   });
 
-  it("does not call readIssue when PR is open (skip optimization)", async () => {
-    const { service, githubService } = makeService({
+  it("does not call listIssues when PR is open (skip optimization)", async () => {
+    const { service, githubBatchCache } = makeService({
       workItems: [makeWorkItem()],
       runs: [makeRun()],
       pr: { number: 201, state: "OPEN", merged_at: null, url: "https://github.com/x/y/pull/201" },
@@ -354,23 +354,23 @@ describe("WorkItemReconcilerService.reconcile", () => {
       worktreeExists: true,
     });
     const reconciled = await service.reconcile();
-    expect(githubService.readIssue).not.toHaveBeenCalled();
+    expect(githubBatchCache.listIssues).not.toHaveBeenCalled();
     expect(reconciled[0].github_issue_state).toBeNull();
   });
 
-  it("does not call readIssue when PR is absent", async () => {
-    const { service, githubService } = makeService({
+  it("does not call listIssues when PR is absent", async () => {
+    const { service, githubBatchCache } = makeService({
       workItems: [makeWorkItem()],
       runs: [makeRun()],
       git: { count: "2\n" },
       worktreeExists: true,
     });
     const reconciled = await service.reconcile();
-    expect(githubService.readIssue).not.toHaveBeenCalled();
+    expect(githubBatchCache.listIssues).not.toHaveBeenCalled();
     expect(reconciled[0].github_issue_state).toBeNull();
   });
 
-  it("degrades gracefully when readIssue throws", async () => {
+  it("degrades gracefully when listIssues throws", async () => {
     const run = makeRun({
       pull_request: {
         number: 200,
@@ -386,20 +386,20 @@ describe("WorkItemReconcilerService.reconcile", () => {
         merge_commit_sha: "deadbeef",
       },
     });
-    const { service, githubService } = makeService({
+    const { service, githubBatchCache } = makeService({
       workItems: [makeWorkItem()],
       runs: [run],
       worktreeExists: true,
     });
-    (githubService.readIssue as any).mockRejectedValueOnce(new Error("gh rate limited"));
+    (githubBatchCache.listIssues as any).mockRejectedValueOnce(new Error("gh rate limited"));
 
     const reconciled = await service.reconcile();
     expect(reconciled[0].github_issue_state).toBeNull();
     expect(((service as any).logger.warn as any).mock.calls.length).toBeGreaterThan(0);
   });
 
-  it("calls GitHubService.findPullRequestForBranch when no stored PR", async () => {
-    const { service, githubService } = makeService({
+  it("calls GitHubBatchCache.findPullRequestForBranch when no stored PR", async () => {
+    const { service, githubBatchCache } = makeService({
       workItems: [makeWorkItem()],
       runs: [makeRun()],
       pr: { number: 201, state: "OPEN", merged_at: null, url: "https://github.com/x/y/pull/201" },
@@ -410,20 +410,20 @@ describe("WorkItemReconcilerService.reconcile", () => {
     const reconciled = await service.reconcile();
     expect(reconciled[0].github_pr).toMatchObject({ number: 201, state: "OPEN" });
     expect(reconciled[0].next_action).toBe("awaiting_review");
-    expect(githubService.findPullRequestForBranch).toHaveBeenCalledWith(
+    expect(githubBatchCache.findPullRequestForBranch).toHaveBeenCalledWith(
       "fusupo/escapement-studio",
       "studio-176-branch",
     );
   });
 
   it("degrades gracefully when findPullRequestForBranch throws", async () => {
-    const { service, githubService } = makeService({
+    const { service, githubBatchCache } = makeService({
       workItems: [makeWorkItem()],
       runs: [makeRun()],
       git: { count: "3\n" },
       worktreeExists: true,
     });
-    (githubService.findPullRequestForBranch as any).mockRejectedValueOnce(new Error("gh rate limited"));
+    (githubBatchCache.findPullRequestForBranch as any).mockRejectedValueOnce(new Error("gh rate limited"));
 
     const reconciled = await service.reconcile();
     expect(reconciled[0].github_pr).toBeNull();
@@ -468,7 +468,7 @@ describe("WorkItemReconcilerService.runStartupReconcile", () => {
     (service as any).logger = logger;
     (service as any).runsDir = "/tmp/runs";
     (service as any).workItemsService = { list: vi.fn(() => []), get: vi.fn() };
-    (service as any).githubService = { findPullRequestForBranch: vi.fn(), readIssue: vi.fn() };
+    (service as any).githubBatchCache = { findPullRequestForBranch: vi.fn(), listIssues: vi.fn() };
     service.diskStore = diskStore;
     service.gitRunner = { run: vi.fn(() => "") };
     service.pathExists = () => false;

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -3,6 +3,7 @@ import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
 import { ExecutionController } from "./execution.controller.js";
+import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { ExecutionService } from "./execution.service.js";
 import { WorkItemReconcilerController } from "./work-item-reconciler.controller.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
@@ -10,7 +11,7 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 @Module({
   imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
   controllers: [ExecutionController, WorkItemReconcilerController],
-  providers: [ExecutionService, WorkItemReconcilerService],
-  exports: [ExecutionService, WorkItemReconcilerService],
+  providers: [ExecutionService, GitHubBatchCache, WorkItemReconcilerService],
+  exports: [ExecutionService, GitHubBatchCache, WorkItemReconcilerService],
 })
 export class ExecutionModule {}

--- a/src/modules/execution/github-batch-cache.service.ts
+++ b/src/modules/execution/github-batch-cache.service.ts
@@ -1,0 +1,192 @@
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  GitHubService,
+  type GitHubListedIssue,
+  type GitHubListedPullRequest,
+} from "../github/github.service.js";
+
+export interface CachedPullRequest {
+  number: number;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  merged_at: string | null;
+  head_ref: string;
+  base_ref: string;
+  url: string;
+  title: string;
+  is_draft: boolean;
+}
+
+export interface CachedIssue {
+  number: number;
+  state: "open" | "closed";
+  closed_at: string | null;
+  url: string;
+  title: string;
+}
+
+interface CacheEntry<T> {
+  fetchedAt: number | null;
+  data: Map<number, T>;
+  inFlight: Promise<Map<number, T>> | null;
+  generation: number;
+}
+
+const PULL_REQUEST_LIMIT = 300;
+const ISSUE_LIMIT = 500;
+
+@Injectable()
+export class GitHubBatchCache {
+  private readonly logger = new Logger(GitHubBatchCache.name);
+  private readonly ttlMs = 60_000;
+  private readonly prCache = new Map<string, CacheEntry<CachedPullRequest>>();
+  private readonly issueCache = new Map<string, CacheEntry<CachedIssue>>();
+
+  constructor(private readonly githubService: GitHubService) {}
+
+  async listPullRequests(repo: string): Promise<Map<number, CachedPullRequest>> {
+    const key = this.normalizeRepo(repo);
+    const entry = this.getOrCreateEntry(this.prCache, key);
+    if (this.isFresh(entry)) return entry.data;
+    if (entry.inFlight) return entry.inFlight;
+
+    const fetchGeneration = entry.generation;
+    entry.inFlight = this.githubService.listPullRequests(key)
+      .then((pulls) => {
+        if (pulls.length === PULL_REQUEST_LIMIT) {
+          this.logger.warn(`Pull request cache fill for ${key} hit ${PULL_REQUEST_LIMIT} items; results may be truncated`);
+        }
+        const nextData = this.toPullRequestMap(pulls);
+        if (entry.generation === fetchGeneration) {
+          entry.data = nextData;
+          entry.fetchedAt = Date.now();
+        }
+        return entry.data;
+      })
+      .finally(() => {
+        if (entry.inFlight) {
+          entry.inFlight = null;
+        }
+      });
+
+    return entry.inFlight;
+  }
+
+  async listIssues(repo: string): Promise<Map<number, CachedIssue>> {
+    const key = this.normalizeRepo(repo);
+    const entry = this.getOrCreateEntry(this.issueCache, key);
+    if (this.isFresh(entry)) return entry.data;
+    if (entry.inFlight) return entry.inFlight;
+
+    const fetchGeneration = entry.generation;
+    entry.inFlight = this.githubService.listIssues(key)
+      .then((issues) => {
+        if (issues.length === ISSUE_LIMIT) {
+          this.logger.warn(`Issue cache fill for ${key} hit ${ISSUE_LIMIT} items; results may be truncated`);
+        }
+        const nextData = this.toIssueMap(issues);
+        if (entry.generation === fetchGeneration) {
+          entry.data = nextData;
+          entry.fetchedAt = Date.now();
+        }
+        return entry.data;
+      })
+      .finally(() => {
+        if (entry.inFlight) {
+          entry.inFlight = null;
+        }
+      });
+
+    return entry.inFlight;
+  }
+
+  async findPullRequestForBranch(repo: string, branch: string): Promise<CachedPullRequest | null> {
+    const normalizedBranch = branch.trim();
+    if (!normalizedBranch) return null;
+    const pulls = await this.listPullRequests(repo);
+    for (const pull of pulls.values()) {
+      if (pull.head_ref === normalizedBranch) {
+        return pull;
+      }
+    }
+    return null;
+  }
+
+  upsertPullRequest(repo: string, pr: CachedPullRequest): void {
+    const key = this.normalizeRepo(repo);
+    const entry = this.getOrCreateEntry(this.prCache, key);
+    entry.generation += 1;
+    entry.data.set(pr.number, { ...pr });
+    entry.fetchedAt ??= Date.now();
+  }
+
+  upsertIssue(repo: string, issue: CachedIssue): void {
+    const key = this.normalizeRepo(repo);
+    const entry = this.getOrCreateEntry(this.issueCache, key);
+    entry.generation += 1;
+    entry.data.set(issue.number, { ...issue });
+    entry.fetchedAt ??= Date.now();
+  }
+
+  invalidate(repo: string): void {
+    const key = this.normalizeRepo(repo);
+    this.prCache.delete(key);
+    this.issueCache.delete(key);
+  }
+
+  invalidateAll(): void {
+    this.prCache.clear();
+    this.issueCache.clear();
+  }
+
+  getCacheInfo(): Array<{
+    repo: string;
+    prs_fetched_at: string | null;
+    issues_fetched_at: string | null;
+    pr_count: number;
+    issue_count: number;
+  }> {
+    const repos = new Set([...this.prCache.keys(), ...this.issueCache.keys()]);
+    return Array.from(repos)
+      .sort((a, b) => a.localeCompare(b))
+      .map((repo) => {
+        const prs = this.prCache.get(repo);
+        const issues = this.issueCache.get(repo);
+        return {
+          repo,
+          prs_fetched_at: prs?.fetchedAt ? new Date(prs.fetchedAt).toISOString() : null,
+          issues_fetched_at: issues?.fetchedAt ? new Date(issues.fetchedAt).toISOString() : null,
+          pr_count: prs?.data.size ?? 0,
+          issue_count: issues?.data.size ?? 0,
+        };
+      });
+  }
+
+  private normalizeRepo(repo: string): string {
+    return this.githubService.normalizeRepo(repo);
+  }
+
+  private isFresh<T>(entry: CacheEntry<T>): boolean {
+    return entry.fetchedAt !== null && Date.now() - entry.fetchedAt < this.ttlMs;
+  }
+
+  private getOrCreateEntry<T>(cache: Map<string, CacheEntry<T>>, repo: string): CacheEntry<T> {
+    const existing = cache.get(repo);
+    if (existing) return existing;
+    const created: CacheEntry<T> = {
+      fetchedAt: null,
+      data: new Map<number, T>(),
+      inFlight: null,
+      generation: 0,
+    };
+    cache.set(repo, created);
+    return created;
+  }
+
+  private toPullRequestMap(pulls: GitHubListedPullRequest[]): Map<number, CachedPullRequest> {
+    return new Map(pulls.map((pull) => [pull.number, { ...pull }]));
+  }
+
+  private toIssueMap(issues: GitHubListedIssue[]): Map<number, CachedIssue> {
+    return new Map(issues.map((issue) => [issue.number, { ...issue }]));
+  }
+}

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -4,7 +4,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
 import { runsRoot, worktreesRoot } from "../../lib/context-layout.js";
-import { GitHubService } from "../github/github.service.js";
+import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import {
@@ -109,7 +109,7 @@ export class WorkItemReconcilerService {
 
   constructor(
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
-    @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
   ) {}
 
   /**
@@ -200,13 +200,13 @@ export class WorkItemReconcilerService {
       return null;
     }
     try {
-      const issue = await this.githubService.readIssue(workItem.repo, workItem.issue_number);
-      const raw = (issue?.state ?? "").toString().toLowerCase();
+      const issues = await this.githubBatchCache.listIssues(workItem.repo);
+      const raw = (issues.get(workItem.issue_number)?.state ?? "").toString().toLowerCase();
       if (raw === "open" || raw === "closed") return raw;
       return null;
     } catch (error) {
       this.logger.warn(
-        `readIssue failed for ${workItem.repo}#${workItem.issue_number}: ${error instanceof Error ? error.message : String(error)}`,
+        `listIssues failed for ${workItem.repo}#${workItem.issue_number}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return null;
     }
@@ -311,7 +311,7 @@ export class WorkItemReconcilerService {
     if (!repo || !branch) return null;
 
     try {
-      const found = await this.githubService.findPullRequestForBranch(repo, branch);
+      const found = await this.githubBatchCache.findPullRequestForBranch(repo, branch);
       if (!found) return null;
       return {
         number: found.number,

--- a/src/modules/github/__tests__/github.service.test.ts
+++ b/src/modules/github/__tests__/github.service.test.ts
@@ -271,3 +271,127 @@ describe("GitHubService reconciliation", () => {
     });
   });
 });
+
+describe("GitHubService batch list methods", () => {
+  it("lists pull requests with normalized fields and commands", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGhJson = vi.fn().mockResolvedValue([
+      {
+        number: 194,
+        url: "https://github.com/fusupo/escapement-studio/pull/194",
+        title: "Batch cache",
+        state: "CLOSED",
+        isDraft: false,
+        baseRefName: "develop",
+        headRefName: "studio-194-branch",
+        mergedAt: "2026-04-12T00:00:00.000Z",
+      },
+    ]);
+    (service as any).runGhJson = runGhJson;
+    (service as any).logger = { warn: vi.fn() };
+
+    const result = await service.listPullRequests("HTTPS://github.com/FUSUPO/escapement-studio/");
+
+    expect(runGhJson).toHaveBeenCalledWith([
+      "pr",
+      "list",
+      "--repo",
+      "fusupo/escapement-studio",
+      "--state",
+      "all",
+      "--limit",
+      "300",
+      "--json",
+      "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt",
+    ]);
+    expect(result).toEqual([
+      {
+        number: 194,
+        state: "MERGED",
+        merged_at: "2026-04-12T00:00:00.000Z",
+        head_ref: "studio-194-branch",
+        base_ref: "develop",
+        url: "https://github.com/fusupo/escapement-studio/pull/194",
+        title: "Batch cache",
+        is_draft: false,
+      },
+    ]);
+  });
+
+  it("lists issues with normalized closed_at fields and empty responses", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGhJson = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          number: 194,
+          title: "Batch cache issue",
+          url: "https://github.com/fusupo/escapement-studio/issues/194",
+          state: "CLOSED",
+          closedAt: "2026-04-12T00:00:00.000Z",
+        },
+      ]);
+    (service as any).runGhJson = runGhJson;
+    (service as any).logger = { warn: vi.fn() };
+
+    expect(await service.listIssues("fusupo/escapement-studio")).toEqual([]);
+    expect(await service.listIssues("fusupo/escapement-studio")).toEqual([
+      {
+        number: 194,
+        state: "closed",
+        closed_at: "2026-04-12T00:00:00.000Z",
+        url: "https://github.com/fusupo/escapement-studio/issues/194",
+        title: "Batch cache issue",
+      },
+    ]);
+    expect(runGhJson).toHaveBeenLastCalledWith([
+      "issue",
+      "list",
+      "--repo",
+      "fusupo/escapement-studio",
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,title,url,state,closedAt",
+    ]);
+  });
+
+  it("warns when batch list results hit the hard limits", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const logger = { warn: vi.fn() };
+    (service as any).logger = logger;
+    (service as any).runGhJson = vi.fn()
+      .mockResolvedValueOnce(Array.from({ length: 300 }, (_, index) => ({
+        number: index + 1,
+        url: `https://github.com/fusupo/escapement-studio/pull/${index + 1}`,
+        title: `PR ${index + 1}`,
+        state: "OPEN",
+        isDraft: false,
+        baseRefName: "develop",
+        headRefName: `branch-${index + 1}`,
+        mergedAt: null,
+      })))
+      .mockResolvedValueOnce(Array.from({ length: 500 }, (_, index) => ({
+        number: index + 1,
+        title: `Issue ${index + 1}`,
+        url: `https://github.com/fusupo/escapement-studio/issues/${index + 1}`,
+        state: "OPEN",
+        closedAt: null,
+      })));
+
+    await service.listPullRequests("fusupo/escapement-studio");
+    await service.listIssues("fusupo/escapement-studio");
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates batch list failures", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    (service as any).runGhJson = vi.fn().mockRejectedValue(new Error("gh failed"));
+
+    await expect(service.listPullRequests("fusupo/escapement-studio")).rejects.toThrow("gh failed");
+    await expect(service.listIssues("fusupo/escapement-studio")).rejects.toThrow("gh failed");
+  });
+});

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import type { Database as DatabaseType } from "better-sqlite3";
@@ -27,6 +27,14 @@ interface RawIssueResponse {
   assignees?: Array<{ login?: string; name?: string }>;
 }
 
+interface RawIssueListResponse {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  closedAt?: string | null;
+}
+
 interface RawPullRequestResponse {
   number: number;
   url: string;
@@ -38,6 +46,25 @@ interface RawPullRequestResponse {
   headRefName?: string;
   mergedAt?: string | null;
   mergeCommit?: { oid?: string | null } | null;
+}
+
+export interface GitHubListedPullRequest {
+  number: number;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  merged_at: string | null;
+  head_ref: string;
+  base_ref: string;
+  url: string;
+  title: string;
+  is_draft: boolean;
+}
+
+export interface GitHubListedIssue {
+  number: number;
+  state: "open" | "closed";
+  closed_at: string | null;
+  url: string;
+  title: string;
 }
 
 export interface GitHubCreateIssueInput {
@@ -79,6 +106,7 @@ interface PullRequestTruthRefreshResult {
 
 @Injectable()
 export class GitHubService {
+  private readonly logger = new Logger(GitHubService.name);
   private pullRequestTruthRefresher?: (pullRequest: GitHubPullRequestDetails, options?: { work_item_ids?: string[] }) => PullRequestTruthRefreshResult;
 
   constructor(
@@ -226,6 +254,81 @@ export class GitHubService {
     ]);
 
     return this.withPullRequestReconciliation(this.toPullRequestDetails(repo, raw));
+  }
+
+  normalizeRepo(repo: string): string {
+    const trimmed = repo.trim().replace(/^https?:\/\/github\.com\//i, "").replace(/^github\.com\//i, "");
+    return trimmed.replace(/^\/+|\/+$/g, "").toLowerCase();
+  }
+
+  async listPullRequests(repo: string): Promise<GitHubListedPullRequest[]> {
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+
+    const normalizedRepo = this.normalizeRepo(repo);
+    const pulls = await this.runGhJson<RawPullRequestResponse[]>([
+      "pr",
+      "list",
+      "--repo",
+      normalizedRepo,
+      "--state",
+      "all",
+      "--limit",
+      "300",
+      "--json",
+      "number,url,title,state,isDraft,baseRefName,headRefName,mergedAt",
+    ]);
+
+    if (pulls.length === 300) {
+      this.logger.warn(`gh pr list hit --limit 300 for ${normalizedRepo}; results may be truncated`);
+    }
+
+    return pulls.map((pull) => {
+      const details = this.toPullRequestDetails(normalizedRepo, pull);
+      return {
+        number: details.number,
+        state: this.normalizePullRequestState(details.state, details.merged_at),
+        merged_at: details.merged_at,
+        head_ref: details.head_ref,
+        base_ref: details.base_ref,
+        url: details.url,
+        title: details.title,
+        is_draft: details.is_draft,
+      };
+    });
+  }
+
+  async listIssues(repo: string): Promise<GitHubListedIssue[]> {
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+
+    const normalizedRepo = this.normalizeRepo(repo);
+    const issues = await this.runGhJson<RawIssueListResponse[]>([
+      "issue",
+      "list",
+      "--repo",
+      normalizedRepo,
+      "--state",
+      "all",
+      "--limit",
+      "500",
+      "--json",
+      "number,title,url,state,closedAt",
+    ]);
+
+    if (issues.length === 500) {
+      this.logger.warn(`gh issue list hit --limit 500 for ${normalizedRepo}; results may be truncated`);
+    }
+
+    return issues.map((issue) => ({
+      number: issue.number,
+      state: `${issue.state}`.toLowerCase() === "closed" ? "closed" : "open",
+      closed_at: issue.closedAt ?? null,
+      url: issue.url,
+      title: issue.title,
+    }));
   }
 
   async findPullRequestForBranch(repo: string, branch: string): Promise<GitHubPullRequestDetails | null> {
@@ -679,13 +782,22 @@ export class GitHubService {
       url: raw.url,
       title: raw.title,
       body: raw.body ?? "",
-      state: raw.state,
+      state: this.normalizePullRequestState(raw.state, raw.mergedAt ?? null),
       is_draft: Boolean(raw.isDraft),
       base_ref: raw.baseRefName?.trim() || "",
       head_ref: raw.headRefName?.trim() || "",
       merged_at: raw.mergedAt ?? null,
       merge_commit_sha: raw.mergeCommit?.oid ?? null,
     };
+  }
+
+  private normalizePullRequestState(state: string, mergedAt: string | null): "OPEN" | "CLOSED" | "MERGED" {
+    if (mergedAt) return "MERGED";
+    const normalized = state.trim().toUpperCase();
+    if (normalized === "OPEN" || normalized === "CLOSED" || normalized === "MERGED") {
+      return normalized;
+    }
+    return "OPEN";
   }
 
   private async runGhJson<T>(args: string[]): Promise<T> {


### PR DESCRIPTION
## Summary
Done.

Changed:
- `src/modules/github/github.service.ts`
- `src/modules/github/__tests__/github.service.test.ts`
- `src/modules/execution/github-batch-cache.service.ts`
- `src/modules/execution/__tests__/github-batch-cache.service.test.ts`
- `src/modules/execution/work-item-reconciler.service.ts`
- `src/modules/execution/__tests__/work-item-reconciler.test.ts`
- `src/modules/execution/execution.module.ts`

What I implemented:
- Added `GitHubService.listPullRequests()` and `listIssues()`
- Added new `GitHubBatchCache` with:
  - 60s TTL
  - per-repo normalized keys
  - in-flight dedup
  - write-through upserts
  - invalidate / invalidateAll
  - diagnostics
  - generation guard so in-flight fetches don’t overwrite write-through updates
- Swapped `WorkItemReconcilerService` to use the cache for:
  - branch → PR lookup
  - issue_number → issue state lookup
- Registered the cache in `ExecutionModule`
- Added unit tests for service, cache, and reconciler behavior

Validation:
- `npx tsc --noEmit` ✅
- targeted vitest for changed files ✅
- `npx vite build --config web/vite.config.ts` ✅
- full `npx vitest run` is blocked by existing environment issue: missing `better-sqlite3` native bindings in this worktree

Note:
- I updated `SCRATCHPAD_studio_194.md` locally to reflect progress, but did not stage/commit it.

If you want, I can make a commit next.

## Context
- Work item: studio-194
- Issue: https://github.com/fusupo/escapement-studio/issues/194
- Base branch: develop
- Head branch: studio-194-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775954016777
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-194-branch
- Scope hint: Add a GitHubBatchCache service with a write-through API for GitHub-derived state reads and updates.

## Changed files
- `src/modules/execution/__tests__/work-item-reconciler.test.ts`
- `src/modules/execution/execution.module.ts`
- `src/modules/execution/work-item-reconciler.service.ts`
- `src/modules/github/__tests__/github.service.test.ts`
- `src/modules/github/github.service.ts`
- `src/modules/execution/__tests__/github-batch-cache.service.test.ts`
- `src/modules/execution/github-batch-cache.service.ts`