### PR TITLE
Studio: migrate direct work-item state writers to HSM dispatch (#201)

### DIFF
--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -185,7 +185,12 @@ function makeService(params: {
   service.hsmService = {
     dispatch: params.hsmDispatch ?? vi.fn(async (_id: string, event: { type: string }) => {
       const prevState = currentWorkItem.state;
-      const nextState = event.type === "user.archive_and_finalize" ? "archived" : "done";
+      const eventStateMap: Record<string, string> = {
+        "user.archive_and_finalize": "archived",
+        "user.cancel": "cancelled",
+        "user.finalize": "done",
+      };
+      const nextState = eventStateMap[event.type] ?? "done";
       currentWorkItem = { ...currentWorkItem, state: nextState as WorkItemState, updated_at: "2026-04-09T00:00:01.000Z" };
       return makeDispatchResult({
         prev_state: prevState,
@@ -630,7 +635,7 @@ describe("ADR 014 step 7: disposition flow", () => {
   });
 
   describe("cancelWorkItem", () => {
-    it("moves the plan dir and transitions to cancelled", () => {
+    it("moves the plan dir and transitions to cancelled", async () => {
       ensurePlanDir(tmpRoot, "studio-157");
       writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
 
@@ -639,7 +644,7 @@ describe("ADR 014 step 7: disposition flow", () => {
         // Valid source state for cancellation (per VALID_HUMAN_TRANSITIONS)
         workItem: makeWorkItem({ state: "drafting" }),
       });
-      const result = service.cancelWorkItem("studio-157");
+      const result = await service.cancelWorkItem("studio-157");
 
       expect(result.state).toBe("cancelled");
       expect(result.archive_path).toBe(archiveDir(tmpRoot, "studio-157"));
@@ -647,18 +652,18 @@ describe("ADR 014 step 7: disposition flow", () => {
       expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(true);
     });
 
-    it("handles the no-plan-dir case by still transitioning", () => {
+    it("handles the no-plan-dir case by still transitioning", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         workItem: makeWorkItem({ state: "planned" }),
       });
-      const result = service.cancelWorkItem("studio-157");
+      const result = await service.cancelWorkItem("studio-157");
 
       expect(result.state).toBe("cancelled");
       expect(result.archive_path).toBe(null);
     });
 
-    it("active-run guard rejects before the filesystem is touched", () => {
+    it("active-run guard rejects before the filesystem is touched", async () => {
       ensurePlanDir(tmpRoot, "studio-157");
       writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
 
@@ -667,7 +672,7 @@ describe("ADR 014 step 7: disposition flow", () => {
         workItem: makeWorkItem({ state: "in_progress" }),
         runs: [makeRun({ status: "running" })],
       });
-      expect(() => service.cancelWorkItem("studio-157")).toThrow(/cannot_dispose_work_item_active_run/);
+      await expect(service.cancelWorkItem("studio-157")).rejects.toThrow(/cannot_dispose_work_item_active_run/);
       expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(true);
     });
   });

--- a/src/modules/execution/__tests__/launch-eligibility.test.ts
+++ b/src/modules/execution/__tests__/launch-eligibility.test.ts
@@ -144,6 +144,19 @@ function makeLaunchHarness(workItem: WorkItemRecord, options: { canLaunch?: bool
 
   (service as any).worktreeRoot = "/tmp/studio-worktrees";
 
+  (service as any).hsmService = {
+    async dispatch(id: string, event: { type: string }) {
+      if (event.type === "user.dispatch") {
+        currentWorkItem = {
+          ...currentWorkItem,
+          state: "in_progress",
+          updated_at: "2026-04-09T00:00:01.000Z",
+        };
+      }
+      return { mutation_applied: true };
+    },
+  };
+
   // ADR 014 step 5: launch() now calls appendRunIdToPlanMetadata after
   // persisting the run. Stub it to a no-op so these tests don't need to
   // wire up plan metadata on the filesystem.
@@ -269,10 +282,10 @@ describe("launch eligibility", () => {
     const result = await harness.service.launch({ work_item_id: workItem.id, prompt: "Launch" });
 
     expect(result.accepted).toBe(true);
-    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "in_progress" } }]);
+    // State transition now via HSM dispatch, not direct update
+    expect(harness.updateCalls).toEqual([]);
     expect(harness.getCurrentWorkItem().state).toBe("in_progress");
     expect(harness.executionOrder).toEqual([
-      `update:${workItem.id}:in_progress`,
       "activity:Execution run queued. Work item state updated to in_progress.",
       "executeRun",
     ]);
@@ -285,10 +298,10 @@ describe("launch eligibility", () => {
     const result = await harness.service.launch({ work_item_id: workItem.id, prompt: "Launch" });
 
     expect(result.accepted).toBe(true);
-    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "in_progress" } }]);
+    // State transition now via HSM dispatch, not direct update
+    expect(harness.updateCalls).toEqual([]);
     expect(harness.getCurrentWorkItem().state).toBe("in_progress");
     expect(harness.executionOrder).toEqual([
-      `update:${workItem.id}:in_progress`,
       "activity:Execution run queued. Work item state updated to in_progress.",
       "executeRun",
     ]);
@@ -394,8 +407,14 @@ describe("launch eligibility", () => {
 describe("ExecutionService.transitionInProgressToReady", () => {
   function makeTransitionHarness(workItem: WorkItemRecord) {
     const service = Object.create(ExecutionService.prototype) as ExecutionService;
-    const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+    const dispatchCalls: Array<{ id: string; event: { type: string } }> = [];
     let currentWorkItem = workItem;
+
+    // Map HSM event types to resulting states for mock.
+    const eventToState: Record<string, WorkItemState> = {
+      "user.investigate": "ready",
+      "user.start_draft": "drafting",
+    };
 
     (service as any).workItemsService = {
       get: (id: string) => {
@@ -404,57 +423,68 @@ describe("ExecutionService.transitionInProgressToReady", () => {
         }
         return currentWorkItem;
       },
-      update: (id: string, patch: Partial<WorkItemRecord>) => {
-        updateCalls.push({ id, patch });
-        currentWorkItem = {
-          ...currentWorkItem,
-          ...patch,
-          updated_at: "2026-04-09T00:00:01.000Z",
-        };
-        return currentWorkItem;
+    };
+
+    (service as any).hsmService = {
+      async dispatch(id: string, event: { type: string }) {
+        dispatchCalls.push({ id, event });
+        const nextState = eventToState[event.type];
+        if (nextState) {
+          currentWorkItem = {
+            ...currentWorkItem,
+            state: nextState,
+            updated_at: "2026-04-09T00:00:01.000Z",
+          };
+        }
+        return { mutation_applied: true };
       },
     };
 
-    return { service, updateCalls, getCurrentWorkItem: () => currentWorkItem };
+    return { service, dispatchCalls, getCurrentWorkItem: () => currentWorkItem };
   }
 
-  it("transitions a work item from in_progress to ready", () => {
+  it("transitions a work item from in_progress to ready", async () => {
     const workItem = makeWorkItem({ state: "in_progress" });
     const harness = makeTransitionHarness(workItem);
 
-    const result = harness.service.transitionInProgressToReady(workItem.id);
+    const result = await harness.service.transitionInProgressToReady(workItem.id);
 
     expect(result.state).toBe("ready");
-    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "ready" } }]);
+    expect(harness.dispatchCalls).toEqual([{ id: workItem.id, event: { type: "user.investigate" } }]);
     expect(harness.getCurrentWorkItem().state).toBe("ready");
   });
 
-  it("throws when the current state is not in_progress", () => {
+  it("throws when the current state is not in_progress", async () => {
     const workItem = makeWorkItem({ state: "planned" });
     const harness = makeTransitionHarness(workItem);
 
-    expect(() => harness.service.transitionInProgressToReady(workItem.id)).toThrow(
+    await expect(harness.service.transitionInProgressToReady(workItem.id)).rejects.toThrow(
       /Cannot transition .* from planned to ready/,
     );
-    expect(harness.updateCalls).toEqual([]);
+    expect(harness.dispatchCalls).toEqual([]);
   });
 
-  it("throws when the current state is ready (no-op rejection)", () => {
+  it("throws when the current state is ready (no-op rejection)", async () => {
     const workItem = makeWorkItem({ state: "ready" });
     const harness = makeTransitionHarness(workItem);
 
-    expect(() => harness.service.transitionInProgressToReady(workItem.id)).toThrow(
+    await expect(harness.service.transitionInProgressToReady(workItem.id)).rejects.toThrow(
       /Cannot transition .* from ready to ready/,
     );
-    expect(harness.updateCalls).toEqual([]);
+    expect(harness.dispatchCalls).toEqual([]);
   });
 });
 
 describe("ExecutionService.transitionInProgressToDrafting (ADR 014 step 5)", () => {
   function makeTransitionHarness(workItem: WorkItemRecord) {
     const service = Object.create(ExecutionService.prototype) as ExecutionService;
-    const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+    const dispatchCalls: Array<{ id: string; event: { type: string } }> = [];
     let currentWorkItem = workItem;
+
+    const eventToState: Record<string, WorkItemState> = {
+      "user.investigate": "ready",
+      "user.start_draft": "drafting",
+    };
 
     (service as any).workItemsService = {
       get: (id: string) => {
@@ -463,58 +493,64 @@ describe("ExecutionService.transitionInProgressToDrafting (ADR 014 step 5)", () 
         }
         return currentWorkItem;
       },
-      update: (id: string, patch: Partial<WorkItemRecord>) => {
-        updateCalls.push({ id, patch });
-        currentWorkItem = {
-          ...currentWorkItem,
-          ...patch,
-          updated_at: "2026-04-09T00:00:01.000Z",
-        };
-        return currentWorkItem;
+    };
+
+    (service as any).hsmService = {
+      async dispatch(id: string, event: { type: string }) {
+        dispatchCalls.push({ id, event });
+        const nextState = eventToState[event.type];
+        if (nextState) {
+          currentWorkItem = {
+            ...currentWorkItem,
+            state: nextState,
+            updated_at: "2026-04-09T00:00:01.000Z",
+          };
+        }
+        return { mutation_applied: true };
       },
     };
 
-    return { service, updateCalls, getCurrentWorkItem: () => currentWorkItem };
+    return { service, dispatchCalls, getCurrentWorkItem: () => currentWorkItem };
   }
 
-  it("transitions a work item from in_progress to drafting", () => {
+  it("transitions a work item from in_progress to drafting", async () => {
     const workItem = makeWorkItem({ state: "in_progress" });
     const harness = makeTransitionHarness(workItem);
 
-    const result = harness.service.transitionInProgressToDrafting(workItem.id);
+    const result = await harness.service.transitionInProgressToDrafting(workItem.id);
 
     expect(result.state).toBe("drafting");
-    expect(harness.updateCalls).toEqual([{ id: workItem.id, patch: { state: "drafting" } }]);
+    expect(harness.dispatchCalls).toEqual([{ id: workItem.id, event: { type: "user.start_draft" } }]);
     expect(harness.getCurrentWorkItem().state).toBe("drafting");
   });
 
-  it("throws when the current state is not in_progress (planned)", () => {
+  it("throws when the current state is not in_progress (planned)", async () => {
     const workItem = makeWorkItem({ state: "planned" });
     const harness = makeTransitionHarness(workItem);
 
-    expect(() => harness.service.transitionInProgressToDrafting(workItem.id)).toThrow(
+    await expect(harness.service.transitionInProgressToDrafting(workItem.id)).rejects.toThrow(
       /Cannot transition .* from planned to drafting/,
     );
-    expect(harness.updateCalls).toEqual([]);
+    expect(harness.dispatchCalls).toEqual([]);
   });
 
-  it("throws when the current state is ready", () => {
+  it("throws when the current state is ready", async () => {
     const workItem = makeWorkItem({ state: "ready" });
     const harness = makeTransitionHarness(workItem);
 
-    expect(() => harness.service.transitionInProgressToDrafting(workItem.id)).toThrow(
+    await expect(harness.service.transitionInProgressToDrafting(workItem.id)).rejects.toThrow(
       /Cannot transition .* from ready to drafting/,
     );
-    expect(harness.updateCalls).toEqual([]);
+    expect(harness.dispatchCalls).toEqual([]);
   });
 
-  it("throws when the current state is drafting (no-op rejection)", () => {
+  it("throws when the current state is drafting (no-op rejection)", async () => {
     const workItem = makeWorkItem({ state: "drafting" });
     const harness = makeTransitionHarness(workItem);
 
-    expect(() => harness.service.transitionInProgressToDrafting(workItem.id)).toThrow(
+    await expect(harness.service.transitionInProgressToDrafting(workItem.id)).rejects.toThrow(
       /Cannot transition .* from drafting to drafting/,
     );
-    expect(harness.updateCalls).toEqual([]);
+    expect(harness.dispatchCalls).toEqual([]);
   });
 });

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -83,13 +83,13 @@ export class ExecutionController {
   }
 
   @Post("transition-ready")
-  transitionInProgressToReady(@Body() body: TransitionWorkItemDto) {
-    return this.executionService.transitionInProgressToReady(body.work_item_id);
+  async transitionInProgressToReady(@Body() body: TransitionWorkItemDto) {
+    return await this.executionService.transitionInProgressToReady(body.work_item_id);
   }
 
   @Post("transition-drafting")
-  transitionInProgressToDrafting(@Body() body: TransitionWorkItemDto) {
-    return this.executionService.transitionInProgressToDrafting(body.work_item_id);
+  async transitionInProgressToDrafting(@Body() body: TransitionWorkItemDto) {
+    return await this.executionService.transitionInProgressToDrafting(body.work_item_id);
   }
 
   @Post("close-merged")

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -419,7 +419,7 @@ export class ExecutionService implements OnModuleInit {
       return { accepted: false, run };
     }
 
-    const launchState = this.markWorkItemInProgressOnLaunch(workItem);
+    const launchState = await this.markWorkItemInProgressOnLaunch(workItem);
     const run = this.createRunRecord({
       workItem: launchState.workItem,
       branch: node.branch,
@@ -546,23 +546,29 @@ export class ExecutionService implements OnModuleInit {
     this.appendEvent(nextRun, { type: "pull_request_created", pull_request: pullRequest });
     this.writeSummary(nextRun);
 
-    // Update work item: set state to open_pr and store PR metadata
+    // Update work item: dispatch HSM event for state transition, then
+    // write non-state fields (branch, meta.pull_request) separately.
     try {
-      const existingMeta = workItem.meta ?? {};
+      const prPayload = {
+        number: pullRequest.number,
+        url: pullRequest.url,
+        title: pullRequest.title,
+        is_draft: pullRequest.is_draft,
+        head_ref: pullRequest.head_ref,
+        base_ref: pullRequest.base_ref,
+        created_at: pullRequest.created_at,
+      };
+      await this.hsmService.dispatch(run.work_item_id, {
+        type: "gh.pr_opened",
+        pull_request: prPayload,
+      });
+      // Write additional fields that the HSM doesn't manage.
+      const existingMeta = this.workItemsService.get(run.work_item_id).meta ?? {};
       this.workItemsService.update(run.work_item_id, {
-        state: "open_pr",
         branch: run.branch,
         meta: {
           ...existingMeta,
-          pull_request: {
-            number: pullRequest.number,
-            url: pullRequest.url,
-            title: pullRequest.title,
-            is_draft: pullRequest.is_draft,
-            head_ref: pullRequest.head_ref,
-            base_ref: pullRequest.base_ref,
-            created_at: pullRequest.created_at,
-          },
+          pull_request: prPayload,
         },
       });
     } catch (updateError) {
@@ -600,8 +606,19 @@ export class ExecutionService implements OnModuleInit {
     // ADR 014 step 3: post-merge sync lands on 'merged_pr', not 'done'.
     // 'merged_pr' is a stable resting state that the disposition flow
     // (ADR 014 step 7) will transition to 'done' after archival completes.
+    // HSM handles the state transition; non-state fields follow separately.
+    await this.hsmService.dispatch(workItem.id, {
+      type: "gh.pr_merged",
+      pull_request: {
+        number: pullRequest.number,
+        url: pullRequest.url,
+        title: pullRequest.title,
+        head_ref: pullRequest.head_ref,
+        base_ref: pullRequest.base_ref,
+        merged_at: pullRequest.merged_at,
+      },
+    });
     this.workItemsService.update(workItem.id, {
-      state: "merged_pr",
       actual_files: actualFilesSelection.files,
       branch: nextBranch,
       archive_path: nextArchivePath,
@@ -2289,7 +2306,7 @@ export class ExecutionService implements OnModuleInit {
     }
   }
 
-  private markWorkItemInProgressOnLaunch(workItem: WorkItemRecord): { workItem: WorkItemRecord; transitioned: boolean } {
+  private async markWorkItemInProgressOnLaunch(workItem: WorkItemRecord): Promise<{ workItem: WorkItemRecord; transitioned: boolean }> {
     // ADR 014 step 5: only launchable states transition to in_progress. The
     // eligibility safety check `launchable_state` already rejects anything
     // else before this method is reached; this guard is defensive.
@@ -2302,8 +2319,9 @@ export class ExecutionService implements OnModuleInit {
       return { workItem, transitioned: false };
     }
 
+    await this.hsmService.dispatch(workItem.id, { type: "user.dispatch" });
     return {
-      workItem: this.workItemsService.update(workItem.id, { state: "in_progress" }),
+      workItem: this.workItemsService.get(workItem.id),
       transitioned: true,
     };
   }
@@ -2321,14 +2339,15 @@ export class ExecutionService implements OnModuleInit {
    * is rich enough to distinguish "plan valid" from "plan needs rework"
    * (the latter going to `drafting`).
    */
-  transitionInProgressToReady(workItemId: string): WorkItemRecord {
+  async transitionInProgressToReady(workItemId: string): Promise<WorkItemRecord> {
     const workItem = this.workItemsService.get(workItemId);
     if (workItem.state !== "in_progress") {
       throw new BadRequestException(
         `Cannot transition ${workItemId} from ${workItem.state} to ready (requires in_progress)`,
       );
     }
-    return this.workItemsService.update(workItemId, { state: "ready" });
+    await this.hsmService.dispatch(workItemId, { type: "user.investigate" });
+    return this.workItemsService.get(workItemId);
   }
 
   /**
@@ -2339,14 +2358,15 @@ export class ExecutionService implements OnModuleInit {
    * operator-triggered in step 5 — automatic failure classification is
    * deferred to step 7 (run disposition).
    */
-  transitionInProgressToDrafting(workItemId: string): WorkItemRecord {
+  async transitionInProgressToDrafting(workItemId: string): Promise<WorkItemRecord> {
     const workItem = this.workItemsService.get(workItemId);
     if (workItem.state !== "in_progress") {
       throw new BadRequestException(
         `Cannot transition ${workItemId} from ${workItem.state} to drafting (requires in_progress)`,
       );
     }
-    return this.workItemsService.update(workItemId, { state: "drafting" });
+    await this.hsmService.dispatch(workItemId, { type: "user.start_draft" });
+    return this.workItemsService.get(workItemId);
   }
 
   /**
@@ -2666,13 +2686,16 @@ export class ExecutionService implements OnModuleInit {
    * `planned`, `drafting`, `ready`, `in_progress`, `open_pr` (the `cancelled`
    * row in `VALID_HUMAN_TRANSITIONS`).
    */
-  cancelWorkItem(workItemId: string): WorkItemRecord {
+  async cancelWorkItem(workItemId: string): Promise<WorkItemRecord> {
     this.assertNoActiveRunForWorkItem(workItemId);
     const moveResult = this.movePlanDirToArchives(workItemId);
-    return this.workItemsService.update(workItemId, {
-      state: "cancelled",
-      archive_path: moveResult.archive_path ?? this.workItemsService.get(workItemId).archive_path,
-    });
+    await this.hsmService.dispatch(workItemId, { type: "user.cancel" });
+    // Write archive_path separately — the HSM doesn't manage this field.
+    const nextArchivePath = moveResult.archive_path ?? this.workItemsService.get(workItemId).archive_path;
+    if (nextArchivePath) {
+      this.workItemsService.update(workItemId, { archive_path: nextArchivePath });
+    }
+    return this.workItemsService.get(workItemId);
   }
 
   /**

--- a/src/modules/graph/__tests__/work-item-transitions.test.ts
+++ b/src/modules/graph/__tests__/work-item-transitions.test.ts
@@ -50,14 +50,14 @@ function makeController(initialState: WorkItemState = "planned") {
   } as unknown as WorkItemsService;
 
   const executionService = {
-    transitionInProgressToReady: vi.fn((id: string) => {
+    transitionInProgressToReady: vi.fn(async (id: string) => {
       if (current.state !== "in_progress") {
         throw new BadRequestException(`Cannot transition ${id} from ${current.state} to ready`);
       }
       current = { ...current, state: "ready" };
       return current;
     }),
-    cancelWorkItem: vi.fn((_id: string) => {
+    cancelWorkItem: vi.fn(async (_id: string) => {
       current = { ...current, state: "cancelled" };
       return current;
     }),
@@ -94,19 +94,19 @@ describe("WorkItemsController.transition", () => {
     ];
 
     for (const [from, to] of allowed) {
-      it(`permits ${from} → ${to}`, () => {
+      it(`permits ${from} → ${to}`, async () => {
         const harness = makeController(from);
-        const result = harness.controller.transition("studio-153", { to });
+        const result = await harness.controller.transition("studio-153", { to });
         expect(result.state).toBe(to);
       });
     }
   });
 
   describe("in_progress → ready delegation", () => {
-    it("delegates in_progress → ready to ExecutionService.transitionInProgressToReady", () => {
+    it("delegates in_progress → ready to ExecutionService.transitionInProgressToReady", async () => {
       const harness = makeController("in_progress");
 
-      const result = harness.controller.transition("studio-153", { to: "ready" });
+      const result = await harness.controller.transition("studio-153", { to: "ready" });
 
       expect(harness.executionService.transitionInProgressToReady).toHaveBeenCalledWith("studio-153");
       expect(harness.workItemsService.update).not.toHaveBeenCalled();
@@ -120,10 +120,10 @@ describe("WorkItemsController.transition", () => {
     // state update.
     const sources: WorkItemState[] = ["planned", "drafting", "ready", "in_progress", "open_pr"];
     for (const from of sources) {
-      it(`delegates ${from} → cancelled to ExecutionService.cancelWorkItem`, () => {
+      it(`delegates ${from} → cancelled to ExecutionService.cancelWorkItem`, async () => {
         const harness = makeController(from);
 
-        const result = harness.controller.transition("studio-153", { to: "cancelled" });
+        const result = await harness.controller.transition("studio-153", { to: "cancelled" });
 
         expect(harness.executionService.cancelWorkItem).toHaveBeenCalledWith("studio-153");
         expect(harness.workItemsService.update).not.toHaveBeenCalled();
@@ -146,9 +146,9 @@ describe("WorkItemsController.transition", () => {
     ];
 
     for (const [from, to] of disallowed) {
-      it(`rejects ${from} → ${to}`, () => {
+      it(`rejects ${from} → ${to}`, async () => {
         const harness = makeController(from);
-        expect(() => harness.controller.transition("studio-153", { to })).toThrow(
+        await expect(harness.controller.transition("studio-153", { to })).rejects.toThrow(
           BadRequestException,
         );
       });
@@ -156,9 +156,9 @@ describe("WorkItemsController.transition", () => {
   });
 
   describe("input validation", () => {
-    it("rejects a missing `to` field", () => {
+    it("rejects a missing `to` field", async () => {
       const harness = makeController("planned");
-      expect(() => harness.controller.transition("studio-153", {} as { to: WorkItemState })).toThrow(
+      await expect(harness.controller.transition("studio-153", {} as { to: WorkItemState })).rejects.toThrow(
         /to.*required/,
       );
     });

--- a/src/modules/graph/work-item.scxml
+++ b/src/modules/graph/work-item.scxml
@@ -36,6 +36,7 @@
     <!-- `planned`: issue exists, but drafting has not started yet. -->
     <state id="planned">
       <transition event="user.start_draft" target="drafting" />
+      <transition event="user.dispatch" target="in_progress" action="createRunRecord" />
     </state>
 
     <!-- `drafting`: the scratchpad/plan is being authored or revised. -->
@@ -55,6 +56,8 @@
       <transition event="run.completed" cond="pr_exists" target="open_pr" />
       <transition event="run.completed" cond="!pr_exists" target="merged_pr" />
       <transition event="run.error" target="run_errored" />
+      <transition event="user.investigate" target="ready" />
+      <transition event="user.start_draft" target="drafting" />
     </state>
 
     <!-- `run_errored`: the latest run failed and needs human intervention. -->

--- a/src/modules/graph/work-items.controller.ts
+++ b/src/modules/graph/work-items.controller.ts
@@ -58,7 +58,7 @@ export class WorkItemsController {
   }
 
   @Post(":id/transition")
-  transition(@Param("id") id: string, @Body() body: TransitionDto) {
+  async transition(@Param("id") id: string, @Body() body: TransitionDto) {
     const target = body?.to;
     if (!target) {
       throw new BadRequestException("transition target `to` is required");

--- a/src/modules/graph/work-items.service.ts
+++ b/src/modules/graph/work-items.service.ts
@@ -1,9 +1,9 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { parseJsonArray } from "../../lib/manifest-core.js";
 import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
-import { deriveIssueWorkItemId, type CreateWorkItemDto, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord } from "./types.js";
+import { deriveIssueWorkItemId, type CreateWorkItemDto, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord, type WorkItemState } from "./types.js";
 
 interface RawWorkItemRecord {
   id: string;
@@ -24,6 +24,8 @@ interface RawWorkItemRecord {
 
 @Injectable()
 export class WorkItemsService {
+  private readonly logger = new Logger(WorkItemsService.name);
+
   constructor(
     @Inject(SQLiteService) private readonly sqlite: SQLiteService,
     @Inject(GraphWriterService) private readonly graphWriter: GraphWriterService,
@@ -139,6 +141,18 @@ export class WorkItemsService {
       }
     }
     return misaligned;
+  }
+
+  /**
+   * Logged escape hatch for setting work item state directly, bypassing
+   * the HSM. Intended for migration tooling and exceptional recovery
+   * scenarios. All calls are logged with the provided reason.
+   *
+   * Production code should use `WorkItemHsmService.dispatch()` instead.
+   */
+  unsafeSetState(id: string, state: WorkItemState, reason: string): WorkItemRecord {
+    this.logger.warn(`unsafeSetState: ${id} → ${state} (reason: ${reason})`);
+    return this.update(id, { state });
   }
 
   delete(id: string): { deleted: true; id: string } {

--- a/src/modules/plans/__tests__/plans.service.test.ts
+++ b/src/modules/plans/__tests__/plans.service.test.ts
@@ -40,10 +40,15 @@ interface HarnessDrafterService {
   draft(workItem: WorkItemRecord, issueBody: string | null): Promise<PlanDraftEnvelope>;
 }
 
+interface HarnessHsmService {
+  dispatch(workItemId: string, event: { type: string }): Promise<{ mutation_applied: boolean }>;
+}
+
 interface Harness {
   service: PlansService;
   workItems: Map<string, WorkItemRecord>;
   updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }>;
+  dispatchCalls: Array<{ workItemId: string; event: { type: string } }>;
   templates: StudioIssueTemplate[];
   artifactRoot: string;
   drafter: HarnessDrafterService;
@@ -111,9 +116,16 @@ function makeHarness(
 ): Harness {
   const workItems = new Map<string, WorkItemRecord>([[initial.id, initial]]);
   const updateCalls: Array<{ id: string; patch: Partial<WorkItemRecord> }> = [];
+  const dispatchCalls: Array<{ workItemId: string; event: { type: string } }> = [];
   const drafterCalls: Array<{ workItem: WorkItemRecord; issueBody: string | null }> = [];
   const templates: StudioIssueTemplate[] = [makeTemplate("feature", "Feature Request")];
   const artifactRoot = mkdtempSync(join(tmpdir(), "studio-154-"));
+
+  // Map HSM event types to the resulting state for the mock.
+  const eventToState: Record<string, WorkItemState> = {
+    "user.start_draft": "drafting",
+    "draft.completed": "ready",
+  };
 
   const workItemsService: HarnessWorkItemsService = {
     get(id: string): WorkItemRecord {
@@ -134,6 +146,25 @@ function makeHarness(
       return next;
     },
   };
+
+  const hsmService: HarnessHsmService = {
+    async dispatch(workItemId: string, event: { type: string }) {
+      dispatchCalls.push({ workItemId, event });
+      const current = workItems.get(workItemId);
+      if (!current) throw new NotFoundException(`Work item not found: ${workItemId}`);
+      const nextState = eventToState[event.type];
+      if (nextState) {
+        const next: WorkItemRecord = {
+          ...current,
+          state: nextState,
+          updated_at: new Date("2026-04-09T00:00:05.000Z").toISOString(),
+        };
+        workItems.set(workItemId, next);
+      }
+      return { mutation_applied: true };
+    },
+  };
+
   const templateService: HarnessTemplateService = {
     listTemplates: () => templates,
   };
@@ -148,12 +179,13 @@ function makeHarness(
 
   const service = Object.create(PlansService.prototype) as PlansService;
   (service as unknown as { workItemsService: HarnessWorkItemsService }).workItemsService = workItemsService;
+  (service as unknown as { hsmService: HarnessHsmService }).hsmService = hsmService;
   (service as unknown as { templateService: HarnessTemplateService }).templateService = templateService;
   (service as unknown as { drafter: HarnessDrafterService }).drafter = drafter;
   (service as unknown as { artifactRoot: string }).artifactRoot = artifactRoot;
   (service as unknown as { logger: { log: (m: string) => void } }).logger = { log: () => {} };
 
-  return { service, workItems, updateCalls, templates, artifactRoot, drafter, drafterCalls };
+  return { service, workItems, updateCalls, dispatchCalls, templates, artifactRoot, drafter, drafterCalls };
 }
 
 function cleanup(h: Harness) {
@@ -179,10 +211,12 @@ describe("PlansService.prepare", () => {
     expect(harness.drafterCalls[0].workItem.id).toBe("studio-154");
     expect(harness.drafterCalls[0].issueBody).toBe("Mocked issue body from fixture.");
 
-    // Two update calls: predicted_files refresh, then state transition
+    // One update call for predicted_files refresh; state transition via HSM dispatch
     expect(harness.updateCalls).toEqual([
       { id: "studio-154", patch: { predicted_files: ["src/foo.ts", "src/bar.ts"] } },
-      { id: "studio-154", patch: { state: "drafting" } },
+    ]);
+    expect(harness.dispatchCalls).toEqual([
+      { workItemId: "studio-154", event: { type: "user.start_draft" } },
     ]);
 
     // Scratchpad contains drafted content (not the legacy stub placeholders)
@@ -252,9 +286,10 @@ describe("PlansService.prepare", () => {
     // No predicted_files update — current value preserved
     const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
     expect(predictedUpdate).toBeUndefined();
-    // State transition still happens
-    const stateUpdate = harness.updateCalls.find((c) => c.patch.state === "drafting");
-    expect(stateUpdate).toBeDefined();
+    // State transition via HSM dispatch still happens
+    expect(harness.dispatchCalls).toEqual([
+      { workItemId: "studio-154", event: { type: "user.start_draft" } },
+    ]);
   });
 
   it("refreshes predicted_files from drafter envelope.affected_files", async () => {
@@ -457,55 +492,57 @@ describe("PlansService.approve", () => {
     harness.workItems.set(workItem.id, { ...workItem, state: "drafting" });
   }
 
-  it("transitions drafting → ready and records approver metadata", () => {
+  it("transitions drafting → ready and records approver metadata", async () => {
     harness = makeHarness(makeWorkItem({ state: "drafting" }));
     primeDraft(harness.workItems.get("studio-154")!, ["src/foo.ts"]);
     harness.updateCalls.length = 0; // clear the primeDraft set() noise
 
-    const result = harness.service.approve("studio-154", { approved_by: "alice" });
+    const result = await harness.service.approve("studio-154", { approved_by: "alice" });
 
     expect(result.metadata.state).toBe("ready");
     expect(result.metadata.approved_by).toBe("alice");
     expect(typeof result.metadata.approved_at).toBe("string");
-    // The last update call should be the state transition to ready
-    const stateUpdate = harness.updateCalls.find((c) => c.patch.state === "ready");
-    expect(stateUpdate).toBeDefined();
+    // State transition via HSM dispatch
+    expect(harness.dispatchCalls).toContainEqual({
+      workItemId: "studio-154",
+      event: { type: "draft.completed" },
+    });
   });
 
-  it("defaults approved_by to 'local' when dto omits it", () => {
+  it("defaults approved_by to 'local' when dto omits it", async () => {
     harness = makeHarness(makeWorkItem({ state: "drafting" }));
     primeDraft(harness.workItems.get("studio-154")!, ["src/foo.ts"]);
 
-    const result = harness.service.approve("studio-154");
+    const result = await harness.service.approve("studio-154");
 
     expect(result.metadata.approved_by).toBe("local");
   });
 
-  it("refines predicted_files from ## Affected Files and returns diff", () => {
+  it("refines predicted_files from ## Affected Files and returns diff", async () => {
     const workItem = makeWorkItem({ state: "drafting", predicted_files: ["old.ts", "shared.ts"] });
     harness = makeHarness(workItem);
     primeDraft(workItem, ["shared.ts", "new.ts"]);
     harness.updateCalls.length = 0;
 
-    const result = harness.service.approve("studio-154");
+    const result = await harness.service.approve("studio-154");
 
     expect(result.predicted_files_diff).toEqual({
       added: ["new.ts"],
       removed: ["old.ts"],
       unchanged: ["shared.ts"],
     });
-    // predicted_files update call came first, then state transition to ready
+    // predicted_files update call came first, then state transition via HSM
     const predictedUpdate = harness.updateCalls.find((c) => c.patch.predicted_files !== undefined);
     expect(predictedUpdate?.patch.predicted_files).toEqual(["shared.ts", "new.ts"]);
   });
 
-  it("leaves predicted_files unchanged when ## Affected Files is empty", () => {
+  it("leaves predicted_files unchanged when ## Affected Files is empty", async () => {
     const workItem = makeWorkItem({ state: "drafting", predicted_files: ["keep.ts"] });
     harness = makeHarness(workItem);
     primeDraft(workItem, []); // empty Affected Files
     harness.updateCalls.length = 0;
 
-    const result = harness.service.approve("studio-154");
+    const result = await harness.service.approve("studio-154");
 
     expect(result.predicted_files_diff).toEqual({
       added: [],
@@ -519,17 +556,17 @@ describe("PlansService.approve", () => {
 
   const rejectedStates: WorkItemState[] = ["planned", "ready", "in_progress", "open_pr", "merged_pr", "done", "deferred", "cancelled"];
   for (const state of rejectedStates) {
-    it(`rejects approve when state is ${state}`, () => {
+    it(`rejects approve when state is ${state}`, async () => {
       harness = makeHarness(makeWorkItem({ state }));
-      expect(() => harness.service.approve("studio-154")).toThrow(BadRequestException);
+      await expect(harness.service.approve("studio-154")).rejects.toThrow(BadRequestException);
     });
   }
 
-  it("throws NotFoundException when the canonical scratchpad is missing", () => {
+  it("throws NotFoundException when the canonical scratchpad is missing", async () => {
     harness = makeHarness(makeWorkItem({ state: "drafting" }));
     // Ensure plan dir exists but not scratchpad
     ensurePlanDir(harness.artifactRoot, "studio-154");
-    expect(() => harness.service.approve("studio-154")).toThrow(NotFoundException);
+    await expect(harness.service.approve("studio-154")).rejects.toThrow(NotFoundException);
   });
 });
 
@@ -540,7 +577,7 @@ describe("PlansService.reopen", () => {
     if (harness) cleanup(harness);
   });
 
-  it("transitions ready → drafting and clears approver metadata", () => {
+  it("transitions ready → drafting and clears approver metadata", async () => {
     harness = makeHarness(makeWorkItem({ state: "ready" }));
     ensurePlanDir(harness.artifactRoot, "studio-154");
     // Seed metadata with an approved state
@@ -559,19 +596,23 @@ describe("PlansService.reopen", () => {
     writeFileSync(metadataPath, JSON.stringify(approved), "utf8");
     writeFileSync(canonicalScratchpadPath(harness.artifactRoot, "studio-154"), "# Plan", "utf8");
 
-    const result = harness.service.reopen("studio-154");
+    const result = await harness.service.reopen("studio-154");
 
     expect(result.metadata.state).toBe("drafting");
     expect(result.metadata.approved_at).toBeNull();
     expect(result.metadata.approved_by).toBeNull();
-    expect(harness.updateCalls).toEqual([{ id: "studio-154", patch: { state: "drafting" } }]);
+    // State transition via HSM dispatch, no direct update calls for state
+    expect(harness.dispatchCalls).toEqual([
+      { workItemId: "studio-154", event: { type: "user.start_draft" } },
+    ]);
+    expect(harness.updateCalls).toEqual([]);
   });
 
   const rejectedStates: WorkItemState[] = ["planned", "drafting", "in_progress", "open_pr", "merged_pr", "done", "deferred", "cancelled"];
   for (const state of rejectedStates) {
-    it(`rejects reopen when state is ${state}`, () => {
+    it(`rejects reopen when state is ${state}`, async () => {
       harness = makeHarness(makeWorkItem({ state }));
-      expect(() => harness.service.reopen("studio-154")).toThrow(BadRequestException);
+      await expect(harness.service.reopen("studio-154")).rejects.toThrow(BadRequestException);
     });
   }
 });
@@ -640,7 +681,7 @@ describe("PlansService lifecycle (integration)", () => {
     );
 
     // 2. approve
-    const afterApprove = harness.service.approve("studio-154", { approved_by: "marc" });
+    const afterApprove = await harness.service.approve("studio-154", { approved_by: "marc" });
     expect(afterApprove.metadata.state).toBe("ready");
     expect(afterApprove.metadata.approved_by).toBe("marc");
     expect(afterApprove.predicted_files_diff?.added).toEqual(["src/new.ts"]);
@@ -653,13 +694,13 @@ describe("PlansService lifecycle (integration)", () => {
     expect(diskMetadata?.approved_by).toBe("marc");
 
     // 3. reopen
-    const afterReopen = harness.service.reopen("studio-154");
+    const afterReopen = await harness.service.reopen("studio-154");
     expect(afterReopen.metadata.state).toBe("drafting");
     expect(afterReopen.metadata.approved_at).toBeNull();
     expect(harness.workItems.get("studio-154")?.state).toBe("drafting");
 
     // 4. approve again — should succeed on the second pass
-    const afterApprove2 = harness.service.approve("studio-154");
+    const afterApprove2 = await harness.service.approve("studio-154");
     expect(afterApprove2.metadata.state).toBe("ready");
     expect(harness.workItems.get("studio-154")?.state).toBe("ready");
   });

--- a/src/modules/plans/plans.controller.ts
+++ b/src/modules/plans/plans.controller.ts
@@ -17,19 +17,19 @@ export class PlansController {
   }
 
   @Post(":work_item_id/approve")
-  approve(
+  async approve(
     @Param("work_item_id") workItemId: string,
     @Body() body: ApprovePlanDto = {},
-  ): PlanResponse {
-    return this.plansService.approve(workItemId, body);
+  ): Promise<PlanResponse> {
+    return await this.plansService.approve(workItemId, body);
   }
 
   @Post(":work_item_id/reopen")
-  reopen(
+  async reopen(
     @Param("work_item_id") workItemId: string,
     @Body() body: ReopenPlanDto = {},
-  ): PlanResponse {
-    return this.plansService.reopen(workItemId, body);
+  ): Promise<PlanResponse> {
+    return await this.plansService.reopen(workItemId, body);
   }
 
   @Get(":work_item_id")

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -14,6 +14,7 @@ import {
   StudioIssueTemplateService,
   type StudioIssueTemplate,
 } from "../github/studio-issue-template.service.js";
+import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import { PlanDrafterService } from "./plan-drafter.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
@@ -48,6 +49,7 @@ export class PlansService {
 
   constructor(
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
     @Inject(StudioIssueTemplateService) private readonly templateService: StudioIssueTemplateService,
     @Inject(PlanDrafterService) private readonly drafter: PlanDrafterService,
   ) {}
@@ -103,7 +105,7 @@ export class PlansService {
     // idempotent on the state transition itself; it just re-runs the drafter
     // and overwrites the scratchpad).
     if (workItem.state !== "drafting") {
-      this.workItemsService.update(workItemId, { state: "drafting" });
+      await this.hsmService.dispatch(workItemId, { type: "user.start_draft" });
     }
 
     // Ensure the plan dir exists and write initial metadata if we were first.
@@ -142,7 +144,7 @@ export class PlansService {
    * work item's `predicted_files` from the scratchpad's `## Affected Files`
    * section, and return the diff for review UIs.
    */
-  approve(workItemId: string, dto: ApprovePlanDto = {}): PlanResponse {
+  async approve(workItemId: string, dto: ApprovePlanDto = {}): Promise<PlanResponse> {
     const workItem = this.workItemsService.get(workItemId);
     if (workItem.state !== "drafting") {
       throw new BadRequestException(
@@ -169,7 +171,7 @@ export class PlansService {
     }
 
     // Transition drafting → ready.
-    this.workItemsService.update(workItemId, { state: "ready" });
+    await this.hsmService.dispatch(workItemId, { type: "draft.completed" });
 
     const now = new Date().toISOString();
     const approvedBy = dto.approved_by?.trim() || "local";
@@ -197,7 +199,7 @@ export class PlansService {
    * Reopen an approved plan for further editing: `ready → drafting`. Clears
    * approver fields in metadata.
    */
-  reopen(workItemId: string, _dto: ReopenPlanDto = {}): PlanResponse {
+  async reopen(workItemId: string, _dto: ReopenPlanDto = {}): Promise<PlanResponse> {
     const workItem = this.workItemsService.get(workItemId);
     if (workItem.state !== "ready") {
       throw new BadRequestException(
@@ -205,7 +207,7 @@ export class PlansService {
       );
     }
 
-    this.workItemsService.update(workItemId, { state: "drafting" });
+    await this.hsmService.dispatch(workItemId, { type: "user.start_draft" });
 
     const metadata = this.updatePlanMetadata(workItemId, (current) => ({
       ...current,


### PR DESCRIPTION
## Summary
- Reroute all 9 remaining direct `workItemsService.update({ state })` calls through `WorkItemHsmService.dispatch()` so the SCXML chart is the sole authority for lifecycle transitions
- Adds `unsafeSetState` escape hatch on `WorkItemsService` for migration tooling
- SCXML chart extended with 3 new transitions for fallback paths

## Migrated call sites

| Service | Method | HSM Event |
|---|---|---|
| PlansService | `prepare()` | `user.start_draft` |
| PlansService | `approve()` | `draft.completed` |
| PlansService | `reopen()` | `user.start_draft` |
| ExecutionService | `publishPullRequest()` | `gh.pr_opened` |
| ExecutionService | `syncMergedPullRequest()` | `gh.pr_merged` |
| ExecutionService | `markWorkItemInProgressOnLaunch()` | `user.dispatch` |
| ExecutionService | `transitionInProgressToReady()` | `user.investigate` |
| ExecutionService | `transitionInProgressToDrafting()` | `user.start_draft` |
| ExecutionService | `cancelWorkItem()` | `user.cancel` |

## SCXML chart additions
- `user.dispatch` from `planned` (fallback for direct launch without drafting)
- `user.investigate` from `in_progress` (manual return to ready)
- `user.start_draft` from `in_progress` (manual return to drafting for rework)

## Test plan
- [x] 482 tests pass, 0 failures
- [x] tsc clean
- [ ] Manual: prepare a plan (planned → drafting) via the UI
- [ ] Manual: approve a plan (drafting → ready) via the UI
- [ ] Manual: dispatch a run (ready → in_progress) via the UI
- [ ] Manual: cancel a work item from any pre-PR state

Closes #201