### PR TITLE
[#137] Studio: delete junk work items by deleting the GitHub issue and removing the graph item with safeguards

### DIFF
--- a/src/__tests__/graph-node-actions.test.ts
+++ b/src/__tests__/graph-node-actions.test.ts
@@ -57,6 +57,14 @@ describe("buildGraphNodeContextMenu", () => {
         disabled: false,
         emphasis: "primary",
       },
+      {
+        id: "delete-work-item",
+        kind: "button",
+        label: "Delete work item",
+        description: "Destructive delete. Removes the GitHub issue when possible and deletes the Studio node instead of cancelling it.",
+        disabled: false,
+        emphasis: "danger",
+      },
     ]);
   });
 

--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -10,7 +10,7 @@ import {
   ensurePlanDir,
   planDir,
 } from "../../../lib/context-layout.js";
-import type { ExecutionDispatchPreview, ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+import type { DeleteWorkItemResult, ExecutionDispatchPreview, ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
 import type { DispatchResult, WorkItemRecord, WorkItemState } from "../../graph/types.js";
 
 /**
@@ -28,6 +28,8 @@ interface HarnessService {
   workItemsService: {
     get: (id: string) => WorkItemRecord;
     update: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
+    getConnectedEdges: (id: string) => Array<{ id: number; from_id: string; rel: string; to_id: string }>;
+    deleteWithConnectedEdges: (id: string, edgeIds: number[]) => { deleted: true; id: string; removed_edge_ids: number[] };
   };
   listRecentRuns: () => ExecutionRunRecord[];
 
@@ -39,6 +41,7 @@ interface HarnessService {
   // studio-87 close flow deps
   githubService: {
     closeIssue: ReturnType<typeof vi.fn>;
+    deleteIssue: ReturnType<typeof vi.fn>;
   };
   // studio-197 write-through
   githubBatchCache: {
@@ -56,6 +59,7 @@ interface HarnessService {
   closeMergedPullRequest: ExecutionService["closeMergedPullRequest"];
   archiveAndCloseMergedPullRequest: ExecutionService["archiveAndCloseMergedPullRequest"];
   cancelWorkItem: ExecutionService["cancelWorkItem"];
+  deleteWorkItem: ExecutionService["deleteWorkItem"];
   // Private helpers exposed via prototype for direct testing
   assertWorkItemInMergedPr: (id: string) => WorkItemRecord;
   assertNoActiveRunForWorkItem: (id: string) => void;
@@ -134,6 +138,10 @@ function makeService(params: {
   workItem?: WorkItemRecord;
   runs?: ExecutionRunRecord[];
   githubCloseIssue?: ReturnType<typeof vi.fn>;
+  githubDeleteIssue?: ReturnType<typeof vi.fn>;
+  connectedEdges?: Array<{ id: number; from_id: string; rel: string; to_id: string }>;
+  deleteWithConnectedEdges?: ReturnType<typeof vi.fn>;
+  deletePlanArtifacts?: ReturnType<typeof vi.fn>;
   updateImpl?: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
   hsmDispatch?: ReturnType<typeof vi.fn>;
 }): HarnessService {
@@ -142,6 +150,7 @@ function makeService(params: {
 
   service.artifactRoot = params.artifactRoot;
   service.logger = { log: vi.fn(), warn: vi.fn() };
+  const connectedEdges = params.connectedEdges ?? [];
   service.workItemsService = {
     get: (id: string) => {
       if (id !== currentWorkItem.id) {
@@ -160,6 +169,13 @@ function makeService(params: {
       currentWorkItem = { ...currentWorkItem, ...patch, updated_at: "2026-04-09T00:00:01.000Z" };
       return currentWorkItem;
     },
+    getConnectedEdges: (id: string) => (id === currentWorkItem.id ? connectedEdges : []),
+    deleteWithConnectedEdges: (params.deleteWithConnectedEdges ?? vi.fn((id: string, edgeIds: number[]) => {
+      if (id !== currentWorkItem.id) {
+        throw new NotFoundException(`Work item not found: ${id}`);
+      }
+      return { deleted: true as const, id, removed_edge_ids: [...edgeIds].sort((a, b) => a - b) };
+    })) as HarnessService["workItemsService"]["deleteWithConnectedEdges"],
   };
 
   // studio-87 close-flow deps. recentRuns is the real in-memory buffer
@@ -179,6 +195,7 @@ function makeService(params: {
         assignees: [],
         body_hash: "hash",
       })),
+    deleteIssue: params.githubDeleteIssue ?? vi.fn(async (repo: string, issueNumber: number) => ({ repo, number: issueNumber, deleted: true })),
   };
   // Stub filesystem + event emission so we don't need real artifact dirs
   // or a live Subject. The real method delegates to node:fs / rxjs.
@@ -221,6 +238,9 @@ function makeService(params: {
     upsertIssue: vi.fn(),
     invalidate: vi.fn(),
     invalidateAll: vi.fn(),
+  };
+  (service as unknown as { plansService: { deletePlanArtifacts: ReturnType<typeof vi.fn> } }).plansService = {
+    deletePlanArtifacts: params.deletePlanArtifacts ?? vi.fn(() => ({ removed: false, path: null })),
   };
 
   return service;
@@ -295,6 +315,86 @@ describe("ADR 014 step 7: disposition flow", () => {
         );
       },
     );
+  });
+
+  describe("deleteWorkItem", () => {
+    it("deletes an eligible issue-backed work item, cleans plan artifacts, and removes connected edges", async () => {
+      const deletePlanArtifacts = vi.fn(() => ({ removed: true, path: "/tmp/plans/studio-157" }));
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "drafting" }),
+        connectedEdges: [
+          { id: 11, from_id: "studio-157", rel: "depends_on", to_id: "studio-200" },
+        ],
+        deletePlanArtifacts,
+      });
+
+      const result = await service.deleteWorkItem({
+        work_item_id: "studio-157",
+        confirm_delete: true,
+        acknowledge_connected_edges: true,
+      });
+
+      expect(service.githubService.deleteIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 157);
+      expect(deletePlanArtifacts).toHaveBeenCalledWith("studio-157");
+      expect(service.workItemsService.deleteWithConnectedEdges).toHaveBeenCalledWith("studio-157", [11]);
+      expect(result).toMatchObject({
+        deleted: true,
+        graph: { deleted: true, removed_edge_ids: [11] },
+        github_issue: { attempted: true, deleted: true, fallback_used: false, message: null },
+        plan_cleanup: { removed: true, path: "/tmp/plans/studio-157" },
+        warnings: [],
+      } satisfies Partial<DeleteWorkItemResult>);
+    });
+
+    it("rejects delete when an active run exists", async () => {
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "planned" }),
+        runs: [makeRun({ run_id: "exec_active", status: "running" })],
+      });
+
+      await expect(service.deleteWorkItem({ work_item_id: "studio-157", confirm_delete: true })).rejects.toThrow(
+        /cannot_dispose_work_item_active_run.*exec_active/,
+      );
+    });
+
+    it("requires explicit acknowledgement before deleting connected work items", async () => {
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "ready" }),
+        connectedEdges: [{ id: 9, from_id: "studio-157", rel: "depends_on", to_id: "studio-200" }],
+      });
+
+      await expect(service.deleteWorkItem({ work_item_id: "studio-157", confirm_delete: true })).rejects.toThrow(
+        /delete_work_item_requires_connected_edge_acknowledgement/,
+      );
+    });
+
+    it("falls back to graph deletion when GitHub delete fails and fallback is explicitly allowed", async () => {
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "planned" }),
+        githubDeleteIssue: vi.fn(async () => {
+          throw new BadRequestException("gh command failed: not authorized");
+        }),
+      });
+
+      const result = await service.deleteWorkItem({
+        work_item_id: "studio-157",
+        confirm_delete: true,
+        allow_graph_delete_without_github: true,
+      });
+
+      expect(result.github_issue).toEqual({
+        attempted: true,
+        deleted: false,
+        fallback_used: true,
+        message: "gh command failed: not authorized",
+      });
+      expect(result.graph).toEqual({ deleted: true, id: "studio-157", removed_edge_ids: [] });
+      expect(result.warnings[0]).toContain("GitHub issue was not deleted");
+    });
   });
 
   describe("movePlanDirToArchives", () => {

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -6,6 +6,8 @@ import type {
   CleanupWorktreeDto,
   CloseMergedPullRequestResult,
   CreateExecutionPullRequestDto,
+  DeleteWorkItemDto,
+  DeleteWorkItemResult,
   FollowUpMessageDto,
   LaunchExecutionRunDto,
   ResolveDisambiguationDto,
@@ -100,6 +102,11 @@ export class ExecutionController {
   @Post("archive-and-close-merged")
   archiveAndCloseMergedPullRequest(@Body() body: TransitionWorkItemDto) {
     return this.executionService.archiveAndCloseMergedPullRequest(body.work_item_id);
+  }
+
+  @Post("delete-work-item")
+  deleteWorkItem(@Body() body: DeleteWorkItemDto): Promise<DeleteWorkItemResult> {
+    return this.executionService.deleteWorkItem(body);
   }
 
   @Get("runs/:runId/chat")

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
+import { PlansModule } from "../plans/plans.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
 import { ExecutionController } from "./execution.controller.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
@@ -11,7 +12,7 @@ import { WorkItemReconcilerController } from "./work-item-reconciler.controller.
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => SettingsModule)],
+  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => PlansModule), forwardRef(() => SettingsModule)],
   controllers: [ExecutionController, GitHubCacheController, WorkItemReconcilerController],
   providers: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, WorkItemReconcilerService],
   exports: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, WorkItemReconcilerService],

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable, Logger, MessageEvent, NotFoundException, OnModuleInit } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent, NotFoundException, OnModuleInit, forwardRef } from "@nestjs/common";
 import { createAgentSession, createCodingTools, SessionManager, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -28,6 +28,7 @@ import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
+import { PlansService } from "../plans/plans.service.js";
 import { SettingsService } from "../settings/settings.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
@@ -57,6 +58,8 @@ import type {
   LaunchExecutionRunResult,
   CleanupWorktreeDto,
   CleanupWorktreeResult,
+  DeleteWorkItemDto,
+  DeleteWorkItemResult,
   ResolveDisambiguationDto,
   ResolveDisambiguationResult,
   RunChatHistory,
@@ -92,6 +95,7 @@ export class ExecutionService implements OnModuleInit {
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
     @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
+    @Inject(forwardRef(() => PlansService)) private readonly plansService: PlansService,
   ) {
     this.githubService.registerPullRequestTruthRefresher((pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options));
   }
@@ -2791,6 +2795,94 @@ export class ExecutionService implements OnModuleInit {
       this.workItemsService.update(workItemId, { archive_path: nextArchivePath });
     }
     return this.workItemsService.get(workItemId);
+  }
+
+  async deleteWorkItem(input: DeleteWorkItemDto): Promise<DeleteWorkItemResult> {
+    const workItemId = input.work_item_id?.trim();
+    if (!workItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    if (input.confirm_delete !== true) {
+      throw new BadRequestException("confirm_delete must be true");
+    }
+
+    const workItem = this.workItemsService.get(workItemId);
+    this.assertDeleteEligible(workItem);
+    this.assertNoActiveRunForWorkItem(workItemId);
+
+    const connectedEdges = this.workItemsService.getConnectedEdges(workItemId);
+    if (connectedEdges.length > 0 && input.acknowledge_connected_edges !== true) {
+      throw new BadRequestException(
+        `delete_work_item_requires_connected_edge_acknowledgement: ${workItemId}`,
+      );
+    }
+
+    const warnings: string[] = [];
+    let githubIssue: DeleteWorkItemResult["github_issue"] = {
+      attempted: false,
+      deleted: false,
+      fallback_used: false,
+      message: null,
+    };
+
+    try {
+      githubIssue = {
+        attempted: true,
+        deleted: true,
+        fallback_used: false,
+        message: null,
+      };
+      await this.githubService.deleteIssue(workItem.repo ?? "", Number(workItem.issue_number));
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      if (input.allow_graph_delete_without_github !== true) {
+        throw new BadRequestException(`github_issue_delete_failed: ${message}`);
+      }
+      githubIssue = {
+        attempted: true,
+        deleted: false,
+        fallback_used: true,
+        message,
+      };
+      warnings.push(`GitHub issue was not deleted: ${message}`);
+    }
+
+    const planCleanup = this.plansService.deletePlanArtifacts(workItemId);
+    const graphResult = this.workItemsService.deleteWithConnectedEdges(workItemId, connectedEdges.map((edge) => edge.id));
+
+    return {
+      deleted: true,
+      work_item: {
+        id: workItem.id,
+        name: workItem.name,
+        state: workItem.state,
+        repo: workItem.repo,
+        issue_number: workItem.issue_number,
+        issue_url: workItem.issue_url,
+      },
+      graph: graphResult,
+      github_issue: githubIssue,
+      plan_cleanup: planCleanup,
+      warnings,
+    };
+  }
+
+  private leafState(state: string): string {
+    return state.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
+  }
+
+  private assertDeleteEligible(workItem: WorkItemRecord): void {
+    const leafState = this.leafState(workItem.state);
+    const eligibleStates = new Set(["planned", "drafting", "ready"]);
+
+    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
+      throw new BadRequestException(`delete_work_item_not_issue_backed: ${workItem.id}`);
+    }
+    if (!eligibleStates.has(leafState)) {
+      throw new BadRequestException(
+        `delete_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; destructive delete is limited to planned, drafting, or ready items`,
+      );
+    }
   }
 
   /**

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -287,6 +287,40 @@ export interface TransitionWorkItemDto {
   work_item_id: string;
 }
 
+export interface DeleteWorkItemDto {
+  work_item_id: string;
+  confirm_delete: boolean;
+  acknowledge_connected_edges?: boolean;
+  allow_graph_delete_without_github?: boolean;
+}
+
+export interface DeleteWorkItemResult {
+  deleted: true;
+  work_item: {
+    id: string;
+    name: string;
+    state: string;
+    repo: string | null;
+    issue_number: number | null;
+    issue_url: string | null;
+  };
+  graph: {
+    deleted: true;
+    removed_edge_ids: number[];
+  };
+  github_issue: {
+    attempted: boolean;
+    deleted: boolean;
+    fallback_used: boolean;
+    message: string | null;
+  };
+  plan_cleanup: {
+    removed: boolean;
+    path: string | null;
+  };
+  warnings: string[];
+}
+
 /**
  * studio-87: summary of a GitHub issue closed as part of the merged-PR
  * close flow. Populated when the work item is issue-backed (kind=issue,

--- a/src/modules/github/__tests__/github.service.test.ts
+++ b/src/modules/github/__tests__/github.service.test.ts
@@ -272,6 +272,44 @@ describe("GitHubService reconciliation", () => {
   });
 });
 
+describe("GitHubService issue deletion", () => {
+  it("deletes an issue with gh issue delete --yes", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGh = vi.fn().mockReturnValue("");
+    (service as any).runGh = runGh;
+
+    await expect(service.deleteIssue("fusupo/escapement-studio", 137)).resolves.toEqual({
+      repo: "fusupo/escapement-studio",
+      number: 137,
+      deleted: true,
+    });
+    expect(runGh).toHaveBeenCalledWith([
+      "issue",
+      "delete",
+      "137",
+      "--repo",
+      "fusupo/escapement-studio",
+      "--yes",
+    ]);
+  });
+
+  it("rejects deleteIssue when repo or issue_number are invalid", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+
+    await expect(service.deleteIssue("", 137)).rejects.toThrow("repo is required");
+    await expect(service.deleteIssue("fusupo/escapement-studio", 0)).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("propagates gh delete failures", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    (service as any).runGh = vi.fn(() => {
+      throw new Error("gh command failed: nope");
+    });
+
+    await expect(service.deleteIssue("fusupo/escapement-studio", 137)).rejects.toThrow("gh command failed: nope");
+  });
+});
+
 describe("GitHubService batch list methods", () => {
   it("lists pull requests with normalized fields and commands", async () => {
     const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);

--- a/src/modules/github/github.controller.ts
+++ b/src/modules/github/github.controller.ts
@@ -21,6 +21,14 @@ export class GitHubController {
     return this.githubService.closeIssue(repo, Number(issueNumber));
   }
 
+  @Post("issue/delete")
+  deleteIssue(
+    @Body("repo") repo: string,
+    @Body("issue_number") issueNumber: number,
+  ) {
+    return this.githubService.deleteIssue(repo, Number(issueNumber));
+  }
+
   @Get("pull-request")
   getPullRequest(
     @Query("repo") repo?: string,

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -81,6 +81,12 @@ export interface GitHubCreatedIssue {
   title: string;
 }
 
+export interface GitHubDeletedIssue {
+  repo: string;
+  number: number;
+  deleted: true;
+}
+
 export interface GitHubPullRequestDetails {
   repo: string;
   number: number;
@@ -184,6 +190,30 @@ export class GitHubService {
     ]);
 
     return this.readIssue(repo, issueNumber);
+  }
+
+  async deleteIssue(repo: string, issueNumber: number): Promise<GitHubDeletedIssue> {
+    if (!repo?.trim()) {
+      throw new BadRequestException("repo is required");
+    }
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new BadRequestException("issue_number must be a positive integer");
+    }
+
+    this.runGh([
+      "issue",
+      "delete",
+      String(issueNumber),
+      "--repo",
+      repo,
+      "--yes",
+    ]);
+
+    return {
+      repo,
+      number: issueNumber,
+      deleted: true,
+    };
   }
 
   async readIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {

--- a/src/modules/graph/__tests__/graph-writer.service.test.ts
+++ b/src/modules/graph/__tests__/graph-writer.service.test.ts
@@ -144,6 +144,23 @@ describe("GraphWriterService", () => {
       const count = (sqlite.getDb().prepare("SELECT COUNT(*) AS c FROM work_items WHERE id = ?").get("item-del") as { c: number }).c;
       expect(count).toBe(0);
     });
+
+    it("deletes connected edges and then deletes the work item in one batch", () => {
+      seedWorkItem(sqlite, "item-a");
+      seedWorkItem(sqlite, "item-b");
+      seedWorkItem(sqlite, "item-c");
+      seedEdge(sqlite, "item-a", "depends_on", "item-b");
+      seedEdge(sqlite, "item-c", "implemented_by", "item-a");
+
+      const connectedEdges = writer.getConnectedEdges("item-a");
+      const result = writer.deleteWorkItemWithEdges("item-a", connectedEdges.map((edge) => edge.id));
+
+      expect(result.status).toBe("applied");
+      const remainingItem = sqlite.getDb().prepare("SELECT COUNT(*) AS c FROM work_items WHERE id = ?").get("item-a") as { c: number };
+      const remainingEdges = sqlite.getDb().prepare("SELECT COUNT(*) AS c FROM edges WHERE from_id = ? OR to_id = ?").get("item-a", "item-a") as { c: number };
+      expect(remainingItem.c).toBe(0);
+      expect(remainingEdges.c).toBe(0);
+    });
   });
 
   describe("apply — stale rejection", () => {

--- a/src/modules/graph/__tests__/work-item-transitions.test.ts
+++ b/src/modules/graph/__tests__/work-item-transitions.test.ts
@@ -58,6 +58,7 @@ function makeController(options: {
       current = { ...current, ...patch };
       return current;
     }),
+    delete: vi.fn((id: string) => ({ deleted: true as const, id })),
   } as unknown as WorkItemsService;
 
   const hsmService = {
@@ -252,6 +253,18 @@ describe("WorkItemsController.transition", () => {
     await expect(
       harness.controller.transition("studio-153", {} as { event: "user.defer" }),
     ).rejects.toThrow(/event.*required/);
+  });
+});
+
+describe("WorkItemsController.delete", () => {
+  it("keeps raw DELETE separate from the cancel workflow", () => {
+    const harness = makeController();
+
+    const result = harness.controller.delete("studio-153");
+
+    expect(harness.workItemsService.delete).toHaveBeenCalledWith("studio-153");
+    expect(harness.executionService.cancelWorkItem).not.toHaveBeenCalled();
+    expect(result).toEqual({ deleted: true, id: "studio-153" });
   });
 });
 

--- a/src/modules/graph/graph-writer.service.ts
+++ b/src/modules/graph/graph-writer.service.ts
@@ -8,6 +8,7 @@ import {
   type CreateEdgeDto,
   type CreateWorkItemDto,
   type EdgeConfidence,
+  type EdgeRecord,
   type EdgeRel,
   type GraphMutation,
   type GraphMutationError,
@@ -122,6 +123,27 @@ export class GraphWriterService {
     } catch (error) {
       throw new BadRequestException(error instanceof Error ? error.message : "Graph write failed");
     }
+  }
+
+  getConnectedEdges(workItemId: string): EdgeRecord[] {
+    const rows = this.db
+      .prepare("SELECT * FROM edges WHERE from_id = ? OR to_id = ? ORDER BY id")
+      .all(workItemId, workItemId) as RawEdgeRecord[];
+
+    return rows.map((row) => ({
+      ...row,
+      meta: this.parseMeta(row.meta),
+    }));
+  }
+
+  deleteWorkItemWithEdges(workItemId: string, edgeIds: number[]): ApplyGraphMutationsResult {
+    const normalizedEdgeIds = [...new Set(edgeIds.filter((edgeId) => Number.isInteger(edgeId)))];
+    return this.apply({
+      mutations: [
+        ...normalizedEdgeIds.map((edgeId) => ({ kind: "delete_edge", id: edgeId } as const)),
+        { kind: "delete_work_item", id: workItemId },
+      ],
+    });
   }
 
   private validateMutations(mutations: GraphMutation[], snapshot: GraphStateSnapshot): GraphMutationError[] {
@@ -411,6 +433,15 @@ export class GraphWriterService {
       meta: JSON.stringify(input.meta ?? {}),
       updated_at: this.now(),
     };
+  }
+
+  private parseMeta(value: string): Record<string, unknown> {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
   }
 
   private toRawWorkItemPatch(input: UpdateWorkItemDto) {

--- a/src/modules/graph/work-items.service.ts
+++ b/src/modules/graph/work-items.service.ts
@@ -3,7 +3,7 @@ import type { Database as DatabaseType } from "better-sqlite3";
 import { parseJsonArray } from "../../lib/manifest-core.js";
 import { GraphWriterService } from "./graph-writer.service.js";
 import { SQLiteService } from "./sqlite.service.js";
-import { deriveIssueWorkItemId, type CreateWorkItemDto, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord, type WorkItemState } from "./types.js";
+import { deriveIssueWorkItemId, type CreateWorkItemDto, type EdgeRecord, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord, type WorkItemState } from "./types.js";
 
 interface RawWorkItemRecord {
   id: string;
@@ -155,6 +155,29 @@ export class WorkItemsService {
     return this.update(id, { state });
   }
 
+  getConnectedEdges(id: string): EdgeRecord[] {
+    if (!id?.trim()) {
+      return [];
+    }
+
+    const rows = this.db
+      .prepare("SELECT * FROM edges WHERE from_id = ? OR to_id = ? ORDER BY id")
+      .all(id, id) as Array<{
+        id: number;
+        from_id: string;
+        rel: EdgeRecord["rel"];
+        to_id: string;
+        confidence: EdgeRecord["confidence"];
+        meta: string;
+        created_at: string;
+      }>;
+
+    return rows.map((row) => ({
+      ...row,
+      meta: this.parseMeta(row.meta),
+    }));
+  }
+
   delete(id: string): { deleted: true; id: string } {
     const result = this.graphWriter.apply({
       mutations: [{ kind: "delete_work_item", id }],
@@ -165,6 +188,23 @@ export class WorkItemsService {
     }
 
     return { deleted: true, id };
+  }
+
+  deleteWithConnectedEdges(id: string, edgeIds: number[]): { deleted: true; id: string; removed_edge_ids: number[] } {
+    const connectedEdges = this.getConnectedEdges(id);
+    const connectedEdgeIds = new Set(connectedEdges.map((edge) => edge.id));
+    const requestedEdgeIds = [...new Set(edgeIds.filter((edgeId) => Number.isInteger(edgeId)))];
+
+    if (requestedEdgeIds.length !== connectedEdges.length || requestedEdgeIds.some((edgeId) => !connectedEdgeIds.has(edgeId))) {
+      throw new BadRequestException(`delete_work_item_requires_all_connected_edges: ${id}`);
+    }
+
+    const result = this.graphWriter.deleteWorkItemWithEdges(id, requestedEdgeIds);
+    if (result.status !== "applied") {
+      throw new BadRequestException(this.getMutationFailureMessage(result));
+    }
+
+    return { deleted: true, id, removed_edge_ids: requestedEdgeIds.sort((a, b) => a - b) };
   }
 
   private toRecord(row: RawWorkItemRecord): WorkItemRecord {

--- a/src/modules/plans/__tests__/plans.service.test.ts
+++ b/src/modules/plans/__tests__/plans.service.test.ts
@@ -192,6 +192,34 @@ function cleanup(h: Harness) {
   rmSync(h.artifactRoot, { recursive: true, force: true });
 }
 
+describe("PlansService.deletePlanArtifacts", () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    if (harness) cleanup(harness);
+  });
+
+  it("removes an existing plan directory", () => {
+    harness = makeHarness(makeWorkItem());
+    ensurePlanDir(harness.artifactRoot, "studio-154");
+    writeFileSync(canonicalScratchpadPath(harness.artifactRoot, "studio-154"), "draft", "utf8");
+
+    const result = harness.service.deletePlanArtifacts("studio-154");
+
+    expect(result).toEqual({
+      removed: true,
+      path: join(harness.artifactRoot, "plans", "studio_154"),
+    });
+    expect(existsSync(join(harness.artifactRoot, "plans", "studio_154"))).toBe(false);
+  });
+
+  it("is a no-op when no plan directory exists", () => {
+    harness = makeHarness(makeWorkItem());
+
+    expect(harness.service.deletePlanArtifacts("studio-154")).toEqual({ removed: false, path: null });
+  });
+});
+
 describe("PlansService.prepare", () => {
   let harness: Harness;
 

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -1,10 +1,11 @@
 import { BadRequestException, Inject, Injectable, Logger, NotFoundException } from "@nestjs/common";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
 import {
   canonicalScratchpadPath,
   ensurePlanDir,
+  planDir,
   readPlanMetadata,
   writePlanMetadata,
   type PlanMetadata,
@@ -205,6 +206,18 @@ export class PlansService {
       metadata,
       scratchpad_content: scratchpadContent,
     };
+  }
+
+  deletePlanArtifacts(workItemId: string): { removed: boolean; path: string | null } {
+    this.workItemsService.get(workItemId);
+
+    const target = planDir(this.artifactRoot, workItemId);
+    if (!existsSync(target)) {
+      return { removed: false, path: null };
+    }
+
+    rmSync(target, { recursive: true, force: true });
+    return { removed: true, path: target };
   }
 
   async persistDraftEnvelope(

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -14,6 +14,7 @@
     createEdge,
     createWorkItem,
     deleteEdge,
+    deleteWorkItem,
     getExecutionEligibility,
     getFrontier,
     getGitHubIssueDetails,
@@ -42,10 +43,12 @@
   let saving = false;
   let edgeSaving = false;
   let error = "";
+  let notice = "";
   let health = null;
   let selectedIssueDetails = null;
   let activeTab = "planning";
   let closingIssue = false;
+  let deletingWorkItem = false;
   let launchingExecution = false;
   let launchEligibilityById = {};
   let launchEligibilityLoadingIds = {};
@@ -69,6 +72,7 @@
   let planStateLoadingIds = {};
   let planStateRequestTokenById = {};
   let planReview = null; // { workItemId, scratchpadContent } | null
+  let deleteDialog = null;
 
   // Panel collapse state
   let chatCollapsed = false;
@@ -140,6 +144,10 @@
     planStateLoading: contextMenuPlanStateLoading,
     preparingPlan,
     approvingPlan,
+    deletingWorkItem,
+    connectedEdges: graphContextMenu.item
+      ? graph.edges.filter((edge) => edge.from_id === graphContextMenu.item.id || edge.to_id === graphContextMenu.item.id)
+      : [],
   });
   $: filterOptions = {
     repos: [...new Set(catalog.map((item) => item.repo).filter(Boolean))].sort(),
@@ -215,10 +223,6 @@
 
   function closeGraphContextMenu() {
     graphContextMenu = { open: false, x: 0, y: 0, item: null };
-  }
-
-  function leafState(state) {
-    return state?.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
   }
 
   function normalizeLaunchEligibilityError(workItemId, message) {
@@ -497,6 +501,7 @@
     if (!item?.id) return;
     closingIssue = true;
     error = "";
+    notice = "";
     try {
       // studio-87: the backend owns the full close orchestration
       // (gh issue close → merged_pr → done transition → dispose matching
@@ -508,6 +513,54 @@
       error = closeError.message;
     } finally {
       closingIssue = false;
+    }
+  }
+
+  function openDeleteDialog(item = selectedItem) {
+    if (!item?.id) return;
+    const connectedEdges = graph.edges.filter((edge) => edge.from_id === item.id || edge.to_id === item.id);
+    deleteDialog = {
+      item,
+      connectedEdges,
+      acknowledgeDelete: false,
+      acknowledgeConnectedEdges: connectedEdges.length === 0,
+      acknowledgeFallback: false,
+      warnings: [],
+      submitting: false,
+    };
+    closeGraphContextMenu();
+  }
+
+  function closeDeleteDialog() {
+    if (deleteDialog?.submitting) return;
+    deleteDialog = null;
+  }
+
+  async function confirmDeleteWorkItem() {
+    if (!deleteDialog?.item?.id || deleteDialog.submitting) return;
+
+    deleteDialog = { ...deleteDialog, submitting: true };
+    deletingWorkItem = true;
+    error = "";
+    notice = "";
+    try {
+      const result = await deleteWorkItem({
+        work_item_id: deleteDialog.item.id,
+        confirm_delete: true,
+        acknowledge_connected_edges: deleteDialog.acknowledgeConnectedEdges,
+        allow_graph_delete_without_github: deleteDialog.acknowledgeFallback,
+      });
+      await loadGraph();
+      selectedId = selectedId === deleteDialog.item.id ? null : selectedId;
+      notice = result.warnings?.length > 0
+        ? result.warnings.join(" ")
+        : `Deleted ${deleteDialog.item.id}.`;
+      deleteDialog = null;
+    } catch (deleteError) {
+      error = deleteError.message;
+      deleteDialog = { ...deleteDialog, submitting: false };
+    } finally {
+      deletingWorkItem = false;
     }
   }
 
@@ -798,6 +851,9 @@
               {#if error}
                 <div class="banner error">{error}</div>
               {/if}
+              {#if notice}
+                <div class="banner info">{notice}</div>
+              {/if}
               {#if loading}
                 <div class="empty-state">Loading graph…</div>
               {:else}
@@ -850,7 +906,9 @@
                   onCreateEdge={handleCreateEdge}
                   onDeleteEdge={handleDeleteEdge}
                   onCloseIssue={handleCloseIssue}
+                  onDeleteWorkItem={openDeleteDialog}
                   {closingIssue}
+                  {deletingWorkItem}
                 />
               </div>
             </div>
@@ -908,6 +966,8 @@
           } else if (event.detail.id === "review-plan") {
             handleReviewPlan(item, planStateById[item.id] ?? null);
             closeGraphContextMenu();
+          } else if (event.detail.id === "delete-work-item") {
+            openDeleteDialog(item);
           }
         }}
         on:requestclose={closeGraphContextMenu}
@@ -938,6 +998,79 @@
             <button class="small" on:click={closePlanReview} aria-label="Close plan review">×</button>
           </header>
           <pre class="plan-review-body">{planReview.scratchpadContent}</pre>
+        </div>
+      </div>
+    {/if}
+
+    {#if deleteDialog}
+      <div class="plan-review-overlay" role="presentation" on:click={closeDeleteDialog}>
+        <div
+          class="plan-review-card delete-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="delete-work-item-title"
+          on:click|stopPropagation
+        >
+          <header class="plan-review-header">
+            <h3 id="delete-work-item-title">Delete {deleteDialog.item.id}</h3>
+            <button class="small" on:click={closeDeleteDialog} disabled={deleteDialog.submitting} aria-label="Close delete dialog">×</button>
+          </header>
+
+          <div class="delete-dialog-body">
+            <p><strong>This permanently removes the Studio graph node.</strong> Delete is different from cancel and should only be used for junk, accidental, duplicate, or malformed work items.</p>
+            <p>The backend will try to delete GitHub issue #{deleteDialog.item.issue_number} in {deleteDialog.item.repo} first, then remove the Studio node and any acknowledged connected edges.</p>
+
+            {#if deleteDialog.connectedEdges.length > 0}
+              <div class="banner warn">
+                This work item has {deleteDialog.connectedEdges.length} connected edge{deleteDialog.connectedEdges.length === 1 ? "" : "s"}. Deleting it will also remove those graph relationships.
+              </div>
+              <ul class="delete-edge-list">
+                {#each deleteDialog.connectedEdges as edge}
+                  <li><code>{edge.from_id}</code> {edge.rel} <code>{edge.to_id}</code></li>
+                {/each}
+              </ul>
+            {/if}
+
+            <label class="checkbox-row">
+              <input
+                type="checkbox"
+                checked={deleteDialog.acknowledgeDelete}
+                on:change={(event) => deleteDialog = { ...deleteDialog, acknowledgeDelete: event.currentTarget.checked }}
+              />
+              <span>I understand this is destructive and is not the normal replacement for cancel.</span>
+            </label>
+
+            {#if deleteDialog.connectedEdges.length > 0}
+              <label class="checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={deleteDialog.acknowledgeConnectedEdges}
+                  on:change={(event) => deleteDialog = { ...deleteDialog, acknowledgeConnectedEdges: event.currentTarget.checked }}
+                />
+                <span>I approve removing all connected edges shown above.</span>
+              </label>
+            {/if}
+
+            <label class="checkbox-row">
+              <input
+                type="checkbox"
+                checked={deleteDialog.acknowledgeFallback}
+                on:change={(event) => deleteDialog = { ...deleteDialog, acknowledgeFallback: event.currentTarget.checked }}
+              />
+              <span>If GitHub issue deletion is unavailable, still delete the Studio node and show me the fallback warning.</span>
+            </label>
+          </div>
+
+          <footer class="delete-dialog-actions">
+            <button class="small" on:click={closeDeleteDialog} disabled={deleteDialog.submitting}>Keep work item</button>
+            <button
+              class="danger"
+              on:click={confirmDeleteWorkItem}
+              disabled={!deleteDialog.acknowledgeDelete || !deleteDialog.acknowledgeConnectedEdges || !deleteDialog.acknowledgeFallback || deleteDialog.submitting}
+            >
+              {deleteDialog.submitting ? "Deleting…" : "Delete permanently"}
+            </button>
+          </footer>
         </div>
       </div>
     {/if}
@@ -1304,6 +1437,53 @@
     flex: 1;
     color: #6b7a94;
     font-size: 12px;
+  }
+
+  .banner.info {
+    background: rgba(37, 99, 235, 0.14);
+    border: 1px solid rgba(96, 165, 250, 0.28);
+    color: #dbeafe;
+  }
+
+  .banner.warn {
+    background: rgba(217, 119, 6, 0.14);
+    border: 1px solid rgba(251, 191, 36, 0.28);
+    color: #fde68a;
+  }
+
+  .delete-dialog {
+    max-width: 640px;
+  }
+
+  .delete-dialog-body {
+    display: grid;
+    gap: 12px;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 13px;
+    color: #cbd5e1;
+  }
+
+  .checkbox-row input {
+    margin-top: 2px;
+  }
+
+  .delete-edge-list {
+    margin: 0;
+    padding-left: 18px;
+    color: #cbd5e1;
+    font-size: 13px;
+  }
+
+  .delete-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 16px;
   }
 
   /* ── Responsive ── */

--- a/web/src/components/GraphNodeContextMenu.svelte
+++ b/web/src/components/GraphNodeContextMenu.svelte
@@ -98,6 +98,7 @@
                 <button
                   class="graph-context-menu-action"
                   class:primary={action.emphasis === "primary"}
+                  class:danger={action.emphasis === "danger"}
                   on:click={() => handleButtonAction(action)}
                   disabled={action.disabled}
                   role="menuitem"
@@ -218,6 +219,17 @@
   .graph-context-menu-action.primary:hover:enabled {
     background: rgba(37, 99, 235, 0.26);
     border-color: rgba(37, 99, 235, 0.4);
+  }
+
+  .graph-context-menu-action.danger {
+    background: rgba(220, 38, 38, 0.15);
+    border-color: rgba(248, 113, 113, 0.3);
+    color: #fecaca;
+  }
+
+  .graph-context-menu-action.danger:hover:enabled {
+    background: rgba(220, 38, 38, 0.24);
+    border-color: rgba(248, 113, 113, 0.45);
   }
 
   .graph-context-menu-description {

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -48,12 +48,14 @@
   export let onCreateEdge = () => {};
   export let onDeleteEdge = () => {};
   export let onCloseIssue = () => {};
+  export let onDeleteWorkItem = () => {};
   export let onLaunchExecution = () => {};
   export let onGitHubTruthRefresh = () => {};
   export let onPreparePlan = () => {};
   export let onApprovePlan = () => {};
   export let onReviewPlan = () => {};
   export let closingIssue = false;
+  export let deletingWorkItem = false;
   export let preparingPlan = false;
   export let approvingPlan = false;
 
@@ -132,6 +134,10 @@
   $: canCloseIssue = issueDetails
     && issueDetails.state?.toLowerCase() === "open"
     && linkedPrDetails?.merged_at != null;
+  $: canDeleteWorkItem = selectedItem?.kind === "issue"
+    && !!selectedItem?.repo
+    && !!selectedItem?.issue_number
+    && ["planned", "drafting", "ready"].includes(leafState(selectedItem?.state));
 
   // ADR 014 step 8 — fetch plan status when the selected item is in a state
   // where a plan should exist. Use a token pattern (mirrors linkedPrLookupToken
@@ -319,6 +325,12 @@
               <button class="danger small" on:click={() => onCloseIssue(selectedItem)} disabled={closingIssue}>
                 {closingIssue ? 'Closing…' : 'Close issue'}
               </button>
+            {/if}
+            {#if canDeleteWorkItem}
+              <button class="danger small" on:click={() => onDeleteWorkItem(selectedItem)} disabled={deletingWorkItem}>
+                {deletingWorkItem ? 'Deleting…' : 'Delete work item'}
+              </button>
+              <p class="muted">Delete is destructive and different from cancel. Use it only for junk, duplicates, or malformed issue-backed items.</p>
             {/if}
           {:else}
             <p class="muted">Loading issue details…</p>
@@ -537,6 +549,9 @@
     </div>
 
     {#if connectedEdges.length > 0}
+      {#if canDeleteWorkItem}
+        <p class="muted">Deleting this work item will also remove these connected edges after explicit acknowledgement.</p>
+      {/if}
       <ul class="edge-list">
         {#each connectedEdges as edge}
           <li>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -230,6 +230,14 @@ export function archiveAndCloseMergedPullRequest(workItemId) {
   });
 }
 
+export function deleteWorkItem(payload) {
+  return request("/api/execution/delete-work-item", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 // ADR 014 step 8 — plan lifecycle endpoints.
 // See src/modules/plans/plans.controller.ts. The GET endpoint returns
 // { work_item_id, metadata, scratchpad_content } and 404s when no plan

--- a/web/src/lib/graph-node-actions.js
+++ b/web/src/lib/graph-node-actions.js
@@ -8,6 +8,8 @@ function leafState(state) {
   return state?.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
 }
 
+const DELETE_ELIGIBLE_STATES = new Set(["planned", "drafting", "ready"]);
+
 export function buildGraphNodeContextMenu({
   item,
   launchEligibility,
@@ -17,6 +19,8 @@ export function buildGraphNodeContextMenu({
   planStateLoading = false,
   preparingPlan = false,
   approvingPlan = false,
+  deletingWorkItem = false,
+  connectedEdges = [],
 } = {}) {
   if (!item) {
     return null;
@@ -49,6 +53,10 @@ export function buildGraphNodeContextMenu({
         : formatDispatchNodeSummary(launchEligibility.dispatch_node);
 
   const actions = [];
+  const deleteEligible = item.kind === "issue"
+    && !!item.repo
+    && !!item.issue_number
+    && DELETE_ELIGIBLE_STATES.has(workItemState);
 
   if (item.issue_url) {
     actions.push({
@@ -107,6 +115,19 @@ export function buildGraphNodeContextMenu({
     disabled: !launchGateOk,
     emphasis: "primary",
   });
+
+  if (deleteEligible) {
+    actions.push({
+      id: "delete-work-item",
+      kind: "button",
+      label: deletingWorkItem ? "Deleting…" : "Delete work item",
+      description: connectedEdges.length > 0
+        ? `Destructive delete. Removes the issue-backed node and ${connectedEdges.length} connected edge${connectedEdges.length === 1 ? "" : "s"}.`
+        : "Destructive delete. Removes the GitHub issue when possible and deletes the Studio node instead of cancelling it.",
+      disabled: deletingWorkItem,
+      emphasis: "danger",
+    });
+  }
 
   return {
     title: item.id,


### PR DESCRIPTION
## Summary
Got it. I’ll treat the product decisions as:

- **Eligible delete states:** only `planned`, `drafting`, and `ready`
- **GitHub delete failure:** **hard stop**; do **not** delete the Studio graph node as fallback
- **Connected items:** after explicit acknowledgement, delete **all adjacent edges**
- **Plan artifacts:** permanently remove `plans/<slug>/`

One important note: the current implementation already matches **3/4** of these, but it does **not** fully match the GitHub-failure rule yet.

### Current alignment
- ✅ restricted to `planned` / `drafting` / `ready`
- ✅ connected-edge delete removes all adjacent edges after acknowledgement
- ✅ plan artifacts are permanently removed
- ⚠️ current backend/UI still supports an **optional fallback** where Studio graph deletion can proceed if GitHub deletion fails and the user acknowledges it

### Required follow-up change
To match your decision exactly, I should:
- remove `allow_graph_delete_without_github` from the backend contract
- make GitHub deletion failure a hard error in `ExecutionService.deleteWorkItem`
- remove the fallback acknowledgement checkbox and fallback wording from the UI
- update tests to assert hard-stop behavior

If you want, I can make that tightening change next.

actual_files synced: 0 file(s).

## Context
- Work item: studio-137
- Issue: https://github.com/fusupo/escapement-studio/issues/137
- Base branch: develop
- Head branch: studio-137-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1776011318540
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-137-branch
- Scope hint: Add an approval-gated destructive delete flow for junk or accidental issue-backed work items that deletes the GitHub issue where possible and removes the graph node with safeguards.

## Changed files
- (not recorded)