### PR TITLE
[#167] Auto-draft plan scratchpad via pi-coding-agent setup-work skill

### DIFF
--- a/src/modules/graph/__tests__/hsm-action-handlers.test.ts
+++ b/src/modules/graph/__tests__/hsm-action-handlers.test.ts
@@ -3,6 +3,10 @@ import { HsmActionHandlers } from "../hsm-action-handlers.js";
 import { HsmGuardHandlers } from "../hsm-guard-handlers.js";
 import type { WorkItemRecord } from "../types.js";
 
+vi.mock("../../../lib/github-cli.js", () => ({
+  fetchIssueBody: vi.fn(() => "Mocked issue body from HSM handler test."),
+}));
+
 function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
   return {
     id: "studio-202",
@@ -24,6 +28,30 @@ function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
 }
 
 const now = () => "2026-04-12T12:00:00.000Z";
+
+function makeDraftEnvelope() {
+  return {
+    summary: "Drafted summary",
+    acceptance_criteria: ["Criterion A"],
+    implementation_tasks: [
+      {
+        description: "Task 1",
+        files: ["src/foo.ts"],
+        rationale: "why",
+        testing: "test it",
+      },
+    ],
+    affected_files: ["src/foo.ts"],
+    questions: [],
+    assumptions: [],
+    blockers: [],
+    technical_notes: {
+      architecture: "arch",
+      approach: "approach",
+      challenges: "challenges",
+    },
+  };
+}
 
 describe("HsmActionHandlers", () => {
   it("createRunRecord persists a run and returns the run id", async () => {
@@ -111,6 +139,84 @@ describe("HsmActionHandlers", () => {
 
     expect(executionService.archiveRunArtifacts).toHaveBeenCalledWith("studio-202");
     expect(result.patch).toMatchObject({ archive_path: "/tmp/archive/studio-202" });
+  });
+
+  it("kickOffPlanDrafter waits for persistDraftEnvelope before completion resolves", async () => {
+    let resolvePersist: undefined | (() => void);
+    const persistDraftEnvelope = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePersist = resolve;
+        }),
+    );
+    const drafter = {
+      startDraft: vi.fn(() => ({
+        sessionId: "draft-session-1",
+        completion: Promise.resolve(makeDraftEnvelope()),
+        cancel: vi.fn(),
+      })),
+    };
+    const handlers = new HsmActionHandlers(
+      {} as never,
+      {} as never,
+      {} as never,
+      drafter as never,
+      { persistDraftEnvelope } as never,
+    );
+
+    const handle = handlers.kickOffPlanDrafter({
+      workItem: makeWorkItem({ state: "drafting" }),
+      event: { type: "user.start_draft" },
+      now,
+    });
+
+    let completed = false;
+    const completion = handle.completion.then(() => {
+      completed = true;
+    });
+    await Promise.resolve();
+
+    expect(persistDraftEnvelope).toHaveBeenCalledWith(
+      "studio-202",
+      expect.objectContaining({ summary: "Drafted summary" }),
+      "Mocked issue body from HSM handler test.",
+      { transitionToDrafting: false },
+    );
+    expect(completed).toBe(false);
+
+    expect(resolvePersist).toBeTypeOf("function");
+    resolvePersist?.();
+    await completion;
+    expect(completed).toBe(true);
+  });
+
+  it("kickOffPlanDrafter propagates persistDraftEnvelope failures", async () => {
+    const drafter = {
+      startDraft: vi.fn(() => ({
+        sessionId: "draft-session-1",
+        completion: Promise.resolve(makeDraftEnvelope()),
+        cancel: vi.fn(),
+      })),
+    };
+    const handlers = new HsmActionHandlers(
+      {} as never,
+      {} as never,
+      {} as never,
+      drafter as never,
+      {
+        persistDraftEnvelope: vi.fn(async () => {
+          throw new Error("persist failed");
+        }),
+      } as never,
+    );
+
+    const handle = handlers.kickOffPlanDrafter({
+      workItem: makeWorkItem({ state: "drafting" }),
+      event: { type: "user.start_draft" },
+      now,
+    });
+
+    await expect(handle.completion).rejects.toThrow("persist failed");
   });
 });
 

--- a/src/modules/graph/hsm-action-handlers.ts
+++ b/src/modules/graph/hsm-action-handlers.ts
@@ -143,11 +143,11 @@ export class HsmActionHandlers {
       get sessionId() {
         return handle.sessionId;
       },
-      completion: handle.completion.then((draft) => {
+      completion: handle.completion.then(async (draft) => {
         if (cancelled) {
           return;
         }
-        this.plansService.persistDraftEnvelope(ctx.workItem.id, draft, issueBody, {
+        await this.plansService.persistDraftEnvelope(ctx.workItem.id, draft, issueBody, {
           transitionToDrafting: false,
         });
       }),


### PR DESCRIPTION
## Summary
I checked, and yes: the main `studio-167` plan-drafting setup was already in place.

I did find one worthwhile improvement and fixed it.

### Improvement made
Fixed an async bug in:
- `src/modules/graph/hsm-action-handlers.ts`

`kickOffPlanDrafter()` was returning a `completion` promise that did **not actually wait** for `plansService.persistDraftEnvelope(...)` to finish. That meant:
- callers could see drafting as “complete” before the scratchpad write finished
- persistence failures could be lost instead of propagating through the returned promise

I changed it to `await` the persistence step.

### Tests added
Updated:
- `src/modules/graph/__tests__/hsm-action-handlers.test.ts`

Added coverage for:
- completion does not resolve until `persistDraftEnvelope()` finishes
- `persistDraftEnvelope()` errors propagate through the invoke handle

### Commit
Created:
- `22867b7` — `fix(graph): await async plan draft persistence`

### Checks run
Passed:
- `npm run check`
- `npx vitest run src/modules/graph/__tests__/hsm-action-handlers.test.ts`
- `npm test`
- `npm run build:web`

Build still emits existing Svelte a11y/CSS warnings in:
- `web/src/App.svelte`
- `web/src/components/PlannerChatAdapter.svelte`
- `web/src/components/ExecutionDispatchPanel.svelte`

but the build succeeds.

### Summary
So: `studio-167` itself was already done, but the current setup did have a real polish/reliability gap around async draft persistence, and that is now improved.

actual_files synced: 0 file(s).

## Context
- Work item: studio-167
- Issue: https://github.com/fusupo/escapement-studio/issues/167
- Base branch: develop
- Head branch: studio-167-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1776013459791
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-167-branch
- Scope hint: Replace stub-only plan preparation with a PlanDrafterService that uses the Escapement setup-work skill to generate a real drafted scratchpad during Prepare plan.

## Changed files
- (not recorded)