### PR TITLE
[#140] Studio: add Launch execution action to the node details panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,23 +99,26 @@ This runs the server TypeScript check plus the production frontend build.
 19. Approve the staged GitHub sync and confirm only the managed `studio-sync` issue body block changes.
 20. Review the execution dispatch panel and confirm it loads a dispatch preview from `GET /api/execution/preview`.
 21. Confirm each dispatchable node shows worktree/branch safety checks before launch.
-22. Launch a dispatchable execution run and confirm status updates stream into the browser from `GET /api/execution/stream`.
-23. Confirm the launched run creates an isolated worktree under the configured repo artifact root (for example `/home/marc/escapement-studio-ctx/worktrees/`) and artifacts under the matching repo artifact root `runs/` directory.
-24. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
-25. Confirm the completed execution run auto-populates the related work item `actual_files` from the recorded `changed_files`.
-26. Restart the Studio server after a completed execution run and confirm the Execute tab still shows the recent run, including `result_summary`, changed files, PR metadata, chat history, and canonical scratchpad content.
-27. Restart the Studio server while an execution run is still active and confirm the run is rehydrated as `error` with an explicit orphan/restart note instead of disappearing.
-28. If the worktree still exists, open the run checklist after restart and confirm it is reconstructed from the worktree scratchpad.
-29. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
-30. Ask the planner to delegate a `reconciliation-analyst` or call `reconciliation_query`, then stage a planning-memory update based on the reported drift and approve it through the existing memory approval flow.
-31. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
-32. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
-33. Verify the graph view still loads data from `/api/graph`.
-34. Select a node to edit it in the sidebar.
-35. Create a new work item in the sidebar and confirm it appears in the graph.
-36. Create an edge between two nodes and confirm it appears in the graph and edge list.
-37. Delete an edge from the sidebar.
-38. Change repo/state/track/phase filters and confirm the rendered graph updates.
+22. In the planning graph, select an eligible issue-backed node and confirm the details sidebar Execution card clearly identifies the selected node and shows an enabled **Launch execution** action.
+23. Select a blocked issue-backed node and confirm the same Execution card keeps the selected-node context visible while showing the backend-provided launch-unavailable reason.
+24. Select a non-issue node (for example a track, phase, or capability) and confirm the Execution card explains that launch is only available for issue-backed work items and does not show the **Launch execution** button.
+25. Launch a dispatchable execution run from the details sidebar and confirm status updates stream into the browser from `GET /api/execution/stream` and the app switches into the Execute tab.
+26. Confirm the launched run creates an isolated worktree under the configured repo artifact root (for example `/home/marc/escapement-studio-ctx/worktrees/`) and artifacts under the matching repo artifact root `runs/` directory.
+27. Trigger a blocked launch condition (for example, reuse an existing branch/worktree) and confirm the browser shows a blocked execution run with clear safety errors.
+28. Confirm the completed execution run auto-populates the related work item `actual_files` from the recorded `changed_files`.
+29. Restart the Studio server after a completed execution run and confirm the Execute tab still shows the recent run, including `result_summary`, changed files, PR metadata, chat history, and canonical scratchpad content.
+30. Restart the Studio server while an execution run is still active and confirm the run is rehydrated as `error` with an explicit orphan/restart note instead of disappearing.
+31. If the worktree still exists, open the run checklist after restart and confirm it is reconstructed from the worktree scratchpad.
+32. Open the reconciliation panel and confirm `GET /api/reconciliation/reports` shows matches, missed predicted files, unpredicted actual files, and drift summaries for reconciled work items.
+33. Ask the planner to delegate a `reconciliation-analyst` or call `reconciliation_query`, then stage a planning-memory update based on the reported drift and approve it through the existing memory approval flow.
+34. Ask the planner to revise or reject the current graph, memory, or GitHub sync proposal from the browser and confirm the follow-up stays in the same planner conversation.
+35. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
+36. Verify the graph view still loads data from `/api/graph`.
+37. Select a node to edit it in the sidebar.
+38. Create a new work item in the sidebar and confirm it appears in the graph.
+39. Create an edge between two nodes and confirm it appears in the graph and edge list.
+40. Delete an edge from the sidebar.
+41. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks
 

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -209,6 +209,10 @@
     graphContextMenu = { open: false, x: 0, y: 0, item: null };
   }
 
