### PR TITLE
Studio: cache refresh triggers (timer, refresh button, mutation write-through) (#197)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.1.6",
         "@nestjs/core": "^11.1.6",
         "@nestjs/platform-express": "^11.1.6",
+        "@nestjs/schedule": "^6.1.1",
         "@scion-scxml/core": "^2.6.24",
         "better-sqlite3": "^11.10.0",
         "dagre-d3-es": "^7.0.14",
@@ -1756,6 +1757,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
+      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -2977,6 +2991,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
@@ -3803,6 +3823,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
       }
     },
     "node_modules/d3": {
@@ -5525,6 +5562,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@nestjs/common": "^11.1.6",
     "@nestjs/core": "^11.1.6",
     "@nestjs/platform-express": "^11.1.6",
+    "@nestjs/schedule": "^6.1.1",
     "@scion-scxml/core": "^2.6.24",
     "better-sqlite3": "^11.10.0",
     "dagre-d3-es": "^7.0.14",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ScheduleModule } from "@nestjs/schedule";
 import { ExecutionModule } from "./modules/execution/execution.module.js";
 import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
@@ -9,6 +10,6 @@ import { ReconciliationModule } from "./modules/reconciliation/reconciliation.mo
 import { SettingsModule } from "./modules/settings/settings.module.js";
 
 @Module({
-  imports: [ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, PlansModule, ReconciliationModule, SettingsModule],
+  imports: [ScheduleModule.forRoot(), ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, PlansModule, ReconciliationModule, SettingsModule],
 })
 export class AppModule {}

--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -40,6 +40,13 @@ interface HarnessService {
   githubService: {
     closeIssue: ReturnType<typeof vi.fn>;
   };
+  // studio-197 write-through
+  githubBatchCache: {
+    upsertPullRequest: ReturnType<typeof vi.fn>;
+    upsertIssue: ReturnType<typeof vi.fn>;
+    invalidate: ReturnType<typeof vi.fn>;
+    invalidateAll: ReturnType<typeof vi.fn>;
+  };
   recentRuns: ExecutionRunRecord[];
   writeStatus: ReturnType<typeof vi.fn>;
   emitRun: ReturnType<typeof vi.fn>;
@@ -206,6 +213,14 @@ function makeService(params: {
           : undefined,
       });
     }),
+  };
+
+  // studio-197: batch cache mock for write-through hooks.
+  service.githubBatchCache = {
+    upsertPullRequest: vi.fn(),
+    upsertIssue: vi.fn(),
+    invalidate: vi.fn(),
+    invalidateAll: vi.fn(),
   };
 
   return service;

