### PR TITLE
Studio: generalize close/archive actions to accept merged_pr | closed (#196)

### DIFF
--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -11,7 +11,7 @@ import {
   planDir,
 } from "../../../lib/context-layout.js";
 import type { ExecutionDispatchPreview, ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
-import type { WorkItemRecord, WorkItemState } from "../../graph/types.js";
+import type { DispatchResult, WorkItemRecord, WorkItemState } from "../../graph/types.js";
 
 /**
  * ADR 014 step 7: disposition flow for `merged_pr → done` and plan dir
@@ -31,6 +31,11 @@ interface HarnessService {
   };
   listRecentRuns: () => ExecutionRunRecord[];
 
+  // studio-196 HSM dispatch
+  hsmService: {
+    dispatch: ReturnType<typeof vi.fn>;
+  };
+
   // studio-87 close flow deps
   githubService: {
     closeIssue: ReturnType<typeof vi.fn>;
@@ -49,6 +54,19 @@ interface HarnessService {
   assertNoActiveRunForWorkItem: (id: string) => void;
   movePlanDirToArchives: (id: string) => { moved: boolean; archive_path: string | null };
   removeRunsForWorkItem: (id: string) => string[];
+}
+
+function makeDispatchResult(overrides: Partial<DispatchResult> = {}): DispatchResult {
+  return {
+    work_item_id: "studio-157",
+    prev_state: "merged_pr",
+    next_state: "done",
+    event: { type: "user.finalize" },
+    applied_actions: [],
+    mutation_applied: true,
+    rejected: false,
+    ...overrides,
+  };
 }
 
 function makeDispatchPreviewStub(): ExecutionDispatchPreview {
@@ -110,6 +128,7 @@ function makeService(params: {
   runs?: ExecutionRunRecord[];
   githubCloseIssue?: ReturnType<typeof vi.fn>;
   updateImpl?: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
+  hsmDispatch?: ReturnType<typeof vi.fn>;
 }): HarnessService {
   const service = Object.create(ExecutionService.prototype) as HarnessService;
   let currentWorkItem = params.workItem ?? makeWorkItem();
@@ -159,6 +178,31 @@ function makeService(params: {
   service.writeStatus = vi.fn();
   service.emitRun = vi.fn();
   service.getPreview = vi.fn(() => makeDispatchPreviewStub()) as HarnessService["getPreview"];
+
+  // studio-196: default HSM dispatch mock — transitions to done for user.finalize.
+  // The mock updates currentWorkItem's state so workItemsService.get returns
+  // the post-transition snapshot.
+  service.hsmService = {
+    dispatch: params.hsmDispatch ?? vi.fn(async (_id: string, event: { type: string }) => {
+      const prevState = currentWorkItem.state;
+      const nextState = event.type === "user.archive_and_finalize" ? "archived" : "done";
+      currentWorkItem = { ...currentWorkItem, state: nextState as WorkItemState, updated_at: "2026-04-09T00:00:01.000Z" };
+      return makeDispatchResult({
+        prev_state: prevState,
+        next_state: nextState as WorkItemState,
+        event: event as DispatchResult["event"],
+        applied_actions: prevState === "merged_pr"
+          ? (event.type === "user.archive_and_finalize"
+            ? ["closeGhIssue", "runArchiver"]
+            : ["closeGhIssue"])
+          : (event.type === "user.archive_and_finalize" ? ["runArchiver"] : []),
+        handler_data: prevState === "merged_pr" && currentWorkItem.kind === "issue" && currentWorkItem.issue_number
+          ? { closed_issue: { repo: currentWorkItem.repo, number: currentWorkItem.issue_number, url: currentWorkItem.issue_url, title: "Disposition test issue", state: "CLOSED" } }
+          : undefined,
+      });
+    }),
+  };
+
   return service;
 }
 
@@ -281,8 +325,8 @@ describe("ADR 014 step 7: disposition flow", () => {
     });
   });
 
-  describe("closeMergedPullRequest (studio-87 full close flow)", () => {
-    it("happy path: closes gh issue, transitions to done, removes runs, returns envelope", async () => {
+  describe("closeMergedPullRequest (studio-196 HSM dispatch flow)", () => {
+    it("happy path: dispatches user.finalize, removes runs, returns envelope", async () => {
       ensurePlanDir(tmpRoot, "studio-157");
       writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
 
@@ -308,12 +352,9 @@ describe("ADR 014 step 7: disposition flow", () => {
       expect(result.dispatch_preview).toBeTruthy();
       expect(result.dispatch_preview.groups).toEqual([]);
 
-      // github.closeIssue called once with repo + issue number
-      expect(service.githubService.closeIssue).toHaveBeenCalledTimes(1);
-      expect(service.githubService.closeIssue).toHaveBeenCalledWith(
-        "fusupo/escapement-studio",
-        157,
-      );
+      // HSM dispatch called with correct event
+      expect(service.hsmService.dispatch).toHaveBeenCalledTimes(1);
+      expect(service.hsmService.dispatch).toHaveBeenCalledWith("studio-157", { type: "user.finalize" });
 
       // Matching run spliced, other run preserved
       expect(service.recentRuns.map((r) => r.run_id)).toEqual(["exec_other"]);
@@ -336,7 +377,7 @@ describe("ADR 014 step 7: disposition flow", () => {
       expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(false);
     });
 
-    it("non-issue-backed work item skips the github close step", async () => {
+    it("non-issue-backed work item returns null closed_issue from handler_data", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         workItem: makeWorkItem({
@@ -350,16 +391,15 @@ describe("ADR 014 step 7: disposition flow", () => {
 
       expect(result.closed_issue).toBeNull();
       expect(result.work_item.state).toBe("done");
-      expect(service.githubService.closeIssue).not.toHaveBeenCalled();
     });
 
-    it("gh-close failure bubbles as BadRequestException and leaves state untouched", async () => {
-      const closeSpy = vi.fn(async () => {
-        throw new Error("gh not authenticated");
+    it("dispatch failure bubbles as-is and leaves runs intact", async () => {
+      const dispatchMock = vi.fn(async () => {
+        throw new BadRequestException("close_merged_failed_github_close: gh not authenticated");
       });
       const service = makeService({
         artifactRoot: tmpRoot,
-        githubCloseIssue: closeSpy,
+        hsmDispatch: dispatchMock,
         runs: [makeRun({ run_id: "exec_still_here", status: "completed" })],
       });
 
@@ -372,58 +412,6 @@ describe("ADR 014 step 7: disposition flow", () => {
       expect(service.workItemsService.get("studio-157").state).toBe("merged_pr");
       expect(service.recentRuns.map((r) => r.run_id)).toEqual(["exec_still_here"]);
       expect(service.writeStatus).not.toHaveBeenCalled();
-    });
-
-    it("state transition failure after a successful gh close surfaces and leaves runs intact", async () => {
-      const closeSpy = vi.fn(async (repo: string, issueNumber: number) => ({
-        repo,
-        number: issueNumber,
-        title: "t",
-        body: "",
-        url: "u",
-        state: "CLOSED",
-        labels: [],
-        assignees: [],
-        body_hash: "h",
-      }));
-      const updateImpl = vi.fn(() => {
-        throw new Error("db write failed");
-      });
-      const service = makeService({
-        artifactRoot: tmpRoot,
-        githubCloseIssue: closeSpy,
-        updateImpl,
-        runs: [makeRun({ run_id: "exec_retryable", status: "completed" })],
-      });
-
-      await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(/db write failed/);
-
-      // gh close did happen; the retry-safety contract says a second attempt
-      // re-runs the whole flow. Runs were not yet disposed because the
-      // finalizer runs AFTER the state transition.
-      expect(closeSpy).toHaveBeenCalledTimes(1);
-      expect(service.recentRuns.map((r) => r.run_id)).toEqual(["exec_retryable"]);
-      expect(service.writeStatus).not.toHaveBeenCalled();
-    });
-
-    it("idempotent retry when the work item is already done", async () => {
-      // Simulates a retry after a prior attempt got past the state
-      // transition but died in the finalizer. Guards must short-circuit,
-      // gh close must still run (idempotent), and the finalizer must run
-      // so leftover runs are disposed.
-      const service = makeService({
-        artifactRoot: tmpRoot,
-        workItem: makeWorkItem({ state: "done" }),
-        runs: [makeRun({ run_id: "exec_leftover", status: "completed" })],
-      });
-
-      const result = await service.closeMergedPullRequest("studio-157");
-
-      expect(result.work_item.state).toBe("done");
-      expect(result.removed_run_ids).toEqual(["exec_leftover"]);
-      expect(service.recentRuns).toEqual([]);
-      // gh close still ran (idempotent) even though work item was done
-      expect(service.githubService.closeIssue).toHaveBeenCalledTimes(1);
     });
 
     it("removes no runs when there are no matching recent runs", async () => {
@@ -439,21 +427,20 @@ describe("ADR 014 step 7: disposition flow", () => {
       expect(service.writeStatus).not.toHaveBeenCalled();
     });
 
-    it.each<WorkItemState>(["open_pr", "in_progress", "ready", "drafting", "planned"])(
-      "throws when state is %s (not merged_pr, not done)",
-      async (state) => {
-        const service = makeService({
-          artifactRoot: tmpRoot,
-          workItem: makeWorkItem({ state }),
-        });
-        await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(BadRequestException);
-        await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(
-          /work_item_not_in_merged_pr/,
-        );
-      },
-    );
+    it("throws when HSM rejects the event (invalid source state)", async () => {
+      const dispatchMock = vi.fn(async () =>
+        makeDispatchResult({ rejected: true, prev_state: "open_pr", next_state: "open_pr", mutation_applied: false }),
+      );
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "open_pr" }),
+        hsmDispatch: dispatchMock,
+      });
+      await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(BadRequestException);
+      await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(/cannot_dispose/);
+    });
 
-    it("throws when an active run exists", async () => {
+    it("throws when an active run exists (pre-dispatch guard)", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         runs: [makeRun({ status: "running" })],
@@ -461,6 +448,31 @@ describe("ADR 014 step 7: disposition flow", () => {
       await expect(service.closeMergedPullRequest("studio-157")).rejects.toThrow(
         /cannot_dispose_work_item_active_run/,
       );
+      // HSM dispatch should NOT have been called
+      expect(service.hsmService.dispatch).not.toHaveBeenCalled();
+    });
+
+    it("from closed state: dispatches user.finalize, no closeGhIssue in actions", async () => {
+      const dispatchMock = vi.fn(async () =>
+        makeDispatchResult({
+          prev_state: "closed",
+          next_state: "done",
+          applied_actions: [], // closed -> done has no closeGhIssue
+        }),
+      );
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "closed" }),
+        hsmDispatch: dispatchMock,
+      });
+      // After dispatch, workItemsService.get must return the post-transition state.
+      (service as any).workItemsService.get = vi.fn(() => makeWorkItem({ state: "done" }));
+
+      const result = await service.closeMergedPullRequest("studio-157");
+
+      expect(result.work_item.state).toBe("done");
+      expect(result.closed_issue).toBeNull();
+      expect(dispatchMock).toHaveBeenCalledWith("studio-157", { type: "user.finalize" });
     });
   });
 
@@ -510,56 +522,70 @@ describe("ADR 014 step 7: disposition flow", () => {
     });
   });
 
-  describe("archiveAndCloseMergedPullRequest", () => {
-    it("moves the plan dir, sets archive_path, and transitions to done", async () => {
-      ensurePlanDir(tmpRoot, "studio-157");
-      writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "approved plan", "utf8");
+  describe("archiveAndCloseMergedPullRequest (studio-196 HSM dispatch flow)", () => {
+    it("dispatches user.archive_and_finalize, removes runs, returns envelope", async () => {
+      const archiveResult = {
+        archive_path: archiveDir(tmpRoot, "studio-157"),
+        readme_path: null,
+        archived_run_ids: [],
+        skipped_run_ids: [],
+      };
+      const dispatchMock = vi.fn(async () =>
+        makeDispatchResult({
+          next_state: "archived" as WorkItemState,
+          event: { type: "user.archive_and_finalize" },
+          applied_actions: ["closeGhIssue", "runArchiver"],
+          handler_data: {
+            closed_issue: { repo: "fusupo/escapement-studio", number: 157, url: "https://github.com/fusupo/escapement-studio/issues/157", title: "Disposition test issue", state: "CLOSED" },
+            archive_result: archiveResult,
+          },
+        }),
+      );
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        hsmDispatch: dispatchMock,
+        workItem: makeWorkItem({ state: "merged_pr" }),
+      });
+      // Update the workItem state to match what dispatch returns
+      (service as any).workItemsService.get = vi.fn(() =>
+        makeWorkItem({ state: "archived" as WorkItemState, archive_path: archiveDir(tmpRoot, "studio-157") }),
+      );
 
-      const service = makeService({ artifactRoot: tmpRoot });
       const result = await service.archiveAndCloseMergedPullRequest("studio-157");
 
-      expect(result.work_item.state).toBe("done");
+      expect(result.work_item.state).toBe("archived");
       expect(result.work_item.archive_path).toBe(archiveDir(tmpRoot, "studio-157"));
-      // Plan dir moved
-      expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(false);
-      expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(true);
-      expect(
-        readFileSync(join(archiveDir(tmpRoot, "studio-157"), "SCRATCHPAD_studio_157.md"), "utf8"),
-      ).toBe("approved plan");
+      expect(result.closed_issue).toEqual({
+        repo: "fusupo/escapement-studio",
+        number: 157,
+        url: "https://github.com/fusupo/escapement-studio/issues/157",
+        title: "Disposition test issue",
+        state: "CLOSED",
+      });
+      expect(result.archive).toEqual(archiveResult);
+      expect(dispatchMock).toHaveBeenCalledWith("studio-157", { type: "user.archive_and_finalize" });
     });
 
-    it("state transition still happens when the plan dir was already gone", async () => {
-      // No ensurePlanDir call — archive step will be a no-op
-      const service = makeService({ artifactRoot: tmpRoot });
-      const result = await service.archiveAndCloseMergedPullRequest("studio-157");
-
-      expect(result.work_item.state).toBe("done");
-      // Run archival still establishes the archive location even when the
-      // plan dir was already absent.
-      expect(result.work_item.archive_path).toBe(archiveDir(tmpRoot, "studio-157"));
-      expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(true);
-    });
-
-    it("guards reject BEFORE the filesystem is touched", async () => {
-      ensurePlanDir(tmpRoot, "studio-157");
-      writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
-
+    it("throws when HSM rejects the event (invalid source state)", async () => {
+      const dispatchMock = vi.fn(async () =>
+        makeDispatchResult({
+          rejected: true,
+          prev_state: "open_pr",
+          next_state: "open_pr",
+          mutation_applied: false,
+        }),
+      );
       const service = makeService({
         artifactRoot: tmpRoot,
         workItem: makeWorkItem({ state: "open_pr" }),
+        hsmDispatch: dispatchMock,
       });
       await expect(service.archiveAndCloseMergedPullRequest("studio-157")).rejects.toThrow(
-        /work_item_not_in_merged_pr/,
+        /cannot_dispose/,
       );
-      // Plan dir still present — guard ran before filesystem
-      expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(true);
-      expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(false);
     });
 
-    it("active-run guard rejects BEFORE the filesystem is touched", async () => {
-      ensurePlanDir(tmpRoot, "studio-157");
-      writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
-
+    it("active-run guard rejects BEFORE dispatch is called", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         runs: [makeRun({ status: "running" })],
@@ -567,7 +593,39 @@ describe("ADR 014 step 7: disposition flow", () => {
       await expect(service.archiveAndCloseMergedPullRequest("studio-157")).rejects.toThrow(
         /cannot_dispose_work_item_active_run/,
       );
-      expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(true);
+      expect(service.hsmService.dispatch).not.toHaveBeenCalled();
+    });
+
+    it("from closed state: dispatches archive_and_finalize, runs runArchiver but NOT closeGhIssue", async () => {
+      const archiveResult = {
+        archive_path: archiveDir(tmpRoot, "studio-157"),
+        readme_path: null,
+        archived_run_ids: [],
+        skipped_run_ids: [],
+      };
+      const dispatchMock = vi.fn(async () =>
+        makeDispatchResult({
+          prev_state: "closed",
+          next_state: "archived" as WorkItemState,
+          event: { type: "user.archive_and_finalize" },
+          applied_actions: ["runArchiver"], // NO closeGhIssue from closed
+          handler_data: { archive_result: archiveResult },
+        }),
+      );
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "closed" }),
+        hsmDispatch: dispatchMock,
+      });
+      (service as any).workItemsService.get = vi.fn(() =>
+        makeWorkItem({ state: "archived" as WorkItemState, archive_path: archiveDir(tmpRoot, "studio-157") }),
+      );
+
+      const result = await service.archiveAndCloseMergedPullRequest("studio-157");
+
+      expect(result.work_item.state).toBe("archived");
+      expect(result.closed_issue).toBeNull(); // No closeGhIssue from closed
+      expect(result.archive).toEqual(archiveResult);
     });
   });
 

--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -144,6 +144,7 @@ describe("ExecutionService.onModuleInit", () => {
     (service as any).recentRuns = [];
     (service as any).recentRunLimit = 16;
     (service as any).workItemReconciler = reconcilerStub;
+    (service as any).hsmService = { registerActionHandler: vi.fn() };
 
     await service.onModuleInit();
 
@@ -171,6 +172,7 @@ describe("ExecutionService.onModuleInit", () => {
         throw new Error("reconciler boom");
       }),
     };
+    (service as any).hsmService = { registerActionHandler: vi.fn() };
 
     await service.onModuleInit();
 

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -25,6 +25,7 @@ import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
+import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import { SettingsService } from "../settings/settings.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
@@ -85,6 +86,7 @@ export class ExecutionService implements OnModuleInit {
   constructor(
     @Inject(GraphService) private readonly graphService: GraphService,
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
     @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
@@ -119,6 +121,73 @@ export class ExecutionService implements OnModuleInit {
         `Failed to hydrate recentRuns from disk: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
+
+    // studio-196: register HSM action handlers for disposition flows.
+    this.hsmService.registerActionHandler("closeGhIssue", async (workItem, _event, ctx) => {
+      if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
+        return; // Not issue-backed; skip.
+      }
+      try {
+        const details = await this.githubService.closeIssue(workItem.repo, workItem.issue_number);
+        ctx.handler_data.closed_issue = {
+          repo: details.repo,
+          number: details.number,
+          url: details.url,
+          title: details.title,
+          state: details.state,
+        };
+      } catch (error) {
+        throw new BadRequestException(
+          `close_merged_failed_github_close: ${this.getErrorMessage(error)}`,
+        );
+      }
+    });
+
+    this.hsmService.registerActionHandler("runArchiver", async (workItem, _event, ctx) => {
+      // Pre-capture run snapshot before any mutation.
+      const runSnapshot = this.captureRunSnapshotForWorkItem(workItem.id);
+
+      // Move plan dir to archives.
+      const moveResult = this.movePlanDirToArchives(workItem.id);
+
+      // Archive run artifacts + README.
+      let archiveResult: ArchiveRunArtifactsResult;
+      try {
+        archiveResult = archiveRunArtifactsForWorkItem(this.artifactRoot, workItem, {
+          runs: runSnapshot,
+          onWarn: (message) => this.logger.warn(message),
+        });
+      } catch (error) {
+        const message = this.getErrorMessage(error);
+        if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
+          throw new BadRequestException(message);
+        }
+        throw error;
+      }
+
+      // Stamp archive meta into the runtime context meta so the HSM
+      // persists it in the same mutation batch as the state transition.
+      const archivePath =
+        archiveResult.archive_path ?? moveResult.archive_path ?? workItem.archive_path;
+      const studioArchive: StudioArchiveMeta = {
+        archived_at: this.now(),
+        readme_path: archiveResult.readme_path,
+        archived_run_ids: archiveResult.archived_run_ids,
+        skipped_run_ids: archiveResult.skipped_run_ids,
+      };
+      ctx.meta.studio_archive = studioArchive;
+
+      // Set archive_path on the work item via patch_overrides.
+      ctx.patch_overrides.archive_path = archivePath;
+
+      // Surface archive results for the response envelope.
+      ctx.handler_data.archive_result = {
+        archive_path: archivePath,
+        readme_path: archiveResult.readme_path,
+        archived_run_ids: archiveResult.archived_run_ids,
+        skipped_run_ids: archiveResult.skipped_run_ids,
+      };
+    });
   }
 
   /**
@@ -2323,51 +2392,23 @@ export class ExecutionService implements OnModuleInit {
    * `syncMergedPullRequest` including a post-close `dispatch_preview`.
    */
   async closeMergedPullRequest(workItemId: string): Promise<CloseMergedPullRequestResult> {
-    const initialWorkItem = this.workItemsService.get(workItemId);
+    // Pre-dispatch guard: refuse while a run is live (HSM doesn't know about runs).
+    this.assertNoActiveRunForWorkItem(workItemId);
 
-    // Idempotent short-circuit: if the work item is already `done`, the
-    // previous attempt got past the state transition but may have failed
-    // during the finalizer. Skip the guards + state update, still run the
-    // finalizer so any leftover run records get disposed.
-    const alreadyDone = initialWorkItem.state === "done";
-    if (!alreadyDone) {
-      this.assertWorkItemInMergedPr(workItemId);
-      this.assertNoActiveRunForWorkItem(workItemId);
+    const result = await this.hsmService.dispatch(workItemId, { type: "user.finalize" });
+
+    if (result.rejected) {
+      throw new BadRequestException(
+        `cannot_dispose: HSM rejected user.finalize from state ${result.prev_state}`,
+      );
     }
 
-    // Step 3: close the linked GitHub issue (issue-backed work items only).
-    // gh issue close is idempotent — closing an already-closed issue is a
-    // no-op per the gh CLI contract, so retries after a partial failure
-    // are safe. A failure here bubbles as BadRequestException and leaves
-    // the work item in `merged_pr` for another attempt.
-    let closedIssue: ClosedGitHubIssueSummary | null = null;
-    if (initialWorkItem.kind === "issue" && initialWorkItem.repo && initialWorkItem.issue_number) {
-      try {
-        const details = await this.githubService.closeIssue(
-          initialWorkItem.repo,
-          initialWorkItem.issue_number,
-        );
-        closedIssue = {
-          repo: details.repo,
-          number: details.number,
-          url: details.url,
-          title: details.title,
-          state: details.state,
-        };
-      } catch (error) {
-        throw new BadRequestException(
-          `close_merged_failed_github_close: ${this.getErrorMessage(error)}`,
-        );
-      }
-    }
-
-    // Step 4: state transition (skipped on the already-done retry path).
-    const updatedWorkItem = alreadyDone
-      ? initialWorkItem
-      : this.workItemsService.update(workItemId, { state: "done" });
-
-    // Step 5: finalizer — splice runs and stamp disposed_at on disk.
+    // Post-dispatch finalizer: dispose matching runs.
     const removedRunIds = this.removeRunsForWorkItem(workItemId);
+
+    // Build the response envelope.
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
 
     return {
       work_item: {
@@ -2530,104 +2571,30 @@ export class ExecutionService implements OnModuleInit {
   async archiveAndCloseMergedPullRequest(
     workItemId: string,
   ): Promise<ArchiveAndCloseMergedPullRequestResult> {
-    const initialWorkItem = this.workItemsService.get(workItemId);
+    // Pre-dispatch guard.
+    this.assertNoActiveRunForWorkItem(workItemId);
 
-    // Step 1: idempotent short-circuit when the previous attempt got past
-    // the state transition but failed in the finalizer. Skip guards +
-    // state update, still run gh close (idempotent) and the finalizer.
-    const alreadyDone = initialWorkItem.state === "done";
-    if (!alreadyDone) {
-      // Steps 2 + 3: source state + active-run guards.
-      this.assertWorkItemInMergedPr(workItemId);
-      this.assertNoActiveRunForWorkItem(workItemId);
+    const result = await this.hsmService.dispatch(workItemId, {
+      type: "user.archive_and_finalize",
+    });
+
+    if (result.rejected) {
+      throw new BadRequestException(
+        `cannot_dispose: HSM rejected user.archive_and_finalize from state ${result.prev_state}`,
+      );
     }
 
-    // Step 4: capture a run snapshot BEFORE any mutation so the archiver
-    // can operate on the authoritative run list even after the finalizer
-    // stamps `disposed_at` (default disk scans skip disposed records,
-    // which would otherwise make a retry see an empty list).
-    const runSnapshot = this.captureRunSnapshotForWorkItem(workItemId);
-
-    // Step 5: gh issue close (issue-backed work items only). Errors here
-    // bubble as BadRequestException BEFORE any filesystem mutation so the
-    // retry can re-attempt the whole flow.
-    let closedIssue: ClosedGitHubIssueSummary | null = null;
-    if (initialWorkItem.kind === "issue" && initialWorkItem.repo && initialWorkItem.issue_number) {
-      try {
-        const details = await this.githubService.closeIssue(
-          initialWorkItem.repo,
-          initialWorkItem.issue_number,
-        );
-        closedIssue = {
-          repo: details.repo,
-          number: details.number,
-          url: details.url,
-          title: details.title,
-          state: details.state,
-        };
-      } catch (error) {
-        throw new BadRequestException(
-          `close_merged_failed_github_close: ${this.getErrorMessage(error)}`,
-        );
-      }
-    }
-
-    // Step 6: move the plan dir into `archives/<slug>/` if it still
-    // exists. A no-op when a prior retry already moved it — the state
-    // update downstream will still run with whatever archive_path the
-    // work item already carries. `archive_already_exists` from the
-    // destination collision path bubbles as BadRequestException.
-    const moveResult = this.movePlanDirToArchives(workItemId);
-
-    // Step 7: archive run artifacts + README. Bypass the
-    // `archiveRunArtifacts` wrapper so we can reuse the pre-captured
-    // snapshot (avoiding a redundant disk re-scan that would drop
-    // disposed runs on retry) and skip the wrapper's active-run guard
-    // which we already ran above.
-    let archiveResult: ArchiveRunArtifactsResult;
-    try {
-      archiveResult = archiveRunArtifactsForWorkItem(this.artifactRoot, initialWorkItem, {
-        runs: runSnapshot,
-        onWarn: (message) => this.logger.warn(message),
-      });
-    } catch (error) {
-      const message = this.getErrorMessage(error);
-      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
-        throw new BadRequestException(message);
-      }
-      throw error;
-    }
-
-    // Step 8: state transition (skipped on the already-done retry path).
-    // Shallow-merge the archive audit block into `meta` alongside any
-    // existing `studio_post_merge_sync` block from the earlier
-    // merged_pr transition.
-    const archivePath = archiveResult.archive_path ?? moveResult.archive_path ?? initialWorkItem.archive_path;
-    const studioArchive: StudioArchiveMeta = {
-      archived_at: this.now(),
-      readme_path: archiveResult.readme_path,
-      archived_run_ids: archiveResult.archived_run_ids,
-      skipped_run_ids: archiveResult.skipped_run_ids,
-    };
-    const nextMeta: Record<string, unknown> = {
-      ...initialWorkItem.meta,
-      studio_archive: studioArchive,
-    };
-
-    const updatedWorkItem = alreadyDone
-      ? this.workItemsService.update(workItemId, {
-          archive_path: archivePath,
-          meta: nextMeta,
-        })
-      : this.workItemsService.update(workItemId, {
-          state: "done",
-          archive_path: archivePath,
-          meta: nextMeta,
-        });
-
-    // Step 9: finalizer — splice matching runs out of recentRuns and
-    // stamp `disposed_at` on each `status.json`.
+    // Post-dispatch finalizer.
     const removedRunIds = this.removeRunsForWorkItem(workItemId);
+
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
+    const archiveData = result.handler_data?.archive_result as {
+      archive_path: string;
+      readme_path: string | null;
+      archived_run_ids: string[];
+      skipped_run_ids: Array<{ run_id: string; reason: string }>;
+    } | undefined;
 
     return {
       work_item: {
@@ -2641,11 +2608,11 @@ export class ExecutionService implements OnModuleInit {
       },
       closed_issue: closedIssue,
       removed_run_ids: removedRunIds,
-      archive: {
-        archive_path: archiveResult.archive_path,
-        readme_path: archiveResult.readme_path,
-        archived_run_ids: archiveResult.archived_run_ids,
-        skipped_run_ids: archiveResult.skipped_run_ids,
+      archive: archiveData ?? {
+        archive_path: updatedWorkItem.archive_path ?? "",
+        readme_path: null,
+        archived_run_ids: [],
+        skipped_run_ids: [],
       },
       dispatch_preview: this.getPreview(updatedWorkItem.repo ?? undefined),
     };

--- a/src/modules/graph/__tests__/work-item-hsm.service.test.ts
+++ b/src/modules/graph/__tests__/work-item-hsm.service.test.ts
@@ -80,10 +80,10 @@ describe("WorkItemHsmService", () => {
     expect(() => service.onModuleInit()).toThrow();
   });
 
-  it("dispatches user.start_draft from planned to pre_pr.drafting with one update mutation", () => {
+  it("dispatches user.start_draft from planned to pre_pr.drafting with one update mutation", async () => {
     const harness = createHarness("planned");
 
-    const result = harness.service.dispatch("studio-200", { type: "user.start_draft" });
+    const result = await harness.service.dispatch("studio-200", { type: "user.start_draft" });
 
     expect(result.next_state).toBe("pre_pr.drafting");
     expect(result.mutation_applied).toBe(true);
@@ -93,10 +93,10 @@ describe("WorkItemHsmService", () => {
     });
   });
 
-  it("rejects illegal events without mutation and logs a debug rejection", () => {
+  it("rejects illegal events without mutation and logs a debug rejection", async () => {
     const harness = createHarness("planned");
 
-    const result = harness.service.dispatch("studio-200", { type: "user.finalize" });
+    const result = await harness.service.dispatch("studio-200", { type: "user.finalize" });
 
     expect(result.rejected).toBe(true);
     expect(result.mutation_applied).toBe(false);
@@ -104,10 +104,10 @@ describe("WorkItemHsmService", () => {
     expect(loggerDebugSpy).toHaveBeenCalledWith(expect.stringContaining("rejected by HSM"));
   });
 
-  it("rehydrates from pre_pr.in_progress and opens a PR state with stamped meta", () => {
+  it("rehydrates from pre_pr.in_progress and opens a PR state with stamped meta", async () => {
     const harness = createHarness("pre_pr.in_progress");
 
-    const result = harness.service.dispatch("studio-200", {
+    const result = await harness.service.dispatch("studio-200", {
       type: "run.completed",
       run_id: "run-1",
       pr_exists: true,
@@ -150,22 +150,96 @@ describe("WorkItemHsmService", () => {
     ["closed", { type: "user.archive_and_finalize" }, "archived"],
   ];
 
-  it.each(transitionCases)("transitions %s via %o to %s", (from, event, expected) => {
+  it.each(transitionCases)("transitions %s via %o to %s", async (from, event, expected) => {
     const harness = createHarness(from);
-    const result = harness.service.dispatch("studio-200", event);
+    const result = await harness.service.dispatch("studio-200", event);
     expect(result.next_state).toBe(expected);
   });
 
-  it("restores pre_pr history on user.undefer", () => {
+  it("restores pre_pr history on user.undefer", async () => {
     const harness = createHarness("deferred", {
       studio_hsm: {
         deferred_from_state: "pre_pr.ready",
       },
     });
 
-    const result = harness.service.dispatch("studio-200", { type: "user.undefer" });
+    const result = await harness.service.dispatch("studio-200", { type: "user.undefer" });
 
     expect(result.next_state).toBe("pre_pr.ready");
     expect(harness.getCurrent().meta).toMatchObject({ studio_hsm: {} });
+  });
+
+  describe("action handler registry (studio-196)", () => {
+    it("registered async handler is called during dispatch", async () => {
+      const harness = createHarness("merged_pr");
+      const handler = vi.fn(async () => {});
+      harness.service.registerActionHandler("closeGhIssue", handler);
+
+      await harness.service.dispatch("studio-200", { type: "user.finalize" });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "studio-200" }),
+        { type: "user.finalize" },
+        expect.objectContaining({ meta: expect.any(Object), handler_data: expect.any(Object) }),
+      );
+    });
+
+    it("handler that throws prevents state write", async () => {
+      const harness = createHarness("merged_pr");
+      harness.service.registerActionHandler("closeGhIssue", async () => {
+        throw new Error("gh close failed");
+      });
+
+      await expect(harness.service.dispatch("studio-200", { type: "user.finalize" })).rejects.toThrow(
+        "gh close failed",
+      );
+
+      // State unchanged — graphWriter.apply never called
+      expect(harness.graphWriter.apply).not.toHaveBeenCalled();
+      expect(harness.getCurrent().state).toBe("merged_pr");
+    });
+
+    it("handler_data populated by handler is returned in DispatchResult", async () => {
+      const harness = createHarness("merged_pr");
+      harness.service.registerActionHandler("closeGhIssue", async (_wi, _ev, ctx) => {
+        ctx.handler_data.closed_issue = { repo: "test/repo", number: 42 };
+      });
+
+      const result = await harness.service.dispatch("studio-200", { type: "user.finalize" });
+
+      expect(result.handler_data).toEqual({ closed_issue: { repo: "test/repo", number: 42 } });
+    });
+
+    it("patch_overrides from handler are merged into the mutation", async () => {
+      const harness = createHarness("merged_pr");
+      harness.service.registerActionHandler("runArchiver", async (_wi, _ev, ctx) => {
+        ctx.patch_overrides.archive_path = "/archives/studio-200";
+      });
+
+      // Use archive_and_finalize which triggers runArchiver (and closeGhIssue on merged_pr)
+      harness.service.registerActionHandler("closeGhIssue", async () => {});
+      await harness.service.dispatch("studio-200", { type: "user.archive_and_finalize" });
+
+      const appliedCall = (harness.graphWriter.apply as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(appliedCall.mutations[0].patch).toMatchObject({
+        state: "archived",
+        archive_path: "/archives/studio-200",
+      });
+    });
+
+    it("throws when registering a duplicate handler name", () => {
+      const harness = createHarness("planned");
+      harness.service.registerActionHandler("closeGhIssue", async () => {});
+      expect(() => harness.service.registerActionHandler("closeGhIssue", async () => {})).toThrow(
+        /already registered/,
+      );
+    });
+
+    it("handler_data is undefined when no handler populates it", async () => {
+      const harness = createHarness("planned");
+      const result = await harness.service.dispatch("studio-200", { type: "user.start_draft" });
+      expect(result.handler_data).toBeUndefined();
+    });
   });
 });

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -227,6 +227,43 @@ export interface DispatchResult {
   applied_actions: string[];
   mutation_applied: boolean;
   rejected: boolean;
+  handler_data?: Record<string, unknown>;
+}
+
+/**
+ * studio-196: context bag passed to each async action handler during dispatch.
+ *
+ * - `meta`           — mutable clone of the work item's meta; changes are
+ *                      persisted in the same mutation batch as the state
+ *                      transition.
+ * - `handler_data`   — transient key-value bag returned in `DispatchResult`
+ *                      but NOT persisted. Handlers use it to surface data
+ *                      (e.g. closed-issue details) to the caller.
+ * - `patch_overrides` — additional top-level work item fields (e.g.
+ *                      `archive_path`) that are merged into the mutation
+ *                      patch alongside the state transition.
+ */
+export interface HsmActionHandlerContext {
+  meta: Record<string, unknown>;
+  handler_data: Record<string, unknown>;
+  patch_overrides: Partial<UpdateWorkItemDto>;
+}
+
+/**
+ * studio-196: async side-effect handler for an HSM action.
+ *
+ * Registered by external modules (execution) via
+ * `WorkItemHsmService.registerActionHandler()`. The handler receives the
+ * work item snapshot at dispatch time and the event that triggered the
+ * transition. It runs BEFORE the state write — if it throws, the
+ * transition aborts and state is unchanged.
+ */
+export interface HsmActionHandler {
+  (
+    workItem: WorkItemRecord,
+    event: WorkItemHsmEvent,
+    context: HsmActionHandlerContext,
+  ): Promise<void>;
 }
 
 export type ApplyGraphMutationsResult =

--- a/src/modules/graph/work-item-hsm.service.ts
+++ b/src/modules/graph/work-item-hsm.service.ts
@@ -8,6 +8,7 @@ import { GraphWriterService } from "./graph-writer.service.js";
 import type { ApplyGraphMutationsResult } from "./types.js";
 import type {
   DispatchResult,
+  HsmActionHandler,
   HsmLeafState,
   PersistedDeferredState,
   PersistedPrePrState,
@@ -58,6 +59,8 @@ interface ParsedChart {
 interface RuntimeContext {
   actions: string[];
   meta: Record<string, unknown>;
+  handler_data: Record<string, unknown>;
+  patch_overrides: Partial<UpdateWorkItemDto>;
   event: WorkItemHsmEvent;
   prevState: WorkItemState;
 }
@@ -69,6 +72,7 @@ export class WorkItemHsmService implements OnModuleInit {
   private chart!: ParsedChart;
   private stateById = new Map<string, ParsedState>();
   private parentById = new Map<string, string | null>();
+  private readonly actionHandlers = new Map<string, HsmActionHandler>();
 
   constructor(
     @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
@@ -84,6 +88,8 @@ export class WorkItemHsmService implements OnModuleInit {
     const machine = new Statechart(this.toScionModel(chart, {
       actions: [],
       meta: {},
+      handler_data: {},
+      patch_overrides: {},
       event: { type: "user.start_draft" },
       prevState: "planned",
     }));
@@ -92,7 +98,14 @@ export class WorkItemHsmService implements OnModuleInit {
     this.chart = chart;
   }
 
-  dispatch(workItemId: string, event: WorkItemHsmEvent): DispatchResult {
+  registerActionHandler(actionName: string, handler: HsmActionHandler): void {
+    if (this.actionHandlers.has(actionName)) {
+      throw new Error(`HSM action handler already registered: ${actionName}`);
+    }
+    this.actionHandlers.set(actionName, handler);
+  }
+
+  async dispatch(workItemId: string, event: WorkItemHsmEvent): Promise<DispatchResult> {
     this.ensureInitialized();
 
     const workItem = this.workItems.get(workItemId);
@@ -123,9 +136,22 @@ export class WorkItemHsmService implements OnModuleInit {
       this.applyAction(action, runtime);
     }
 
+    // Execute registered async side-effect handlers BEFORE the state write.
+    // If any handler throws, abort — state unchanged.
+    for (const action of runtime.actions) {
+      const handler = this.actionHandlers.get(action);
+      if (handler) {
+        await handler(workItem, event, {
+          meta: runtime.meta,
+          handler_data: runtime.handler_data,
+          patch_overrides: runtime.patch_overrides,
+        });
+      }
+    }
+
     this.clearDeferredHistoryIfNeeded(runtime.meta, prevState, nextState);
 
-    const patch: UpdateWorkItemDto = { state: nextState };
+    const patch: UpdateWorkItemDto = { state: nextState, ...runtime.patch_overrides };
     if (JSON.stringify(runtime.meta) !== JSON.stringify(workItem.meta)) {
       patch.meta = runtime.meta;
     }
@@ -144,6 +170,7 @@ export class WorkItemHsmService implements OnModuleInit {
       applied_actions: runtime.actions,
       mutation_applied: true,
       rejected: false,
+      handler_data: Object.keys(runtime.handler_data).length > 0 ? runtime.handler_data : undefined,
     };
   }
 
@@ -179,6 +206,8 @@ export class WorkItemHsmService implements OnModuleInit {
     return {
       actions: [],
       meta: this.cloneMeta(workItem.meta),
+      handler_data: {},
+      patch_overrides: {},
       event,
       prevState,
     };

--- a/src/modules/graph/work-item.scxml
+++ b/src/modules/graph/work-item.scxml
@@ -79,7 +79,7 @@
   <!-- `merged_pr`: merged successfully; finalize or archive next. -->
   <state id="merged_pr" onentry="stampMeta:studio_post_merge_sync">
     <transition event="user.finalize" target="done" action="closeGhIssue" />
-    <transition event="user.archive_and_finalize" target="archived" action="runArchiver" />
+    <transition event="user.archive_and_finalize" target="archived" action="closeGhIssue,runArchiver" />
   </state>
 
   <!-- `closed`: issue/PR closed without the normal merged disposition. -->


### PR DESCRIPTION
## Summary
- Rewire `closeMergedPullRequest` and `archiveAndCloseMergedPullRequest` from imperative state-guarded orchestrators into thin HSM event dispatchers
- Both methods now call `hsmService.dispatch` with `user.finalize` or `user.archive_and_finalize`; the HSM chart accepts these events from both `merged_pr` and `closed` states
- `WorkItemHsmService.dispatch()` is now async with an action handler registry for side-effect handlers (`closeGhIssue`, `runArchiver`)
- SCXML chart updated: `merged_pr`'s `user.archive_and_finalize` now carries `action="closeGhIssue,runArchiver"`

## Changes
- **`src/modules/graph/types.ts`** — Added `HsmActionHandler`, `HsmActionHandlerContext`, `handler_data` on `DispatchResult`
- **`src/modules/graph/work-item-hsm.service.ts`** — Async dispatch, action handler registry, `patch_overrides` + `handler_data` runtime support
- **`src/modules/graph/work-item.scxml`** — Added `closeGhIssue` to `merged_pr`'s archive transition
- **`src/modules/execution/execution.service.ts`** — Inject `WorkItemHsmService`, register `closeGhIssue` + `runArchiver` handlers, collapse disposition methods to thin dispatchers
- **`src/modules/execution/__tests__/disposition.test.ts`** — Rewrote for dispatch-based flow, added `closed` source state test cases
- **`src/modules/graph/__tests__/work-item-hsm.service.test.ts`** — Async dispatch, 6 new handler registry tests
- **`src/modules/execution/__tests__/execution-rehydrate.test.ts`** — Mock for `registerActionHandler`

## Test plan
- [x] 482 tests pass, 0 failures
- [x] tsc clean
- [ ] Manual: finalize a `merged_pr` work item via the UI — verify GH issue is closed and state becomes `done`
- [ ] Manual: archive-and-finalize a `merged_pr` work item — verify GH issue closed, archive bundle written, state becomes `archived`
- [ ] Manual: finalize a `closed` work item — verify no `gh issue close` call, state becomes `done`
- [ ] Manual: archive-and-finalize a `closed` work item — verify archive bundle written without GH issue close

Closes #196