+  function leafState(state) {
+    return state?.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
+  }
+
   function normalizeLaunchEligibilityError(workItemId, message) {
     return {
       work_item_id: workItemId,
@@ -586,21 +590,28 @@
     launchingExecution = true;
     error = "";
     try {
+      const itemLeafState = leafState(item?.state);
       // ADR 014 step 8 — stricter UI gate than the backend: require work
       // item state to be `ready` so users can't skip plan approval via the
       // UI, even though the backend still accepts `planned` as a
       // transitional fallback.
-      if (item?.state !== "ready") {
+      if (itemLeafState !== "ready") {
         error = `Approve the plan first — work item state is ${item?.state ?? "unknown"}, expected ready.`;
         return;
       }
+
       const eligibility = await ensureLaunchEligibility(workItemId, { force: true });
+      if (!eligibility?.issue_backed) {
+        error = "Launch execution is only available for issue-backed work items.";
+        return;
+      }
       if (!eligibility?.can_launch) {
         error = eligibility?.launch_unavailable_reason || "Launch execution is not available for this node.";
         return;
       }
 
       const result = await launchExecutionRun({ work_item_id: workItemId, disambiguate: true });
+      await ensureLaunchEligibility(workItemId, { force: true });
       closeGraphContextMenu();
       if (result?.run) {
         activeTab = "execute";

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -214,10 +214,19 @@
   $: showApprovePlan = planSubState === "drafting";
   $: showReviewPlan = planSubState === "drafting" || planSubState === "ready";
   $: launchStateOk = leafState(selectedItem?.state) === "ready";
-  $: launchDisabled = !launchEligibility?.can_launch
+  $: launchIssueBacked = !!launchEligibility?.issue_backed;
+  $: launchAvailable = !!launchEligibility?.can_launch && launchStateOk && launchIssueBacked;
+  $: launchDisabled = !launchAvailable
     || launchEligibilityLoading
-    || launchingExecution
-    || !launchStateOk;
+    || launchingExecution;
+  $: selectedExecutionLabel = selectedItem?.name || selectedItem?.id || "Selected node";
+  $: selectedExecutionMeta = [
+    selectedItem?.id,
+    selectedItem?.kind,
+    selectedItem?.issue_number && selectedItem?.repo
+      ? `#${selectedItem.issue_number} in ${selectedItem.repo}`
+      : null,
+  ].filter(Boolean);
 
   $: if (!selectedItem && edgeForm.from_id && !graph.items.some((item) => item.id === edgeForm.from_id)) {
     edgeForm = { ...defaultEdge };
@@ -372,26 +381,35 @@
           </div>
         {/if}
 
+        <p><strong>{selectedExecutionLabel}</strong></p>
+        {#if selectedExecutionMeta.length > 0}
+          <p class="muted">{selectedExecutionMeta.join(" · ")}</p>
+        {/if}
+
         {#if launchEligibilityLoading}
           <p class="muted">Checking frontier eligibility…</p>
         {:else if launchEligibility}
-          <span class="status-pill {launchEligibility.can_launch && launchStateOk ? 'healthy' : 'warn'}">{launchEligibility.can_launch && launchStateOk ? 'dispatchable' : 'blocked'}</span>
-          {#if launchEligibility.dispatch_node}
+          <span class="status-pill {launchAvailable ? 'healthy' : 'warn'}">{launchAvailable ? 'dispatchable' : 'blocked'}</span>
+          {#if launchIssueBacked && launchEligibility.dispatch_node}
             <p class="muted">
               Branch <code>{launchEligibility.dispatch_node.branch}</code>
               · Base <code>{launchEligibility.dispatch_node.default_base_ref}</code>
             </p>
           {/if}
-          {#if !launchEligibility.can_launch && launchEligibility.launch_unavailable_reason}
+          {#if !launchIssueBacked}
+            <p class="muted">Execution launch is only available for issue-backed work items.</p>
+          {:else if !launchEligibility.can_launch && launchEligibility.launch_unavailable_reason}
             <p class="muted">{launchEligibility.launch_unavailable_reason}</p>
           {:else if launchEligibility.can_launch && !launchStateOk}
             <p class="muted">Approve the plan first — work item state is {selectedItem?.state ?? "unknown"}, expected <code>ready</code>.</p>
-          {:else if launchEligibility.can_launch && launchStateOk}
-            <p class="muted">This node is currently on the frontier and can be launched into execution.</p>
+          {:else if launchAvailable}
+            <p class="muted">Launch execution will start a run for this selected node.</p>
           {/if}
-          <button on:click={() => onLaunchExecution(selectedItem)} disabled={launchDisabled}>
-            {launchingExecution ? "Launching..." : "Launch execution"}
-          </button>
+          {#if launchIssueBacked}
+            <button on:click={() => onLaunchExecution(selectedItem)} disabled={launchDisabled}>
+              {launchingExecution ? "Launching..." : "Launch execution"}
+            </button>
+          {/if}
         {:else}
           <p class="muted">Select a node to inspect execution availability.</p>
         {/if}


### PR DESCRIPTION
## Summary
Done.

### What I changed

**`web/src/components/Sidebar.svelte`**
- Updated the Execution card to:
  - clearly identify the selected node being acted on
  - only show **Launch execution** for issue-backed selections
  - keep blocked reason messaging visible for issue-backed items that cannot launch
  - show a non-action explanation for non-issue-backed selections

**`web/src/App.svelte`**
- Hardened the shared launch handler to:
  - normalize selected work-item state before enforcing `ready`
  - reject non-issue-backed launches before dispatch
  - continue using the existing eligibility lookup + launch flow
  - refresh launch eligibility after launch attempts so sidebar state stays aligned

**`README.md`**
- Expanded the manual verification checklist to cover:
  - eligible issue-backed node from the details panel
  - blocked issue-backed node messaging
  - non-issue node behavior with no launch CTA
  - launch-from-details-panel flow switching into the Execute tab

### Commits made

- `feat(sidebar): gate node launch action on issue-backed items`
- `fix(execution): enforce issue-backed details launches`
- `docs(readme): cover details-panel execution launch checks`

### Checks run

Ran after each significant change and again at the end:

- `npm run check` — passed
- `npm test` — failed consistently in this worktree because `better-sqlite3` native bindings are missing
- `npm run build:web` — passed

### Remaining blockers / follow-up

- **Environment blocker:** `npm test` is currently failing due missing `better-sqlite3` native bindings, not because of this UI change.
- **Follow-up recommended:** manual browser verification of the new details-panel launch behavior against a live server, per the updated README steps.

actual_files synced: 0 file(s).

## Context
- Work item: studio-140
- Issue: https://github.com/fusupo/escapement-studio/issues/140
- Base branch: develop
- Head branch: studio-140-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1775982163444
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-140-branch
- Scope hint: Add a launch-execution action to the selected node details panel for eligible issue-backed work items.

## Changed files
- (not recorded)