--- a/src/modules/execution/__tests__/github-cache-scheduler.test.ts
+++ b/src/modules/execution/__tests__/github-cache-scheduler.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GitHubCacheScheduler } from "../github-cache-scheduler.service.js";
+import type { WorkItemRecord } from "../../graph/types.js";
+
+function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
+  return {
+    id: "studio-100",
+    name: "Test item",
+    kind: "issue",
+    state: "open_pr",
+    repo: "fusupo/escapement-studio",
+    issue_number: 100,
+    issue_url: "https://github.com/fusupo/escapement-studio/issues/100",
+    scope_hint: null,
+    branch: "studio-100-branch",
+    archive_path: null,
+    predicted_files: [],
+    actual_files: [],
+    meta: {},
+    updated_at: "2026-04-11T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeService(stubs: {
+  workItems?: WorkItemRecord[];
+  prMap?: Map<number, { number: number; state: string; merged_at: string | null; head_ref: string; base_ref: string; url: string; title: string; is_draft: boolean }>;
+  issueMap?: Map<number, { number: number; state: string; closed_at: string | null; url: string; title: string }>;
+} = {}) {
+  const cache = {
+    invalidate: vi.fn(),
+    invalidateAll: vi.fn(),
+    listPullRequests: vi.fn(async () => stubs.prMap ?? new Map()),
+    listIssues: vi.fn(async () => stubs.issueMap ?? new Map()),
+    upsertPullRequest: vi.fn(),
+    upsertIssue: vi.fn(),
+  };
+  const workItemsService = {
+    list: vi.fn(() => stubs.workItems ?? []),
+    get: vi.fn((id: string) => {
+      const match = (stubs.workItems ?? []).find((w) => w.id === id);
+      if (!match) throw new Error("not found");
+      return match;
+    }),
+  };
+  const hsmService = {
+    dispatch: vi.fn(async () => ({
+      work_item_id: "studio-100",
+      prev_state: "open_pr",
+      next_state: "merged_pr",
+      event: { type: "gh.pr_merged" },
+      applied_actions: [],
+      mutation_applied: true,
+      rejected: false,
+    })),
+  };
+
+  const scheduler = Object.create(GitHubCacheScheduler.prototype) as GitHubCacheScheduler;
+  (scheduler as unknown as { cache: typeof cache }).cache = cache;
+  (scheduler as unknown as { workItemsService: typeof workItemsService }).workItemsService = workItemsService;
+  (scheduler as unknown as { hsmService: typeof hsmService }).hsmService = hsmService;
+  (scheduler as unknown as { logger: { log: () => void; warn: () => void } }).logger = {
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  return { scheduler, cache, workItemsService, hsmService };
+}
+
+describe("GitHubCacheScheduler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when no repos are tracked", async () => {
+    const { scheduler } = makeService({ workItems: [] });
+    const results = await scheduler.sweep();
+    expect(results).toEqual([]);
+  });
+
+  it("invalidates and refetches cache for tracked repos", async () => {
+    const { scheduler, cache } = makeService({
+      workItems: [makeWorkItem()],
+    });
+    await scheduler.sweep();
+    expect(cache.invalidate).toHaveBeenCalledWith("fusupo/escapement-studio");
+    expect(cache.listPullRequests).toHaveBeenCalledWith("fusupo/escapement-studio");
+    expect(cache.listIssues).toHaveBeenCalledWith("fusupo/escapement-studio");
+  });
+
+  it("dispatches gh.pr_merged when open_pr item has a MERGED PR", async () => {
+    const prMap = new Map([[100, {
+      number: 100,
+      state: "MERGED",
+      merged_at: "2026-04-11T01:00:00.000Z",
+      head_ref: "studio-100-branch",
+      base_ref: "develop",
+      url: "https://github.com/x/y/pull/100",
+      title: "PR title",
+      is_draft: false,
+    }]]);
+    const { scheduler, hsmService } = makeService({
+      workItems: [makeWorkItem({ state: "open_pr" })],
+      prMap,
+    });
+    const results = await scheduler.sweep();
+    expect(hsmService.dispatch).toHaveBeenCalledWith("studio-100", expect.objectContaining({
+      type: "gh.pr_merged",
+    }));
+    expect(results[0].dispatched).toBe(1);
+  });
+
+  it("dispatches gh.issue_closed when merged_pr item has a closed issue", async () => {
+    const issueMap = new Map([[100, {
+      number: 100,
+      state: "closed",
+      closed_at: "2026-04-11T02:00:00.000Z",
+      url: "https://github.com/x/y/issues/100",
+      title: "Issue title",
+    }]]);
+    const { scheduler, hsmService } = makeService({
+      workItems: [makeWorkItem({ state: "merged_pr" })],
+      issueMap,
+    });
+    await scheduler.sweep();
+    expect(hsmService.dispatch).toHaveBeenCalledWith("studio-100", expect.objectContaining({
+      type: "gh.issue_closed",
+    }));
+  });
+
+  it("does NOT dispatch when work item is in a non-source state", async () => {
+    const prMap = new Map([[100, {
+      number: 100,
+      state: "MERGED",
+      merged_at: "2026-04-11T01:00:00.000Z",
+      head_ref: "studio-100-branch",
+      base_ref: "develop",
+      url: "https://github.com/x/y/pull/100",
+      title: "PR title",
+      is_draft: false,
+    }]]);
+    const { scheduler, hsmService } = makeService({
+      workItems: [makeWorkItem({ state: "done" })],
+      prMap,
+    });
+    await scheduler.sweep();
+    expect(hsmService.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("scopes sweep to a single repo when repo param is provided", async () => {
+    const { scheduler, cache } = makeService({
+      workItems: [makeWorkItem()],
+    });
+    await scheduler.sweep("fusupo/other-repo");
+    expect(cache.invalidate).toHaveBeenCalledWith("fusupo/other-repo");
+    expect(cache.invalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows per-repo fetch errors and continues", async () => {
+    const { scheduler, cache } = makeService({
+      workItems: [makeWorkItem(), makeWorkItem({ id: "studio-200", repo: "fusupo/other-repo" })],
+    });
+    (cache.listPullRequests as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("rate limited"));
+    const results = await scheduler.sweep();
+    // First repo fails, second succeeds
+    expect(results).toHaveLength(2);
+    expect(results[0].dispatched).toBe(0); // failed repo
+  });
+
+  it("swallows per-dispatch HSM errors and continues", async () => {
+    const prMap = new Map([[100, {
+      number: 100,
+      state: "MERGED",
+      merged_at: "2026-04-11T01:00:00.000Z",
+      head_ref: "studio-100-branch",
+      base_ref: "develop",
+      url: "https://github.com/x/y/pull/100",
+      title: "PR title",
+      is_draft: false,
+    }]]);
+    const { scheduler, hsmService } = makeService({
+      workItems: [makeWorkItem({ state: "open_pr" })],
+      prMap,
+    });
+    (hsmService.dispatch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("HSM error"));
+    const results = await scheduler.sweep();
+    expect(results[0].dispatched).toBe(0);
+  });
+});

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -4,14 +4,16 @@ import { GraphModule } from "../graph/graph.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
 import { ExecutionController } from "./execution.controller.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
+import { GitHubCacheController } from "./github-cache.controller.js";
+import { GitHubCacheScheduler } from "./github-cache-scheduler.service.js";
 import { ExecutionService } from "./execution.service.js";
 import { WorkItemReconcilerController } from "./work-item-reconciler.controller.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 
 @Module({
   imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
-  controllers: [ExecutionController, WorkItemReconcilerController],
-  providers: [ExecutionService, GitHubBatchCache, WorkItemReconcilerService],
-  exports: [ExecutionService, GitHubBatchCache, WorkItemReconcilerService],
+  controllers: [ExecutionController, GitHubCacheController, WorkItemReconcilerController],
+  providers: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, WorkItemReconcilerService],
+  exports: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, WorkItemReconcilerService],
 })
 export class ExecutionModule {}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -22,6 +22,7 @@ import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-w
 import { loadRunRecordsForArtifactRoot, loadRunRecordsFromDisk } from "./run-disk-store.js";
 import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
 import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.js";
+import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
@@ -88,6 +89,7 @@ export class ExecutionService implements OnModuleInit {
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
     @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
   ) {
@@ -562,6 +564,19 @@ export class ExecutionService implements OnModuleInit {
         type: "gh.pr_opened",
         pull_request: prPayload,
       });
+      // studio-197: write-through to batch cache so next reconcile sees the PR.
+      if (workItem.repo) {
+        this.githubBatchCache.upsertPullRequest(workItem.repo, {
+          number: pullRequest.number,
+          state: "OPEN",
+          merged_at: null,
+          head_ref: pullRequest.head_ref,
+          base_ref: pullRequest.base_ref,
+          url: pullRequest.url,
+          title: pullRequest.title,
+          is_draft: pullRequest.is_draft ?? false,
+        });
+      }
       // Write additional fields that the HSM doesn't manage.
       const existingMeta = this.workItemsService.get(run.work_item_id).meta ?? {};
       this.workItemsService.update(run.work_item_id, {
@@ -617,6 +632,17 @@ export class ExecutionService implements OnModuleInit {
         base_ref: pullRequest.base_ref,
         merged_at: pullRequest.merged_at,
       },
+    });
+    // studio-197: write-through to batch cache so next reconcile sees MERGED.
+    this.githubBatchCache.upsertPullRequest(workItem.repo, {
+      number: pullRequest.number,
+      state: "MERGED",
+      merged_at: pullRequest.merged_at,
+      head_ref: pullRequest.head_ref,
+      base_ref: pullRequest.base_ref,
+      url: pullRequest.url,
+      title: pullRequest.title,
+      is_draft: false,
     });
     this.workItemsService.update(workItem.id, {
       actual_files: actualFilesSelection.files,
@@ -2446,12 +2472,26 @@ export class ExecutionService implements OnModuleInit {
       );
     }
 
+    // studio-197: write-through closed issue to batch cache.
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
+    if (closedIssue) {
+      const wi = this.workItemsService.get(workItemId);
+      if (wi.repo) {
+        this.githubBatchCache.upsertIssue(wi.repo, {
+          number: closedIssue.number,
+          state: "closed",
+          closed_at: new Date().toISOString(),
+          url: closedIssue.url,
+          title: closedIssue.title,
+        });
+      }
+    }
+
     // Post-dispatch finalizer: dispose matching runs.
     const removedRunIds = this.removeRunsForWorkItem(workItemId);
 
     // Build the response envelope.
     const updatedWorkItem = this.workItemsService.get(workItemId);
-    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
 
     return {
       work_item: {
@@ -2627,11 +2667,25 @@ export class ExecutionService implements OnModuleInit {
       );
     }
 
+    // studio-197: write-through closed issue to batch cache.
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
+    if (closedIssue) {
+      const wi = this.workItemsService.get(workItemId);
+      if (wi.repo) {
+        this.githubBatchCache.upsertIssue(wi.repo, {
+          number: closedIssue.number,
+          state: "closed",
+          closed_at: new Date().toISOString(),
+          url: closedIssue.url,
+          title: closedIssue.title,
+        });
+      }
+    }
+
     // Post-dispatch finalizer.
     const removedRunIds = this.removeRunsForWorkItem(workItemId);
 
     const updatedWorkItem = this.workItemsService.get(workItemId);
-    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
     const archiveData = result.handler_data?.archive_result as {
       archive_path: string;
       readme_path: string | null;

--- a/src/modules/execution/github-cache-scheduler.service.ts
+++ b/src/modules/execution/github-cache-scheduler.service.ts
@@ -1,0 +1,191 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
+import { GitHubBatchCache, type CachedPullRequest, type CachedIssue } from "./github-batch-cache.service.js";
+
+/**
+ * studio-197: periodic cache refresh + auto-dispatch of `gh.*` HSM events.
+ *
+ * Runs every 60s. For each tracked repo: invalidate the batch cache,
+ * refetch PR + issue state from GitHub, then iterate reconcilable work
+ * items and dispatch HSM events where the cached GH state has advanced
+ * beyond the work item's local state.
+ *
+ * The same sweep logic is exposed via `sweep(repo?)` so the
+ * `POST /api/github-cache/refresh` endpoint can trigger it on demand.
+ */
+@Injectable()
+export class GitHubCacheScheduler {
+  private readonly logger = new Logger(GitHubCacheScheduler.name);
+
+  constructor(
+    @Inject(GitHubBatchCache) private readonly cache: GitHubBatchCache,
+    @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleTick(): Promise<void> {
+    try {
+      const results = await this.sweep();
+      if (results.length > 0) {
+        const totalDispatched = results.reduce((sum, r) => sum + r.dispatched, 0);
+        this.logger.log(
+          `Cache sweep: ${results.length} repo(s), ${totalDispatched} HSM event(s) dispatched`,
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Cache sweep failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Run a full cache-refresh + HSM-dispatch sweep. If `repo` is provided,
+   * only that repo is refreshed; otherwise all tracked repos are swept.
+   *
+   * Returns per-repo results for the response envelope.
+   */
+  async sweep(repo?: string): Promise<SweepResult[]> {
+    const repos = repo ? [repo] : this.discoverTrackedRepos();
+    if (repos.length === 0) {
+      return [];
+    }
+
+    const results: SweepResult[] = [];
+    for (const r of repos) {
+      try {
+        const result = await this.sweepRepo(r);
+        results.push(result);
+      } catch (error) {
+        this.logger.warn(
+          `Sweep failed for ${r}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        results.push({ repo: r, prs: 0, issues: 0, dispatched: 0 });
+      }
+    }
+    return results;
+  }
+
+  private async sweepRepo(repo: string): Promise<SweepResult> {
+    // Invalidate + refetch
+    this.cache.invalidate(repo);
+    const [prs, issues] = await Promise.all([
+      this.cache.listPullRequests(repo),
+      this.cache.listIssues(repo),
+    ]);
+
+    // Dispatch HSM events for any state advances
+    const workItems = this.workItemsService.list({}).filter(
+      (w) => w.repo === repo && DISPATCH_SOURCE_STATES.has(w.state),
+    );
+
+    let dispatched = 0;
+    for (const workItem of workItems) {
+      const events = this.detectStateAdvances(workItem, prs, issues);
+      for (const event of events) {
+        try {
+          const result = await this.hsmService.dispatch(workItem.id, event);
+          if (result.mutation_applied) {
+            dispatched++;
+            this.logger.log(
+              `Sweep dispatched ${event.type} for ${workItem.id}: ${result.prev_state} → ${result.next_state}`,
+            );
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Sweep dispatch ${event.type} failed for ${workItem.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    }
+
+    return { repo, prs: prs.size, issues: issues.size, dispatched };
+  }
+
+  /**
+   * Compare a work item's local state against the cached GH state and
+   * return any HSM events that should fire. Each event is only returned
+   * when the work item is in the expected source state for that transition.
+   */
+  private detectStateAdvances(
+    workItem: WorkItemRecord,
+    prs: Map<number, CachedPullRequest>,
+    issues: Map<number, CachedIssue>,
+  ): import("../graph/types.js").WorkItemHsmEvent[] {
+    const events: import("../graph/types.js").WorkItemHsmEvent[] = [];
+    const state = this.normalizeState(workItem.state);
+    const branch = workItem.branch?.trim();
+
+    // in_progress → open_pr: a PR exists for the work item's branch
+    if (state === "in_progress" && branch) {
+      for (const pr of prs.values()) {
+        if (pr.head_ref === branch) {
+          events.push({ type: "gh.pr_opened", pull_request: pr as unknown as Record<string, unknown> });
+          break;
+        }
+      }
+    }
+
+    // open_pr → merged_pr: the PR for this branch is MERGED
+    if (state === "open_pr" && branch) {
+      for (const pr of prs.values()) {
+        if (pr.head_ref === branch && pr.state === "MERGED") {
+          events.push({ type: "gh.pr_merged", pull_request: pr as unknown as Record<string, unknown> });
+          break;
+        }
+      }
+    }
+
+    // merged_pr → closed: the linked issue is closed
+    if (state === "merged_pr" && typeof workItem.issue_number === "number") {
+      const issue = issues.get(workItem.issue_number);
+      if (issue && issue.state === "closed") {
+        events.push({ type: "gh.issue_closed", issue: issue as unknown as Record<string, unknown> });
+      }
+    }
+
+    return events;
+  }
+
+  /**
+   * Discover all distinct repo values from tracked work items. Used when
+   * no specific repo is requested (timer tick sweeps everything).
+   */
+  private discoverTrackedRepos(): string[] {
+    const workItems = this.workItemsService.list({});
+    const repos = new Set<string>();
+    for (const w of workItems) {
+      if (w.repo) repos.add(w.repo);
+    }
+    return Array.from(repos);
+  }
+
+  /**
+   * Normalize dotted pre_pr.X states to their leaf for comparison.
+   */
+  private normalizeState(state: WorkItemState): string {
+    return state.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
+  }
+}
+
+export interface SweepResult {
+  repo: string;
+  prs: number;
+  issues: number;
+  dispatched: number;
+}
+
+/**
+ * Work item states that can produce gh.* events during a sweep.
+ * Only items in these states are worth checking against cached GH truth.
+ */
+const DISPATCH_SOURCE_STATES: ReadonlySet<WorkItemState> = new Set([
+  "in_progress",
+  "pre_pr.in_progress",
+  "open_pr",
+  "merged_pr",
+]);

--- a/src/modules/execution/github-cache.controller.ts
+++ b/src/modules/execution/github-cache.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Inject, Post, Query } from "@nestjs/common";
+import { GitHubCacheScheduler, type SweepResult } from "./github-cache-scheduler.service.js";
+
+/**
+ * studio-197: on-demand cache refresh endpoint.
+ *
+ * `POST /api/github-cache/refresh` triggers the same sweep logic as
+ * the scheduler's @Cron tick: invalidate cache, refetch from GitHub,
+ * dispatch HSM events for any state advances. Optionally scoped to a
+ * single repo via `?repo=owner/repo`.
+ */
+@Controller("api/github-cache")
+export class GitHubCacheController {
+  constructor(
+    @Inject(GitHubCacheScheduler)
+    private readonly scheduler: GitHubCacheScheduler,
+  ) {}
+
+  @Post("refresh")
+  async refresh(@Query("repo") repo?: string): Promise<{
+    refreshed: SweepResult[];
+  }> {
+    const refreshed = await this.scheduler.sweep(repo || undefined);
+    return { refreshed };
+  }
+}

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -11,6 +11,7 @@
     listExecutionRuns,
     listReconciledWorkItems,
     openPullRequest,
+    refreshGitHubCache,
     resolveDisambiguation,
     sendFollowUpMessage,
   } from "../lib/api.js";
@@ -485,7 +486,7 @@
         {/if}
       {/if}
     </div>
-    <button class="secondary small" on:click={() => loadData({ quiet: true })} disabled={refreshing || loading}>{refreshing ? "Refreshing..." : "Refresh"}</button>
+    <button class="secondary small" on:click={async () => { refreshing = true; try { await refreshGitHubCache(); } catch (e) { /* best-effort */ } await loadData({ quiet: true }); }} disabled={refreshing || loading}>{refreshing ? "Refreshing..." : "Refresh"}</button>
   </div>
 
   {#if copiedMessage}

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -103,6 +103,17 @@ export function listArchivedExecutionRuns() {
   return request("/api/execution/archived-runs");
 }
 
+/**
+ * studio-197: trigger a full cache refresh + HSM dispatch sweep.
+ * Optionally scoped to a single repo.
+ */
+export function refreshGitHubCache(repo) {
+  const url = repo
+    ? `/api/github-cache/refresh?repo=${encodeURIComponent(repo)}`
+    : "/api/github-cache/refresh";
+  return request(url, { method: "POST", headers: jsonHeaders, body: JSON.stringify({}) });
+}
+
 export function getArchivedExecutionRunBundle(workItemId) {
   return request(`/api/execution/archived-runs/${encodeURIComponent(workItemId)}`);
 }


### PR DESCRIPTION
## Summary
- `@Cron(EVERY_MINUTE)` `GitHubCacheScheduler` — invalidates cache per repo, refetches PR/issue state, dispatches `gh.*` HSM events for any observed state advances
- `POST /api/github-cache/refresh` endpoint — on-demand sweep, same logic as the timer
- Write-through hooks at 4 mutation sites: `createPullRequest`, `syncMergedPullRequest`, `closeMergedPullRequest`, `archiveAndCloseMergedPullRequest`
- Frontend Refresh button wired to hit the new endpoint before reloading data
- `@nestjs/schedule` added, `ScheduleModule.forRoot()` in AppModule

## Files changed
- **new**: `src/modules/execution/github-cache-scheduler.service.ts` — scheduler with sweep logic
- **new**: `src/modules/execution/github-cache.controller.ts` — refresh endpoint
- **new**: `src/modules/execution/__tests__/github-cache-scheduler.test.ts` — 8 tests
- **modified**: `src/app.module.ts` — ScheduleModule import
- **modified**: `src/modules/execution/execution.module.ts` — register scheduler + controller
- **modified**: `src/modules/execution/execution.service.ts` — inject GitHubBatchCache, add 4 write-through hooks
- **modified**: `src/modules/execution/__tests__/disposition.test.ts` — add githubBatchCache mock to harness
- **modified**: `web/src/lib/api.js` — add refreshGitHubCache function
- **modified**: `web/src/components/ExecutionDispatchPanel.svelte` — wire Refresh button
- **modified**: `package.json` / `package-lock.json` — @nestjs/schedule

## Test plan
- [x] 497 tests pass, 0 failures
- [x] tsc clean
- [ ] Manual: verify timer fires every 60s (check Nest log for "Cache sweep" line)
- [ ] Manual: click Refresh in execution panel — verify it triggers the endpoint and reloads
- [ ] Manual: create a PR via Studio, verify it appears in cache immediately (no 60s wait)

Closes #197