### PR TITLE
[#130] Studio: persist execution run state to disk and rehydrate on server restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,16 +103,19 @@ This runs the server TypeScript check plus the production frontend build.
 23. Confirm the launched run creates an isolated worktree under the configured repo artifact root (for example `/home/marc/escapement-studio-ctx/worktrees/`) and artifacts under the matching repo artifact root `runs/` directory.
 24. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
 25. Confirm the completed execution run auto-populates the related work item `actual_files` from the recorded `changed_files`.
-26. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
-27. Ask the planner to delegate a `reconciliation-analyst` or call `reconciliation_query`, then stage a planning-memory update based on the reported drift and approve it through the existing memory approval flow.
-28. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
-29. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
-30. Verify the graph view still loads data from `/api/graph`.
-31. Select a node to edit it in the sidebar.
-32. Create a new work item in the sidebar and confirm it appears in the graph.
-33. Create an edge between two nodes and confirm it appears in the graph and edge list.
-34. Delete an edge from the sidebar.
-35. Change repo/state/track/phase filters and confirm the rendered graph updates.
+26. Restart the Studio server after a completed execution run and confirm the Execute tab still shows the recent run, including `result_summary`, changed files, PR metadata, chat history, and canonical scratchpad content.
+27. Restart the Studio server while an execution run is still active and confirm the run is rehydrated as `error` with an explicit orphan/restart note instead of disappearing.
+28. If the worktree still exists, open the run checklist after restart and confirm it is reconstructed from the worktree scratchpad.
+29. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
+30. Ask the planner to delegate a `reconciliation-analyst` or call `reconciliation_query`, then stage a planning-memory update based on the reported drift and approve it through the existing memory approval flow.
+31. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
+32. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
+33. Verify the graph view still loads data from `/api/graph`.
+34. Select a node to edit it in the sidebar.
+35. Create a new work item in the sidebar and confirm it appears in the graph.
+36. Create an edge between two nodes and confirm it appears in the graph and edge list.
+37. Delete an edge from the sidebar.
+38. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 
@@ -311,6 +314,8 @@ Execution artifacts are persisted under:
   outputs/
 ```
 
+`status.json` is the restart-recovery source of truth for execution runs. On boot, Studio reloads recent runs from these snapshots, rewrites previously non-terminal runs (`queued`, `preparing`, `disambiguating`, `running`) to `error` with an orphan note, and keeps completed-run fields such as `result_summary`, `changed_files`, `pull_request`, and durable `activity_log` chat history available to the Execute tab.
+
 Studio's repo discovery model treats a local checkout as the primary repo identity. GitHub `owner/repo` should be derived from `git remote get-url origin`, and a suggested artifact root can be read from `**context-path**` in `AGENTS.md` or `CLAUDE.md`.
 
 Blocked launches return `accepted: false` plus a run record with `status: "blocked"` and explicit safety check failures.
@@ -360,6 +365,8 @@ Each completed run should also persist artifacts under:
   summary.md
   outputs/
 ```
+
+For the full execution/artifact contract, including restart recovery and archive edge cases, see [`docs/contracts/run-artifacts.md`](docs/contracts/run-artifacts.md).
 
 ### Stage and approve a GitHub sync
 

--- a/docs/contracts/run-artifacts.md
+++ b/docs/contracts/run-artifacts.md
@@ -36,7 +36,7 @@ Example fields:
 - `agent_type`
 
 ### `status.json`
-Current mutable snapshot.
+Current mutable snapshot and the authoritative restart-recovery record for execution runs.
 
 Example fields:
 
@@ -48,8 +48,25 @@ Example fields:
 - `progress_message`
 - `result`
 
+For execution runs, `status.json` is expected to carry the full `ExecutionRunRecord` snapshot used by `GET /api/execution/runs` after a server restart, including:
+
+- identity/provenance: `run_id`, `work_item_id`, `work_item_name`, `branch`, `base_ref`, `worktree_path`, `artifact_dir`
+- lifecycle state: `status`, `created_at`, `updated_at`, optional `started_at` / `completed_at` / `disposed_at`
+- user-visible detail fields: `progress_message`, `result_summary`, `changed_files`, `pull_request`, `errors`
+- durable chat/activity state: `activity_log`
+- launch safety context: `safety_checks`
+
+Loader behavior (`src/modules/execution/run-disk-store.ts`):
+
+- malformed JSON or snapshots missing required fields are skipped with a warning
+- snapshots with unknown execution statuses are skipped with a warning
+- disposed runs (`disposed_at != null`) are excluded from the live recent-runs hydration path by default
+- optional arrays/objects are sanitized so malformed entries do not poison restart recovery
+
 ### `events.jsonl`
 Append-only durable event log.
+
+`events.jsonl` is useful for forensics and richer timeline reconstruction, but the Studio execution UI currently rehydrates from `status.json` first. If the two disagree after a crash, `status.json` wins for recent-run list/detail hydration and `events.jsonl` remains best-effort diagnostic history.
 
 ### `summary.md`
 Human-readable completion summary where practical.
@@ -94,6 +111,40 @@ Follow-up interactions append to the existing `events.jsonl`:
 
 - `follow_up_sent` — when a steer/followUp message is accepted by an active session
 - `follow_up_turn_completed` — when a new-turn follow-up finishes
+
+The corresponding user/assistant messages must also be reflected in `status.json.activity_log` immediately so a crash between turns does not lose chat history from `GET /api/execution/runs/:runId/chat`.
+
+## Execution restart recovery
+
+On Studio boot, execution restart recovery follows this order:
+
+1. `WorkItemReconcilerService.runStartupReconcile()` scans `runs/<run_id>/status.json`.
+2. Any non-terminal execution run left in `queued`, `preparing`, `disambiguating`, or `running` is rewritten in place to `status: "error"`.
+3. The orphan rewrite appends an `activity_log` entry explaining that the run was orphaned by server restart and adds an `orphaned_by_restart` error.
+4. `ExecutionService.hydrateRecentRunsFromDisk()` reloads the newest live snapshots into the in-memory recent-runs buffer.
+
+This means operators can rely on the following restart semantics:
+
+- completed/error/blocked runs remain visible in the Execute tab after restart
+- runs that were active during a crash are preserved as errored runs with an explicit restart note instead of disappearing
+- completed-run metadata such as `result_summary`, `changed_files`, and `pull_request` survive as long as `status.json` survives
+- chat history survives when `activity_log` was flushed before the crash
+
+### Detail endpoint sources after restart
+
+| Endpoint | Primary source | Fallback / notes |
+|---------|----------------|------------------|
+| `GET /api/execution/runs` | live in-memory buffer rehydrated from `status.json` | capped to the service recent-run limit |
+| `GET /api/execution/runs/:runId/chat` | `status.json.activity_log` | only `user_message` / `agent_message` entries are surfaced |
+| `GET /api/execution/runs/:runId/scratchpad` | canonical `plans/<slug>/SCRATCHPAD_<slug>.md` | falls back to the surviving worktree scratchpad when canonical is absent |
+| `GET /api/execution/runs/:runId/checklist` | surviving worktree `SCRATCHPAD_<slug>.md` | best-effort only; returns an empty checklist if the worktree was cleaned up |
+
+### Archive/restart edge cases
+
+- Archived/disposed runs are intentionally excluded from the live recent-runs list after restart; they are surfaced through the archived-runs endpoints instead.
+- If only an archive bundle survives, the archived-runs readers can still expose summary/history data, but the live Execute tab should not resurrect the disposed run into `/api/execution/runs`.
+- Scratchpad restoration is strongest when the canonical plan file still exists; checklist restoration is strongest when the worktree still exists.
+- If a worktree has already been removed, `getRunChecklist()` may legitimately return an empty checklist even though the run summary, chat history, and PR metadata remain available.
 
 ## Archive bundle layout
 
@@ -196,3 +247,4 @@ See:
 - artifacts should be retained by default in V1
 - failed runs should still write terminal status, terminal event, and best-effort summary
 - when a PR is opened from a completed execution run, the run summary/status may also include the created PR URL for later browser refreshes
+- execution restart recovery is filesystem-backed in V1; no separate SQLite/index source of truth is required for recent-run hydration

--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { ExecutionService } from "../execution.service.js";
 import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+import { canonicalScratchpadPath } from "../../../lib/context-layout.js";
 
 function makeRun(runId: string, overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
   return {
@@ -262,6 +263,78 @@ describe("ExecutionService activity persistence", () => {
     expect(persisted.activity_log.at(-1)).toMatchObject({
       kind: "user_message",
       message: "Can you explain what failed?",
+    });
+  });
+});
+
+describe("ExecutionService run detail rehydration", () => {
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    artifactRoot = mkdtempSync(join(tmpdir(), "exec-detail-"));
+    mkdirSync(join(artifactRoot, "runs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  it("rehydrates recent run details from status.json, canonical scratchpads, and surviving worktrees", () => {
+    const runsDir = join(artifactRoot, "runs");
+    const worktreePath = join(artifactRoot, "worktrees", "studio-176-branch");
+    mkdirSync(worktreePath, { recursive: true });
+
+    const run = makeRun("run_detail", {
+      status: "completed",
+      updated_at: "2026-04-10T07:00:00.000Z",
+      worktree_path: worktreePath,
+      artifact_dir: join(runsDir, "run_detail"),
+      activity_log: [
+        { timestamp: "2026-04-10T06:00:00.000Z", kind: "user_message", message: "Please persist this run." },
+        { timestamp: "2026-04-10T06:05:00.000Z", kind: "agent_message", message: "Persistence is now durable." },
+      ],
+    });
+    writeRun(runsDir, run);
+
+    const canonicalPath = canonicalScratchpadPath(artifactRoot, run.work_item_id);
+    mkdirSync(dirname(canonicalPath), { recursive: true });
+    writeFileSync(canonicalPath, "canonical scratchpad content", "utf8");
+    writeFileSync(join(worktreePath, "SCRATCHPAD_studio_176.md"), [
+      "# Scratchpad",
+      "",
+      "## Implementation Plan",
+      "- [x] Persist run state",
+      "- [ ] Rehydrate detail endpoints",
+    ].join("\n"), "utf8");
+
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
+    service.hydrateRecentRunsFromDisk();
+
+    expect(service.listRecentRuns().map((candidate) => candidate.run_id)).toEqual(["run_detail"]);
+    expect(service.getRunChatHistory("run_detail").messages).toEqual([
+      {
+        timestamp: "2026-04-10T06:00:00.000Z",
+        role: "user",
+        text: "Please persist this run.",
+      },
+      {
+        timestamp: "2026-04-10T06:05:00.000Z",
+        role: "assistant",
+        text: "Persistence is now durable.",
+      },
+    ]);
+    expect(service.getRunScratchpad("run_detail")).toEqual({
+      run_id: "run_detail",
+      content: "canonical scratchpad content",
+    });
+    expect(service.getRunChecklist("run_detail")).toEqual({
+      run_id: "run_detail",
+      items: [
+        { text: "Persist run state", checked: true },
+        { text: "Rehydrate detail endpoints", checked: false },
+      ],
+      completed: 1,
+      total: 2,
     });
   });
 });

--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -34,6 +34,15 @@ function writeRun(runsDir: string, run: ExecutionRunRecord): void {
   writeFileSync(join(dir, "status.json"), JSON.stringify(run, null, 2), "utf8");
 }
 
+function makeServiceWithEmptyBuffer(artifactRoot: string): ExecutionService {
+  const service = Object.create(ExecutionService.prototype) as ExecutionService;
+  (service as any).logger = { log: vi.fn(), warn: vi.fn() };
+  (service as any).artifactRoot = artifactRoot;
+  (service as any).recentRuns = [];
+  (service as any).recentRunLimit = 16;
+  return service;
+}
+
 describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
   let artifactRoot: string;
 
@@ -46,22 +55,13 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
     rmSync(artifactRoot, { recursive: true, force: true });
   });
 
