### PR TITLE
Studio: expose HSM enabled-events for frontend button rendering (#203)

### DIFF
--- a/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler-controller.test.ts
@@ -13,6 +13,7 @@ function makeReconciled(id: string): ReconciledWorkItem {
     github_issue_state: null,
     next_action: "relaunch",
     rationale: "stub",
+    enabled_events: [],
   };
 }
 

--- a/src/modules/execution/__tests__/work-item-reconciler.test.ts
+++ b/src/modules/execution/__tests__/work-item-reconciler.test.ts
@@ -172,6 +172,7 @@ describe("WorkItemReconcilerService.reconcile", () => {
     git?: Partial<Record<"count" | "status", string>>;
     worktreeExists?: boolean;
     issueState?: string | null;
+    enabledEvents?: string[];
   }) {
     const service = Object.create(WorkItemReconcilerService.prototype) as WorkItemReconcilerService;
     const diskStore: ReconcilerDiskStore = {
@@ -207,13 +208,18 @@ describe("WorkItemReconcilerService.reconcile", () => {
     (service as any).artifactRoot = "/tmp/artifact-root";
     (service as any).runsDir = "/tmp/artifact-root/runs";
     (service as any).worktreeRoot = "/tmp/artifact-root/worktrees";
+    const hsmService = {
+      getEnabledEvents: vi.fn(() => stubs.enabledEvents ?? []),
+    };
+
     (service as any).workItemsService = workItemsService;
     (service as any).githubBatchCache = githubBatchCache;
+    (service as any).hsmService = hsmService;
     service.diskStore = diskStore;
     service.gitRunner = gitRunner;
     service.pathExists = () => stubs.worktreeExists ?? false;
 
-    return { service, diskStore, gitRunner, workItemsService, githubBatchCache };
+    return { service, diskStore, gitRunner, workItemsService, githubBatchCache, hsmService };
   }
 
   it("returns an empty array when no work items are in a reconcilable state", async () => {
@@ -330,6 +336,28 @@ describe("WorkItemReconcilerService.reconcile", () => {
       runs: [makeRun()],
     });
     expect(await service.reconcile()).toEqual([]);
+  });
+
+  it("populates enabled_events from hsmService.getEnabledEvents", async () => {
+    const { service } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+      enabledEvents: ["user.finalize", "user.archive_and_finalize"],
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].enabled_events).toEqual(["user.finalize", "user.archive_and_finalize"]);
+  });
+
+  it("falls back to empty enabled_events when getEnabledEvents throws", async () => {
+    const { service, hsmService } = makeService({
+      workItems: [makeWorkItem()],
+      runs: [makeRun()],
+    });
+    (hsmService.getEnabledEvents as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error("HSM not initialized");
+    });
+    const reconciled = await service.reconcile();
+    expect(reconciled[0].enabled_events).toEqual([]);
   });
 
   it("uses the stored PR on the latest run without calling gh", async () => {

--- a/src/modules/execution/work-item-reconciler.service.ts
+++ b/src/modules/execution/work-item-reconciler.service.ts
@@ -5,8 +5,9 @@ import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
 import { runsRoot, worktreesRoot } from "../../lib/context-layout.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
+import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
-import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
+import type { WorkItemHsmEvent, WorkItemRecord, WorkItemState } from "../graph/types.js";
 import {
   detectAndMarkOrphans,
   loadRunRecordsFromDisk,
@@ -112,6 +113,7 @@ export class WorkItemReconcilerService {
   constructor(
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
+    @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
   ) {}
 
   /**
@@ -165,6 +167,16 @@ export class WorkItemReconcilerService {
         : null;
       const { nextAction, rationale } = decideNextAction({ workItem, latestRun, worktree, githubPr });
 
+      // studio-203: enabled user events from the HSM chart for this state.
+      let enabledEvents: WorkItemHsmEvent["type"][] = [];
+      try {
+        enabledEvents = this.hsmService.getEnabledEvents(workItem.id);
+      } catch (error) {
+        this.logger.warn(
+          `getEnabledEvents failed for ${workItem.id}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+
       out.push({
         work_item_id: workItem.id,
         graph_state: workItem.state,
@@ -174,6 +186,7 @@ export class WorkItemReconcilerService {
         github_issue_state: githubIssueState,
         next_action: nextAction,
         rationale,
+        enabled_events: enabledEvents,
       });
     }
 

--- a/src/modules/execution/work-item-reconciler.types.ts
+++ b/src/modules/execution/work-item-reconciler.types.ts
@@ -1,5 +1,5 @@
 import type { ExecutionRunRecord } from "./types.js";
-import type { WorkItemState } from "../graph/types.js";
+import type { WorkItemHsmEvent, WorkItemState } from "../graph/types.js";
 
 /**
  * Issue #176: pure derived view that joins graph state, run artifacts on
@@ -68,6 +68,9 @@ export interface ReconciledWorkItem {
   github_issue_state: "open" | "closed" | null;
   next_action: NextAction;
   rationale: string;
+  /** studio-203: user.* events the HSM will accept from the current state.
+   * Drives frontend button rendering — replaces hard-coded next_action checks. */
+  enabled_events: WorkItemHsmEvent["type"][];
 }
 
 /** Summary emitted by the startup reconcile pass. Used both by the Nest

--- a/web/src/components/ExecutionDetailPane.svelte
+++ b/web/src/components/ExecutionDetailPane.svelte
@@ -11,11 +11,16 @@
   export let validationPolicy = null;
   export let scratchpadContent = undefined;
   export let scratchpadLoading = false;
-  // studio-84: merged-PR disposition props. The parent computes
-  // `canDispose` from the reconciled feed (next_action === 'close_out')
-  // and sets `disposing` while a Close or Archive-and-close request is
-  // in flight so both buttons can be disabled together.
+  // studio-203: disposition props. The parent computes `canDispose` from
+  // the HSM's enabled_events (user.finalize / user.archive_and_finalize)
+  // and sets `disposing` while a request is in flight.
   export let canDispose = false;
+
+  // studio-203: event-to-label map for disposition buttons.
+  const EVENT_LABELS = {
+    "user.finalize": "Close",
+    "user.archive_and_finalize": "Archive and close",
+  };
   export let disposing = false;
   export let dispositionError = "";
 

--- a/web/src/components/ExecutionDispatchPanel.svelte
+++ b/web/src/components/ExecutionDispatchPanel.svelte
@@ -93,14 +93,22 @@
   ) || [];
 
   /**
-   * studio-84: returns true iff the reconciled feed marks this run's work
-   * item as ready for merged-PR disposition (next_action === 'close_out').
-   * This is the single source of truth for showing the Close /
-   * Archive-and-close buttons and the 'ready to close' pill badge.
+   * studio-203: returns the list of HSM-enabled user events for a run's
+   * work item. Drives disposition button rendering — replaces the old
+   * hard-coded next_action === 'close_out' check.
+   */
+  function enabledEventsFor(run) {
+    if (!run) return [];
+    return reconciledByWorkItem[run.work_item_id]?.enabled_events ?? [];
+  }
+
+  /**
+   * Convenience: true when the disposition card should be shown.
+   * Checks if finalize or archive_and_finalize is in the enabled events.
    */
   function canDisposeRun(run) {
-    if (!run) return false;
-    return reconciledByWorkItem[run.work_item_id]?.next_action === "close_out";
+    const events = enabledEventsFor(run);
+    return events.includes("user.finalize") || events.includes("user.archive_and_finalize");
   }
 
   $: selectedRun = selectedRunId ? runs.find((r) => r.run_id === selectedRunId) ?? null : null;


### PR DESCRIPTION
## Summary
- Wire `WorkItemHsmService.getEnabledEvents()` into the reconciled work item response
- Frontend replaces hard-coded `next_action === "close_out"` gate with `enabled_events` membership check
- `next_action` preserved on wire for pill badge rendering (not removed)

## Changes
- **`work-item-reconciler.types.ts`** — add `enabled_events: WorkItemHsmEvent["type"][]` to `ReconciledWorkItem`
- **`work-item-reconciler.service.ts`** — inject `WorkItemHsmService`, call `getEnabledEvents` per row with try/catch fallback
- **`work-item-reconciler.test.ts`** — add `hsmService` mock, 2 new test cases (happy path + error fallback)
- **`work-item-reconciler-controller.test.ts`** — add `enabled_events` to factory
- **`ExecutionDispatchPanel.svelte`** — `canDisposeRun` now checks `enabled_events` for `user.finalize` / `user.archive_and_finalize`
- **`ExecutionDetailPane.svelte`** — `EVENT_LABELS` map for data-driven button text

## Test plan
- [x] 499 tests pass, 0 failures
- [x] tsc clean
- [ ] Manual: verify disposition buttons appear for merged_pr AND closed work items
- [ ] Manual: verify pill badges still show next_action labels

Closes #203