-  function makeServiceWithEmptyBuffer(): ExecutionService {
-    const service = Object.create(ExecutionService.prototype) as ExecutionService;
-    (service as any).logger = { log: vi.fn(), warn: vi.fn() };
-    (service as any).artifactRoot = artifactRoot;
-    (service as any).recentRuns = [];
-    (service as any).recentRunLimit = 16;
-    return service;
-  }
-
   it("loads completed runs from disk into recentRuns sorted newest-first", () => {
     const runsDir = join(artifactRoot, "runs");
     writeRun(runsDir, makeRun("run_a", { updated_at: "2026-04-01T00:00:00.000Z" }));
     writeRun(runsDir, makeRun("run_b", { updated_at: "2026-04-03T00:00:00.000Z" }));
     writeRun(runsDir, makeRun("run_c", { updated_at: "2026-04-02T00:00:00.000Z" }));
 
-    const service = makeServiceWithEmptyBuffer();
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
     service.hydrateRecentRunsFromDisk();
 
     expect((service as any).recentRuns.map((r: ExecutionRunRecord) => r.run_id)).toEqual([
@@ -75,7 +75,7 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
     const runsDir = join(artifactRoot, "runs");
     writeRun(runsDir, makeRun("run_a"));
 
-    const service = makeServiceWithEmptyBuffer();
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
     (service as any).recentRuns.push(makeRun("run_a", { progress_message: "already-tracked" }));
     service.hydrateRecentRunsFromDisk();
 
@@ -96,7 +96,7 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
       );
     }
 
-    const service = makeServiceWithEmptyBuffer();
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
     service.hydrateRecentRunsFromDisk();
 
     const runs = (service as any).recentRuns as ExecutionRunRecord[];
@@ -135,7 +135,7 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
     mkdirSync(malformedDir, { recursive: true });
     writeFileSync(join(malformedDir, "status.json"), JSON.stringify({ run_id: "run_malformed" }), "utf8");
 
-    const service = makeServiceWithEmptyBuffer();
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
     service.hydrateRecentRunsFromDisk();
 
     const runs = (service as any).recentRuns as ExecutionRunRecord[];
@@ -148,9 +148,121 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
 
   it("is a no-op when the runs dir does not exist", () => {
     rmSync(join(artifactRoot, "runs"), { recursive: true, force: true });
-    const service = makeServiceWithEmptyBuffer();
+    const service = makeServiceWithEmptyBuffer(artifactRoot);
     service.hydrateRecentRunsFromDisk();
     expect((service as any).recentRuns).toEqual([]);
+  });
+});
+
+describe("ExecutionService activity persistence", () => {
+  let artifactRoot: string;
+
+  beforeEach(() => {
+    artifactRoot = mkdtempSync(join(tmpdir(), "exec-activity-"));
+    mkdirSync(join(artifactRoot, "runs"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(artifactRoot, { recursive: true, force: true });
+  });
+
+  function makeService(run: ExecutionRunRecord): ExecutionService {
+    const service = Object.create(ExecutionService.prototype) as ExecutionService;
+    (service as any).logger = { log: vi.fn(), warn: vi.fn() };
+    (service as any).artifactRoot = artifactRoot;
+    (service as any).recentRuns = [run];
+    (service as any).recentRunLimit = 16;
+    (service as any).activeSessions = new Map();
+    (service as any).eventSubject = { next: vi.fn() };
+    (service as any).eventCounter = 0;
+    (service as any).streamId = "execution-runs";
+    (service as any).now = () => "2026-04-10T06:00:00.000Z";
+    (service as any).appendEvent = vi.fn();
+    (service as any).emitRun = vi.fn();
+    (service as any).extractTextFromMessage = (message: any) => message?.text ?? null;
+    return service;
+  }
+
+  it("flushes pushActivity updates to status.json so chat survives a restart", () => {
+    const runsDir = join(artifactRoot, "runs");
+    const run = makeRun("run_chat", {
+      status: "running",
+      artifact_dir: join(runsDir, "run_chat"),
+    });
+    writeRun(runsDir, run);
+
+    const service = makeService(run);
+    (service as any).pushActivity("run_chat", "user_message", "Please keep the summary short.");
+
+    const persisted = JSON.parse(readFileSync(join(runsDir, "run_chat", "status.json"), "utf8")) as ExecutionRunRecord;
+    expect(persisted.updated_at).toBe("2026-04-10T06:00:00.000Z");
+    expect(persisted.activity_log.at(-1)).toMatchObject({
+      kind: "user_message",
+      message: "Please keep the summary short.",
+    });
+
+    const restarted = makeServiceWithEmptyBuffer(artifactRoot);
+    restarted.hydrateRecentRunsFromDisk();
+    expect(restarted.getRunChatHistory("run_chat").messages).toEqual([
+      {
+        timestamp: "2026-04-10T06:00:00.000Z",
+        role: "user",
+        text: "Please keep the summary short.",
+      },
+    ]);
+  });
+
+  it("persists assistant message_end events into the durable activity log", () => {
+    const runsDir = join(artifactRoot, "runs");
+    const run = makeRun("run_agent", {
+      status: "running",
+      artifact_dir: join(runsDir, "run_agent"),
+    });
+    writeRun(runsDir, run);
+
+    const service = makeService(run);
+    (service as any).handleSessionEvent("run_agent", {
+      type: "message_end",
+      message: { text: "Implemented the restart recovery flow." } as any,
+    } as any);
+
+    const persisted = JSON.parse(readFileSync(join(runsDir, "run_agent", "status.json"), "utf8")) as ExecutionRunRecord;
+    expect(persisted.activity_log.at(-1)).toMatchObject({
+      kind: "agent_message",
+      message: "Implemented the restart recovery flow.",
+    });
+
+    const restarted = makeServiceWithEmptyBuffer(artifactRoot);
+    restarted.hydrateRecentRunsFromDisk();
+    expect(restarted.getRunChatHistory("run_agent").messages).toEqual([
+      {
+        timestamp: "2026-04-10T06:00:00.000Z",
+        role: "assistant",
+        text: "Implemented the restart recovery flow.",
+      },
+    ]);
+  });
+
+  it("persists follow-up user messages even when the run cannot accept them", async () => {
+    const runsDir = join(artifactRoot, "runs");
+    const run = makeRun("run_follow_up", {
+      status: "error",
+      artifact_dir: join(runsDir, "run_follow_up"),
+    });
+    writeRun(runsDir, run);
+
+    const service = makeService(run);
+    const result = await service.sendFollowUp({
+      run_id: "run_follow_up",
+      message: "Can you explain what failed?",
+    });
+
+    expect(result.accepted).toBe(false);
+    const persisted = JSON.parse(readFileSync(join(runsDir, "run_follow_up", "status.json"), "utf8")) as ExecutionRunRecord;
+    expect(persisted.activity_log.at(-1)).toMatchObject({
+      kind: "user_message",
+      message: "Can you explain what failed?",
+    });
   });
 });
 

--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -105,6 +105,47 @@ describe("ExecutionService.hydrateRecentRunsFromDisk", () => {
     expect(runs.at(-1)?.run_id).toBe("run_04");
   });
 
+  it("rehydrates completed and errored runs, while filtering disposed and malformed ones", () => {
+    const runsDir = join(artifactRoot, "runs");
+    writeRun(runsDir, makeRun("run_completed", {
+      updated_at: "2026-04-03T00:00:00.000Z",
+      result_summary: "done",
+      changed_files: ["src/a.ts"],
+      pull_request: {
+        number: 130,
+        url: "https://github.com/fusupo/escapement-studio/pull/130",
+        title: "feat: persist execution runs",
+        body: "Body",
+        base_ref: "develop",
+        head_ref: "studio-130-branch",
+        is_draft: false,
+        created_at: "2026-04-03T00:00:00.000Z",
+      },
+    }));
+    writeRun(runsDir, makeRun("run_error", {
+      status: "error",
+      updated_at: "2026-04-02T00:00:00.000Z",
+      errors: [{ code: "boom", message: "boom" }],
+    }));
+    writeRun(runsDir, makeRun("run_disposed", {
+      updated_at: "2026-04-04T00:00:00.000Z",
+      disposed_at: "2026-04-04T00:10:00.000Z",
+    }));
+    const malformedDir = join(runsDir, "run_malformed");
+    mkdirSync(malformedDir, { recursive: true });
+    writeFileSync(join(malformedDir, "status.json"), JSON.stringify({ run_id: "run_malformed" }), "utf8");
+
+    const service = makeServiceWithEmptyBuffer();
+    service.hydrateRecentRunsFromDisk();
+
+    const runs = (service as any).recentRuns as ExecutionRunRecord[];
+    expect(runs.map((run) => run.run_id)).toEqual(["run_completed", "run_error"]);
+    expect(runs[0].result_summary).toBe("done");
+    expect(runs[0].changed_files).toEqual(["src/a.ts"]);
+    expect(runs[0].pull_request?.number).toBe(130);
+    expect(runs[1].errors).toEqual([{ code: "boom", message: "boom" }]);
+  });
+
   it("is a no-op when the runs dir does not exist", () => {
     rmSync(join(artifactRoot, "runs"), { recursive: true, force: true });
     const service = makeServiceWithEmptyBuffer();
@@ -125,17 +166,40 @@ describe("ExecutionService.onModuleInit", () => {
     rmSync(artifactRoot, { recursive: true, force: true });
   });
 
-  it("runs the startup reconcile then rehydrates recentRuns", async () => {
+  it("runs the startup reconcile then rehydrates recentRuns from the rewritten disk state", async () => {
     const runsDir = join(artifactRoot, "runs");
     writeRun(runsDir, makeRun("run_completed", { status: "completed" }));
     writeRun(runsDir, makeRun("run_running", { status: "running" as ExecutionRunStatus }));
 
     const reconcilerStub = {
-      runStartupReconcile: vi.fn(async () => ({
-        reconciled: [],
-        orphans: [],
-        summary: { total: 0, orphans_rewritten: 1, next_actions: {} as any, generated_at: "" },
-      })),
+      runStartupReconcile: vi.fn(async () => {
+        const rewritten = {
+          ...makeRun("run_running", {
+            status: "running" as ExecutionRunStatus,
+            updated_at: "2026-04-10T00:00:00.000Z",
+          }),
+          status: "error",
+          updated_at: "2026-04-10T05:00:00.000Z",
+          completed_at: "2026-04-10T05:00:00.000Z",
+          progress_message: 'Orphaned by server restart at 2026-04-10T05:00:00.000Z (was "running").',
+          result_summary: "Orphaned by server restart at 2026-04-10T05:00:00.000Z.",
+          activity_log: [{
+            timestamp: "2026-04-10T05:00:00.000Z",
+            kind: "status_change",
+            message: "orphaned by server restart at 2026-04-10T05:00:00.000Z",
+          }],
+          errors: [{
+            code: "orphaned_by_restart",
+            message: 'Run was in status "running" when the Studio server restarted and could not be resumed.',
+          }],
+        } satisfies ExecutionRunRecord;
+        writeRun(runsDir, rewritten);
+        return {
+          reconciled: [],
+          orphans: [{ run_id: "run_running", previous_status: "running", rewritten_at: "2026-04-10T05:00:00.000Z" }],
+          summary: { total: 0, orphans_rewritten: 1, next_actions: {} as any, generated_at: "" },
+        };
+      }),
     };
 
     const service = Object.create(ExecutionService.prototype) as ExecutionService;
@@ -150,11 +214,14 @@ describe("ExecutionService.onModuleInit", () => {
 
     expect(reconcilerStub.runStartupReconcile).toHaveBeenCalledTimes(1);
     const runs = (service as any).recentRuns as ExecutionRunRecord[];
-    // Both runs ended up in recentRuns — the disk-rewrite of the running
-    // run is owned by runStartupReconcile (stubbed), so the raw file is
-    // untouched here. What matters for onModuleInit is that the buffer
-    // reflects whatever is on disk after that pass.
-    expect(runs.map((r) => r.run_id).sort()).toEqual(["run_completed", "run_running"]);
+    expect(runs.map((r) => r.run_id)).toEqual(["run_running", "run_completed"]);
+    expect(runs[0]).toMatchObject({
+      run_id: "run_running",
+      status: "error",
+      progress_message: expect.stringMatching(/Orphaned by server restart/),
+      result_summary: expect.stringMatching(/Orphaned by server restart/),
+      errors: [expect.objectContaining({ code: "orphaned_by_restart" })],
+    });
   });
 
   it("swallows reconcile errors and still rehydrates", async () => {

--- a/src/modules/execution/__tests__/run-disk-store.test.ts
+++ b/src/modules/execution/__tests__/run-disk-store.test.ts
@@ -92,6 +92,68 @@ describe("loadRunRecordsFromDisk", () => {
     expect(records).toEqual([]);
     expect(warn).toHaveBeenCalled();
   });
+
+  it("skips records with unknown statuses", () => {
+    const runDir = join(runsDir, "weird_status");
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, "status.json"), JSON.stringify({
+      ...makeRun("weird_status"),
+      status: "mystery_state",
+    }), "utf8");
+
+    const warn = vi.fn();
+    const records = loadRunRecordsFromDisk(runsDir, { onWarn: warn });
+    expect(records).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/did not match ExecutionRunRecord shape/));
+  });
+
+  it("filters disposed runs by default but can include them explicitly", () => {
+    writeRunStatus(runsDir, makeRun("run_live", { updated_at: "2026-04-10T01:00:00.000Z" }));
+    writeRunStatus(runsDir, makeRun("run_disposed", {
+      updated_at: "2026-04-10T02:00:00.000Z",
+      disposed_at: "2026-04-10T03:00:00.000Z",
+    }));
+
+    expect(loadRunRecordsFromDisk(runsDir).map((record) => record.run_id)).toEqual(["run_live"]);
+    expect(loadRunRecordsFromDisk(runsDir, { includeDisposed: true }).map((record) => record.run_id)).toEqual([
+      "run_disposed",
+      "run_live",
+    ]);
+  });
+
+  it("sanitizes optional persisted fields while preserving completed-run metadata", () => {
+    writeRunStatus(runsDir, makeRun("run_completed", {
+      result_summary: "Finished successfully.",
+      changed_files: ["src/a.ts", 123 as unknown as string, "src/b.ts"],
+      activity_log: [
+        { timestamp: "2026-04-10T00:00:00.000Z", kind: "agent_message", message: "hello" },
+        { nope: true } as unknown as ExecutionRunRecord["activity_log"][number],
+      ],
+      pull_request: {
+        number: 130,
+        url: "https://github.com/fusupo/escapement-studio/pull/130",
+        title: "feat: persist runs",
+        body: "Body",
+        base_ref: "develop",
+        head_ref: "studio-130-branch",
+        is_draft: false,
+        created_at: "2026-04-10T00:00:00.000Z",
+      },
+      errors: [
+        { code: "kept", message: "kept" },
+        { code: 42, message: null } as unknown as NonNullable<ExecutionRunRecord["errors"]>[number],
+      ],
+    }));
+
+    const [record] = loadRunRecordsFromDisk(runsDir);
+    expect(record.result_summary).toBe("Finished successfully.");
+    expect(record.changed_files).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(record.activity_log).toEqual([
+      { timestamp: "2026-04-10T00:00:00.000Z", kind: "agent_message", message: "hello", detail: undefined },
+    ]);
+    expect(record.pull_request?.number).toBe(130);
+    expect(record.errors).toEqual([{ code: "kept", message: "kept" }]);
+  });
 });
 
 describe("detectAndMarkOrphans", () => {

--- a/src/modules/execution/__tests__/scratchpad-canonical.test.ts
+++ b/src/modules/execution/__tests__/scratchpad-canonical.test.ts
@@ -25,6 +25,7 @@ interface HarnessService {
   warnings: string[];
   syncScratchpadToCanonical: ExecutionService["syncScratchpadToCanonical"];
   getRunScratchpad: ExecutionService["getRunScratchpad"];
+  getRunChecklist: ExecutionService["getRunChecklist"];
   writeScratchpad: (
     run: ExecutionRunRecord,
     node: ExecutionDispatchNodePreview,
@@ -188,6 +189,36 @@ describe("ExecutionService scratchpad canonical flow", () => {
       const service = makeService(tmpRoot);
       const result = service.getRunScratchpad("nonexistent");
       expect(result.content).toBe(null);
+    });
+  });
+
+  describe("getRunChecklist", () => {
+    it("reconstructs checklist state from the surviving worktree scratchpad", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeService(tmpRoot, run);
+
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), [
+        "# Scratchpad",
+        "",
+        "## Implementation Plan",
+        "- [x] Finish persistence layer",
+        "- [ ] Verify restart hydration",
+        "",
+        "## Work Log",
+      ].join("\n"), "utf8");
+
+      expect(service.getRunChecklist("exec_test")).toEqual({
+        run_id: "exec_test",
+        items: [
+          { text: "Finish persistence layer", checked: true },
+          { text: "Verify restart hydration", checked: false },
+        ],
+        completed: 1,
+        total: 2,
+      });
     });
   });
 

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -203,8 +203,7 @@ export class ExecutionService implements OnModuleInit {
    * exercise the rehydration path independently of `onModuleInit`.
    */
   hydrateRecentRunsFromDisk(): void {
-    const runsDir = join(this.artifactRoot, "runs");
-    const loaded = loadRunRecordsFromDisk(runsDir);
+    const loaded = loadRunRecordsForArtifactRoot(this.artifactRoot);
     const existingIds = new Set(this.recentRuns.map((run) => run.run_id));
     for (const run of loaded) {
       if (existingIds.has(run.run_id)) continue;

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1420,12 +1420,21 @@ export class ExecutionService implements OnModuleInit {
   }
 
   private pushActivity(runId: string, kind: ActivityLogEntryKind, message: string, detail?: string) {
-    const run = this.getRun(runId);
-    if (!run) {
+    const index = this.recentRuns.findIndex((candidate) => candidate.run_id === runId);
+    if (index === -1) {
       return;
     }
-    const entry: ActivityLogEntry = { timestamp: this.now(), kind, message, ...(detail ? { detail } : {}) };
-    run.activity_log.push(entry);
+
+    const timestamp = this.now();
+    const entry: ActivityLogEntry = { timestamp, kind, message, ...(detail ? { detail } : {}) };
+    const nextRun: ExecutionRunRecord = {
+      ...this.recentRuns[index],
+      updated_at: timestamp,
+      activity_log: [...this.recentRuns[index]!.activity_log, entry],
+    };
+
+    this.recentRuns[index] = nextRun;
+    this.writeStatus(nextRun);
   }
 
   private resolveLaunchEligibility(

--- a/src/modules/execution/run-disk-store.ts
+++ b/src/modules/execution/run-disk-store.ts
@@ -1,7 +1,13 @@
 import { existsSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { runsRoot } from "../../lib/context-layout.js";
-import type { ActivityLogEntry, ExecutionRunRecord, ExecutionRunStatus } from "./types.js";
+import type {
+  ActivityLogEntry,
+  ExecutionPullRequestRecord,
+  ExecutionRunRecord,
+  ExecutionRunStatus,
+  ExecutionSafetyCheck,
+} from "./types.js";
 
 /**
  * Issue #176: pure filesystem helpers for reading and rewriting execution
@@ -17,6 +23,16 @@ import type { ActivityLogEntry, ExecutionRunRecord, ExecutionRunStatus } from ".
  * via `runsRoot(artifactRoot)` (from `src/lib/context-layout.ts`) and
  * pass them in directly. This keeps unit tests free of Nest bootstrapping.
  */
+
+const VALID_RUN_STATUSES: ReadonlySet<ExecutionRunStatus> = new Set<ExecutionRunStatus>([
+  "queued",
+  "blocked",
+  "preparing",
+  "disambiguating",
+  "running",
+  "completed",
+  "error",
+]);
 
 const NON_TERMINAL_STATUSES: ReadonlySet<ExecutionRunStatus> = new Set<ExecutionRunStatus>([
   "queued",
@@ -270,28 +286,117 @@ export function coerceRecord(raw: unknown): ExecutionRunRecord | null {
 
   if (typeof record.run_id !== "string" || !record.run_id) return null;
   if (typeof record.work_item_id !== "string" || !record.work_item_id) return null;
-  if (typeof record.status !== "string") return null;
-  if (typeof record.updated_at !== "string") return null;
+  if (typeof record.status !== "string" || !VALID_RUN_STATUSES.has(record.status as ExecutionRunStatus)) return null;
+  if (typeof record.updated_at !== "string" || !record.updated_at) return null;
   if (typeof record.branch !== "string") return null;
   if (typeof record.artifact_dir !== "string") return null;
 
-  const activityLog = Array.isArray(record.activity_log) ? (record.activity_log as ActivityLogEntry[]) : [];
-  const safetyChecks = Array.isArray(record.safety_checks) ? record.safety_checks : [];
+  const activityLog = Array.isArray(record.activity_log)
+    ? record.activity_log.map(coerceActivityLogEntry).filter((entry): entry is ActivityLogEntry => entry != null)
+    : [];
+  const safetyChecks = Array.isArray(record.safety_checks)
+    ? record.safety_checks.map(coerceSafetyCheck).filter((check): check is ExecutionSafetyCheck => check != null)
+    : [];
+  const changedFiles = Array.isArray(record.changed_files)
+    ? record.changed_files.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : undefined;
+  const errors = Array.isArray(record.errors)
+    ? record.errors.map(coerceRunError).filter((entry): entry is NonNullable<ExecutionRunRecord["errors"]>[number] => entry != null)
+    : undefined;
+  const pullRequest = coercePullRequestRecord(record.pull_request);
 
-  // Pass through the raw parsed object with required fields verified and
-  // defaults filled for list/object fields. The cast is narrowing — we've
-  // verified the string fields above and the two array fields here.
   return {
-    run_type: (record.run_type as ExecutionRunRecord["run_type"]) ?? "execution",
+    ...record,
+    run_type: "execution",
     work_item_name: (record.work_item_name as string) ?? record.work_item_id as string,
+    status: record.status as ExecutionRunStatus,
     created_at: (record.created_at as string) ?? (record.updated_at as string),
     base_ref: (record.base_ref as string) ?? "",
     worktree_path: (record.worktree_path as string) ?? "",
     prompt: (record.prompt as string) ?? "",
-    ...record,
+    repo: typeof record.repo === "string" ? record.repo : null,
+    issue_url: typeof record.issue_url === "string" ? record.issue_url : null,
+    started_at: typeof record.started_at === "string" ? record.started_at : undefined,
+    completed_at: typeof record.completed_at === "string" ? record.completed_at : undefined,
+    disposed_at: typeof record.disposed_at === "string" ? record.disposed_at : record.disposed_at === null ? null : undefined,
+    session_id: typeof record.session_id === "string" ? record.session_id : undefined,
+    progress_message: typeof record.progress_message === "string" ? record.progress_message : undefined,
+    result_summary: typeof record.result_summary === "string" ? record.result_summary : undefined,
     activity_log: activityLog,
-    safety_checks: safetyChecks as ExecutionRunRecord["safety_checks"],
+    safety_checks: safetyChecks,
+    changed_files: changedFiles,
+    pull_request: pullRequest,
+    errors,
   } as ExecutionRunRecord;
+}
+
+function coerceActivityLogEntry(raw: unknown): ActivityLogEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const entry = raw as Record<string, unknown>;
+  if (typeof entry.timestamp !== "string" || typeof entry.kind !== "string" || typeof entry.message !== "string") {
+    return null;
+  }
+  return {
+    timestamp: entry.timestamp,
+    kind: entry.kind as ActivityLogEntry["kind"],
+    message: entry.message,
+    detail: typeof entry.detail === "string" ? entry.detail : undefined,
+  };
+}
+
+function coerceSafetyCheck(raw: unknown): ExecutionSafetyCheck | null {
+  if (!raw || typeof raw !== "object") return null;
+  const check = raw as Record<string, unknown>;
+  if (typeof check.code !== "string" || typeof check.status !== "string" || typeof check.message !== "string") {
+    return null;
+  }
+  if (check.status !== "pass" && check.status !== "warn" && check.status !== "fail") {
+    return null;
+  }
+  return {
+    code: check.code,
+    status: check.status,
+    message: check.message,
+  };
+}
+
+function coerceRunError(raw: unknown): NonNullable<ExecutionRunRecord["errors"]>[number] | null {
+  if (!raw || typeof raw !== "object") return null;
+  const error = raw as Record<string, unknown>;
+  if (typeof error.code !== "string" || typeof error.message !== "string") {
+    return null;
+  }
+  return { code: error.code, message: error.message };
+}
+
+function coercePullRequestRecord(raw: unknown): ExecutionPullRequestRecord | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const record = raw as Record<string, unknown>;
+  if (
+    typeof record.number !== "number" ||
+    typeof record.url !== "string" ||
+    typeof record.title !== "string" ||
+    typeof record.body !== "string" ||
+    typeof record.base_ref !== "string" ||
+    typeof record.head_ref !== "string" ||
+    typeof record.is_draft !== "boolean" ||
+    typeof record.created_at !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    number: record.number,
+    url: record.url,
+    title: record.title,
+    body: record.body,
+    base_ref: record.base_ref,
+    head_ref: record.head_ref,
+    is_draft: record.is_draft,
+    created_at: record.created_at,
+    state: typeof record.state === "string" ? record.state : undefined,
+    merged_at: typeof record.merged_at === "string" || record.merged_at === null ? record.merged_at : undefined,
+    merge_commit_sha: typeof record.merge_commit_sha === "string" || record.merge_commit_sha === null ? record.merge_commit_sha : undefined,
+  };
 }
 
 function formatError(error: unknown): string {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -88,6 +88,13 @@ export interface LaunchExecutionRunDto {
   disambiguate?: boolean;
 }
 
+/**
+ * Durable execution-run snapshot persisted to `runs/<run_id>/status.json`.
+ *
+ * This record is the restart-recovery source of truth for the Execute tab:
+ * `ExecutionService` rehydrates recent runs from these snapshots on boot,
+ * and orphan detection rewrites previously non-terminal snapshots in place.
+ */
 export interface ExecutionRunRecord {
   run_id: string;
   run_type: "execution";


### PR DESCRIPTION
## Summary
Done.

### What I changed

**Persistence + rehydration**
- `src/modules/execution/run-disk-store.ts`
  - Hardened `status.json` coercion/validation
  - Rejects unknown statuses/malformed required fields
  - Sanitizes optional persisted fields
  - Preserves completed-run metadata (`result_summary`, `changed_files`, `pull_request`, `errors`, `activity_log`)
  - Keeps disposed runs out of live hydration by default

- `src/modules/execution/execution.service.ts`
  - `hydrateRecentRunsFromDisk()` now uses the artifact-root loader helper
  - `pushActivity()` now immediately rewrites `status.json`, updating `updated_at`, so chat/activity survives crashes and restarts

- `src/modules/execution/types.ts`
  - Documented `ExecutionRunRecord` as the durable restart snapshot contract

**Tests**
- `src/modules/execution/__tests__/run-disk-store.test.ts`
  - Added coverage for unknown statuses, disposed filtering, and sanitized persisted metadata

- `src/modules/execution/__tests__/execution-rehydrate.test.ts`
  - Added restart-hydration coverage for completed/errored/disposed/malformed runs
  - Added orphan-rewrite startup coverage
  - Added crash-survival tests for user messages, assistant `message_end` chat, and follow-up messages
  - Added end-to-end-style detail rehydration coverage for recent runs, chat, scratchpad, and checklist

- `src/modules/execution/__tests__/scratchpad-canonical.test.ts`
  - Added direct checklist reconstruction coverage from surviving worktree scratchpads

**Docs**
- `docs/contracts/run-artifacts.md`
  - Documented `status.json` as the authoritative restart source
  - Added orphan rewrite semantics
  - Added detail-endpoint source order
  - Added archive/restart edge cases

- `README.md`
  - Added restart-persistence manual verification steps
  - Documented execution-run restart behavior

### Commits
- `1ab59ef` `fix(execution): harden run snapshot rehydration`
- `e7bcbec` `fix(execution): persist live activity updates`
- `d0b8994` `test(execution): cover detail rehydration`
- `51cc03d` `docs(execution): document restart persistence`

### Tests/checks run

**Passed**
- `npm run check`
- `npx vitest run src/modules/execution/__tests__/execution-rehydrate.test.ts src/modules/execution/__tests__/run-disk-store.test.ts`
- `npx vitest run src/modules/execution/__tests__/execution-rehydrate.test.ts src/modules/execution/__tests__/run-disk-store.test.ts src/modules/execution/__tests__/scratchpad-canonical.test.ts`
- `npm run build:web`  
  - built successfully
  - emitted existing Svelte a11y/CSS warnings

**Failed / blocked**
- `npm test`
  - fails in unrelated graph/manifest suites because `better-sqlite3` native bindings are missing in this worktree

### Remaining blockers / follow-up
- Environment blocker: full Vitest suite cannot pass here until `better-sqlite3` bindings are available.
- No code blockers remain for `studio-130` itself.

actual_files synced: 0 file(s).

## Context
- Work item: studio-130
- Issue: https://github.com/fusupo/escapement-studio/issues/130
- Base branch: develop
- Head branch: studio-130-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775978492916
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-130-branch
- Scope hint: Persist execution run records and rehydrate recent runs, status, and artifact-backed context after server restart.

## Changed files
- (not recorded)