### PR TITLE
[#136] Studio: cancel work items by closing the GitHub issue and marking the graph item cancelled

### DIFF
--- a/src/__tests__/graph-node-actions.test.ts
+++ b/src/__tests__/graph-node-actions.test.ts
@@ -58,6 +58,14 @@ describe("buildGraphNodeContextMenu", () => {
         emphasis: "primary",
       },
       {
+        id: "cancel-work-item",
+        kind: "button",
+        label: "Cancel work item",
+        description: "Non-destructive cancel. Closes the linked GitHub issue, marks the Studio node cancelled, and preserves planning history.",
+        disabled: false,
+        emphasis: "warn",
+      },
+      {
         id: "delete-work-item",
         kind: "button",
         label: "Delete work item",
@@ -246,6 +254,33 @@ describe("buildGraphNodeContextMenu", () => {
         planState: null,
       });
       expect(actionIds(menu)).toContain("prepare-plan");
+    });
+
+    it("shows cancel for issue-backed pre-PR states but keeps delete separate", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "in_progress" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+      });
+      const ids = actionIds(menu);
+      expect(ids).toContain("cancel-work-item");
+      expect(ids).not.toContain("delete-work-item");
+    });
+
+    it("hides cancel for cancelled items", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ state: "cancelled" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+      });
+      expect(actionIds(menu)).not.toContain("cancel-work-item");
+      expect(actionIds(menu)).not.toContain("launch-execution");
+    });
+
+    it("hides cancel for non-issue work items", () => {
+      const menu = buildGraphNodeContextMenu({
+        item: makeItem({ kind: "capability", issue_number: null, issue_url: null, repo: null, state: "ready" }),
+        launchEligibility: makeEligibility({ can_launch: false }),
+      });
+      expect(actionIds(menu)).not.toContain("cancel-work-item");
     });
   });
 });

--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -10,7 +10,7 @@ import {
   ensurePlanDir,
   planDir,
 } from "../../../lib/context-layout.js";
-import type { DeleteWorkItemResult, ExecutionDispatchPreview, ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
+import type { CancelWorkItemResult, DeleteWorkItemResult, ExecutionDispatchPreview, ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
 import type { DispatchResult, WorkItemRecord, WorkItemState } from "../../graph/types.js";
 
 /**
@@ -184,7 +184,7 @@ function makeService(params: {
   service.listRecentRuns = () => [...service.recentRuns];
   service.githubService = {
     closeIssue: params.githubCloseIssue ??
-      vi.fn(async (repo: string, issueNumber: number) => ({
+      vi.fn(async (repo: string, issueNumber: number, _comment?: string | null) => ({
         repo,
         number: issueNumber,
         title: "Disposition test issue",
@@ -773,35 +773,69 @@ describe("ADR 014 step 7: disposition flow", () => {
   });
 
   describe("cancelWorkItem", () => {
-    it("moves the plan dir and transitions to cancelled", async () => {
+    function cancelInput(overrides: Partial<{ work_item_id: string; confirm_cancel: boolean; cancel_note?: string }> = {}) {
+      return {
+        work_item_id: "studio-157",
+        confirm_cancel: true,
+        cancel_note: "No longer needed.",
+        ...overrides,
+      };
+    }
+
+    it("closes GitHub with the optional note, moves the plan dir, and transitions to cancelled", async () => {
       ensurePlanDir(tmpRoot, "studio-157");
       writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
 
       const service = makeService({
         artifactRoot: tmpRoot,
-        // Valid source state for cancellation (event enabled by the HSM)
         workItem: makeWorkItem({ state: "drafting" }),
       });
-      const result = await service.cancelWorkItem("studio-157");
+      const result = await service.cancelWorkItem(cancelInput());
 
-      expect(result.state).toBe("cancelled");
-      expect(result.archive_path).toBe(archiveDir(tmpRoot, "studio-157"));
+      expect(service.githubService.closeIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 157, "No longer needed.");
+      expect(result).toEqual({
+        cancelled: true,
+        work_item: expect.objectContaining({
+          id: "studio-157",
+          state: "cancelled",
+          archive_path: archiveDir(tmpRoot, "studio-157"),
+        }),
+        closed_issue: {
+          repo: "fusupo/escapement-studio",
+          number: 157,
+          url: "https://github.com/fusupo/escapement-studio/issues/157",
+          title: "Disposition test issue",
+          state: "CLOSED",
+        },
+        warnings: [],
+      } satisfies CancelWorkItemResult);
       expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(false);
       expect(existsSync(archiveDir(tmpRoot, "studio-157"))).toBe(true);
     });
 
-    it("handles the no-plan-dir case by still transitioning", async () => {
+    it("handles the no-plan-dir case by still transitioning and preserving null archive_path", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         workItem: makeWorkItem({ state: "planned" }),
       });
-      const result = await service.cancelWorkItem("studio-157");
+      const result = await service.cancelWorkItem(cancelInput({ cancel_note: undefined }));
 
-      expect(result.state).toBe("cancelled");
-      expect(result.archive_path).toBe(null);
+      expect(result.work_item.state).toBe("cancelled");
+      expect(result.work_item.archive_path).toBe(null);
+      expect(service.githubService.closeIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 157, undefined);
     });
 
-    it("active-run guard rejects before the filesystem is touched", async () => {
+    it("requires explicit confirmation", async () => {
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "ready" }),
+      });
+
+      await expect(service.cancelWorkItem(cancelInput({ confirm_cancel: false }))).rejects.toThrow(/confirm_cancel must be true/);
+      expect(service.githubService.closeIssue).not.toHaveBeenCalled();
+    });
+
+    it("active-run guard rejects before GitHub or filesystem side effects", async () => {
       ensurePlanDir(tmpRoot, "studio-157");
       writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
 
@@ -810,8 +844,43 @@ describe("ADR 014 step 7: disposition flow", () => {
         workItem: makeWorkItem({ state: "in_progress" }),
         runs: [makeRun({ status: "running" })],
       });
-      await expect(service.cancelWorkItem("studio-157")).rejects.toThrow(/cannot_dispose_work_item_active_run/);
+      await expect(service.cancelWorkItem(cancelInput())).rejects.toThrow(/cannot_dispose_work_item_active_run/);
+      expect(service.githubService.closeIssue).not.toHaveBeenCalled();
       expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(true);
+    });
+
+    it("does not archive or transition when GitHub close fails", async () => {
+      ensurePlanDir(tmpRoot, "studio-157");
+      writeFileSync(canonicalScratchpadPath(tmpRoot, "studio-157"), "plan", "utf8");
+
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "ready" }),
+        githubCloseIssue: vi.fn(async () => {
+          throw new Error("gh close failed");
+        }),
+      });
+
+      await expect(service.cancelWorkItem(cancelInput())).rejects.toThrow(/gh close failed/);
+      expect(existsSync(planDir(tmpRoot, "studio-157"))).toBe(true);
+      expect(service.hsmService.dispatch).not.toHaveBeenCalled();
+    });
+
+    it("surfaces when GitHub closes but the HSM transition rejects", async () => {
+      const service = makeService({
+        artifactRoot: tmpRoot,
+        workItem: makeWorkItem({ state: "ready" }),
+        hsmDispatch: vi.fn(async () => makeDispatchResult({
+          prev_state: "ready",
+          next_state: "ready",
+          event: { type: "user.cancel" },
+          rejected: true,
+          mutation_applied: false,
+        })),
+      });
+
+      await expect(service.cancelWorkItem(cancelInput())).rejects.toThrow(/cancel_work_item_transition_failed_after_github_close/);
+      expect(service.githubService.closeIssue).toHaveBeenCalled();
     });
   });
 

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -3,6 +3,8 @@ import type { MessageEvent } from "@nestjs/common";
 import { Observable } from "rxjs";
 import { ExecutionService } from "./execution.service.js";
 import type {
+  CancelWorkItemDto,
+  CancelWorkItemResult,
   CleanupWorktreeDto,
   CloseMergedPullRequestResult,
   CreateExecutionPullRequestDto,
@@ -102,6 +104,11 @@ export class ExecutionController {
   @Post("archive-and-close-merged")
   archiveAndCloseMergedPullRequest(@Body() body: TransitionWorkItemDto) {
     return this.executionService.archiveAndCloseMergedPullRequest(body.work_item_id);
+  }
+
+  @Post("cancel-work-item")
+  cancelWorkItem(@Body() body: CancelWorkItemDto): Promise<CancelWorkItemResult> {
+    return this.executionService.cancelWorkItem(body);
   }
 
   @Post("delete-work-item")

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -37,6 +37,8 @@ import type {
   ArchivedRunBundle,
   ArchiveAndCloseMergedPullRequestResult,
   ArchiveRunArtifactsResult,
+  CancelWorkItemDto,
+  CancelWorkItemResult,
   ChecklistItem,
   ClosedGitHubIssueSummary,
   CloseMergedPullRequestResult,
@@ -2780,21 +2782,56 @@ export class ExecutionService implements OnModuleInit {
    * archive-and-close). Called by `WorkItemsController.transition` after it
    * verifies the event is enabled for the current state.
    */
-  async cancelWorkItem(workItemId: string): Promise<WorkItemRecord> {
+  async cancelWorkItem(input: CancelWorkItemDto): Promise<CancelWorkItemResult> {
+    const workItemId = input.work_item_id?.trim();
+    if (!workItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    if (input.confirm_cancel !== true) {
+      throw new BadRequestException("confirm_cancel must be true");
+    }
+
+    const workItem = this.workItemsService.get(workItemId);
+    this.assertCancelEligible(workItem);
     this.assertNoActiveRunForWorkItem(workItemId);
+
+    const closedIssue = await this.githubService.closeIssue(
+      workItem.repo ?? "",
+      Number(workItem.issue_number),
+      input.cancel_note,
+    );
+
     const moveResult = this.movePlanDirToArchives(workItemId);
     const result = await this.hsmService.dispatch(workItemId, { type: "user.cancel" });
     if (result.rejected) {
       throw new BadRequestException(
-        `cannot_cancel: HSM rejected user.cancel from state ${result.prev_state}`,
+        `cancel_work_item_transition_failed_after_github_close: HSM rejected user.cancel from state ${result.prev_state}`,
       );
     }
-    // Write archive_path separately — the HSM doesn't manage this field.
+
     const nextArchivePath = moveResult.archive_path ?? this.workItemsService.get(workItemId).archive_path;
     if (nextArchivePath) {
       this.workItemsService.update(workItemId, { archive_path: nextArchivePath });
     }
-    return this.workItemsService.get(workItemId);
+
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+    return {
+      cancelled: true,
+      work_item: {
+        id: updatedWorkItem.id,
+        state: updatedWorkItem.state,
+        archive_path: updatedWorkItem.archive_path,
+        updated_at: updatedWorkItem.updated_at,
+      },
+      closed_issue: {
+        repo: closedIssue.repo,
+        number: closedIssue.number,
+        url: closedIssue.url,
+        title: closedIssue.title,
+        state: closedIssue.state,
+      },
+      warnings: [],
+    };
   }
 
   async deleteWorkItem(input: DeleteWorkItemDto): Promise<DeleteWorkItemResult> {
@@ -2869,6 +2906,20 @@ export class ExecutionService implements OnModuleInit {
 
   private leafState(state: string): string {
     return state.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
+  }
+
+  private assertCancelEligible(workItem: WorkItemRecord): void {
+    const leafState = this.leafState(workItem.state);
+    const eligibleStates = new Set(["planned", "drafting", "ready", "in_progress", "deferred"]);
+
+    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
+      throw new BadRequestException(`cancel_work_item_not_issue_backed: ${workItem.id}`);
+    }
+    if (!eligibleStates.has(leafState)) {
+      throw new BadRequestException(
+        `cancel_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; cancel is limited to pre-PR issue-backed work items`,
+      );
+    }
   }
 
   private assertDeleteEligible(workItem: WorkItemRecord): void {

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -287,6 +287,24 @@ export interface TransitionWorkItemDto {
   work_item_id: string;
 }
 
+export interface CancelWorkItemDto {
+  work_item_id: string;
+  confirm_cancel: boolean;
+  cancel_note?: string;
+}
+
+export interface CancelWorkItemResult {
+  cancelled: true;
+  work_item: {
+    id: string;
+    state: string;
+    archive_path: string | null;
+    updated_at: string;
+  };
+  closed_issue: ClosedGitHubIssueSummary;
+  warnings: string[];
+}
+
 export interface DeleteWorkItemDto {
   work_item_id: string;
   confirm_delete: boolean;

--- a/src/modules/github/__tests__/github.service.test.ts
+++ b/src/modules/github/__tests__/github.service.test.ts
@@ -272,6 +272,107 @@ describe("GitHubService reconciliation", () => {
   });
 });
 
+describe("GitHubService issue closing", () => {
+  it("closes an issue without posting a comment by default", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGh = vi.fn().mockReturnValue("");
+    const readIssueResult = {
+      repo: "fusupo/escapement-studio",
+      number: 136,
+      title: "Cancel work item",
+      body: "",
+      url: "https://github.com/fusupo/escapement-studio/issues/136",
+      state: "CLOSED",
+      labels: [],
+      assignees: [],
+      body_hash: "hash",
+      managed_block: null,
+    };
+    const readIssue = vi.fn().mockResolvedValue(readIssueResult);
+    (service as any).runGh = runGh;
+    (service as any).readIssue = readIssue;
+
+    await expect(service.closeIssue("fusupo/escapement-studio", 136)).resolves.toEqual(readIssueResult);
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(runGh).toHaveBeenCalledWith([
+      "issue",
+      "close",
+      "136",
+      "--repo",
+      "fusupo/escapement-studio",
+    ]);
+    expect(readIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 136);
+  });
+
+  it("posts a comment before closing when one is provided", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGh = vi.fn().mockReturnValue("");
+    const readIssueResult = {
+      repo: "fusupo/escapement-studio",
+      number: 136,
+      title: "Cancel work item",
+      body: "",
+      url: "https://github.com/fusupo/escapement-studio/issues/136",
+      state: "CLOSED",
+      labels: [],
+      assignees: [],
+      body_hash: "hash",
+      managed_block: null,
+    };
+    (service as any).runGh = runGh;
+    (service as any).readIssue = vi.fn().mockResolvedValue(readIssueResult);
+
+    await expect(service.closeIssue("fusupo/escapement-studio", 136, "Not pursuing this work.")).resolves.toEqual(readIssueResult);
+    expect(runGh).toHaveBeenNthCalledWith(1, [
+      "issue",
+      "comment",
+      "136",
+      "--repo",
+      "fusupo/escapement-studio",
+      "--body",
+      "Not pursuing this work.",
+    ]);
+    expect(runGh).toHaveBeenNthCalledWith(2, [
+      "issue",
+      "close",
+      "136",
+      "--repo",
+      "fusupo/escapement-studio",
+    ]);
+  });
+
+  it("rejects closeIssue when repo or issue_number are invalid", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+
+    await expect(service.closeIssue("", 136)).rejects.toThrow("repo is required");
+    await expect(service.closeIssue("fusupo/escapement-studio", 0)).rejects.toThrow("issue_number must be a positive integer");
+  });
+
+  it("stops before close when posting the comment fails", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGh = vi.fn(() => {
+      throw new Error("gh command failed: comment nope");
+    });
+    (service as any).runGh = runGh;
+
+    await expect(service.closeIssue("fusupo/escapement-studio", 136, "Not pursuing this work.")).rejects.toThrow("gh command failed: comment nope");
+    expect(runGh).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates close failures after posting the comment", async () => {
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const runGh = vi.fn()
+      .mockReturnValueOnce("")
+      .mockImplementationOnce(() => {
+        throw new Error("gh command failed: close nope");
+      });
+    (service as any).runGh = runGh;
+
+    await expect(service.closeIssue("fusupo/escapement-studio", 136, "Not pursuing this work.")).rejects.toThrow("gh command failed: close nope");
+    expect(runGh).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("GitHubService issue deletion", () => {
   it("deletes an issue with gh issue delete --yes", async () => {
     const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -173,12 +173,25 @@ export class GitHubService {
     };
   }
 
-  async closeIssue(repo: string, issueNumber: number): Promise<GitHubIssueDetails> {
+  async closeIssue(repo: string, issueNumber: number, comment?: string | null): Promise<GitHubIssueDetails> {
     if (!repo?.trim()) {
       throw new BadRequestException("repo is required");
     }
     if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
       throw new BadRequestException("issue_number must be a positive integer");
+    }
+
+    const trimmedComment = typeof comment === "string" ? comment.trim() : "";
+    if (trimmedComment) {
+      this.runGh([
+        "issue",
+        "comment",
+        String(issueNumber),
+        "--repo",
+        repo,
+        "--body",
+        trimmedComment,
+      ]);
     }
 
     this.runGh([

--- a/src/modules/graph/__tests__/work-item-transitions.test.ts
+++ b/src/modules/graph/__tests__/work-item-transitions.test.ts
@@ -85,9 +85,28 @@ function makeController(options: {
       current = { ...current, state: "pre_pr.drafting" };
       return current;
     }),
-    cancelWorkItem: vi.fn(async (_id: string) => {
+    cancelWorkItem: vi.fn(async (input: { work_item_id: string; confirm_cancel: boolean; cancel_note?: string }) => {
+      if (input.confirm_cancel !== true) {
+        throw new BadRequestException("confirm_cancel must be true");
+      }
       current = { ...current, state: "cancelled" };
-      return current;
+      return {
+        cancelled: true as const,
+        work_item: {
+          id: current.id,
+          state: current.state,
+          archive_path: current.archive_path,
+          updated_at: current.updated_at,
+        },
+        closed_issue: {
+          repo: current.repo ?? "",
+          number: current.issue_number ?? 0,
+          url: current.issue_url ?? "",
+          title: current.name,
+          state: "CLOSED",
+        },
+        warnings: [],
+      };
     }),
   } as unknown as ExecutionService;
 
@@ -219,11 +238,36 @@ describe("WorkItemsController.transition", () => {
       enabledEvents: ["user.cancel"],
     });
 
-    const result = await harness.controller.transition("studio-153", { event: "user.cancel" });
-
-    expect(harness.executionService.cancelWorkItem).toHaveBeenCalledWith("studio-153");
+    await expect(
+      harness.controller.transition("studio-153", { event: "user.cancel" }),
+    ).rejects.toThrow(/confirm_cancel must be true/);
+    expect(harness.executionService.cancelWorkItem).toHaveBeenCalledWith({
+      work_item_id: "studio-153",
+      confirm_cancel: false,
+      cancel_note: undefined,
+    });
     expect(harness.hsmService.dispatch).not.toHaveBeenCalled();
-    expect(result.state).toBe("cancelled");
+  });
+
+  it("passes cancel confirmation payload through to ExecutionService.cancelWorkItem", async () => {
+    const harness = makeController({
+      initialState: "ready",
+      enabledEvents: ["user.cancel"],
+    });
+
+    const result = await harness.controller.transition("studio-153", {
+      event: "user.cancel",
+      confirm_cancel: true,
+      cancel_note: "No longer needed.",
+    });
+
+    expect(harness.executionService.cancelWorkItem).toHaveBeenCalledWith({
+      work_item_id: "studio-153",
+      confirm_cancel: true,
+      cancel_note: "No longer needed.",
+    });
+    expect(harness.hsmService.dispatch).not.toHaveBeenCalled();
+    expect(result.work_item.state).toBe("cancelled");
   });
 
   it("rejects unsupported transition events", async () => {

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -24,9 +24,11 @@ import { WorkItemsService } from "./work-items.service.js";
  * transition table — `ready → in_progress` is a valid launch transition).
  *
  * This helper mirrors the upstream SQL exactly except it widens the state
- * filter to `state IN ('planned', 'ready')`. If the upstream planner is
- * updated to support multi-state frontiers, this helper should be replaced
- * with a direct upstream call.
+ * filter to `state IN ('planned', 'ready')`. That intentionally keeps
+ * terminal history states like `cancelled`, `done`, and `archived` out of
+ * the default frontier without deleting their graph nodes. If the upstream
+ * planner is updated to support multi-state frontiers, this helper should be
+ * replaced with a direct upstream call.
  */
 function queryStudioFrontier(db: DatabaseType): FrontierItem[] {
   const sql = `

--- a/src/modules/graph/work-items.controller.ts
+++ b/src/modules/graph/work-items.controller.ts
@@ -20,6 +20,8 @@ import type { CreateWorkItemDto } from "./types.js";
 
 interface TransitionDto {
   event: WorkItemTransitionEvent;
+  confirm_cancel?: boolean;
+  cancel_note?: string;
 }
 
 type WorkItemTransitionEvent =
@@ -83,7 +85,7 @@ export class WorkItemsController {
   }
 
   @Post(":id/transition")
-  async transition(@Param("id") id: string, @Body() body: TransitionDto) {
+  async transition(@Param("id") id: string, @Body() body: TransitionDto): Promise<any> {
     const eventType = body?.event;
     if (!eventType) {
       throw new BadRequestException("transition event `event` is required");
@@ -115,7 +117,11 @@ export class WorkItemsController {
         await this.hsmService.dispatch(id, { type: eventType });
         break;
       case "user.cancel":
-        return await this.executionService.cancelWorkItem(id);
+        return await this.executionService.cancelWorkItem({
+          work_item_id: id,
+          confirm_cancel: body.confirm_cancel === true,
+          cancel_note: body.cancel_note,
+        });
     }
 
     return this.workItems.get(id);

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -10,6 +10,7 @@
   import Sidebar from "./components/Sidebar.svelte";
   import {
     approvePlan,
+    cancelWorkItem,
     closeMergedPullRequest,
     createEdge,
     createWorkItem,
@@ -46,6 +47,7 @@
   let health = null;
   let activeTab = "planning";
   let closingIssue = false;
+  let cancelingWorkItem = false;
   let deletingWorkItem = false;
   let launchingExecution = false;
   let launchEligibilityById = {};
@@ -70,6 +72,7 @@
   let planStateLoadingIds = {};
   let planStateRequestTokenById = {};
   let planReview = null; // { workItemId, scratchpadContent } | null
+  let cancelDialog = null;
   let deleteDialog = null;
 
   // Panel collapse state
@@ -142,6 +145,7 @@
     planStateLoading: contextMenuPlanStateLoading,
     preparingPlan,
     approvingPlan,
+    cancelingWorkItem,
     deletingWorkItem,
     connectedEdges: graphContextMenu.item
       ? graph.edges.filter((edge) => edge.from_id === graphContextMenu.item.id || edge.to_id === graphContextMenu.item.id)
@@ -457,6 +461,46 @@
     }
   }
 
+  function openCancelDialog(item = selectedItem) {
+    if (!item?.id) return;
+    cancelDialog = {
+      item,
+      confirmCancel: false,
+      cancelNote: "",
+      submitting: false,
+    };
+    closeGraphContextMenu();
+  }
+
+  function closeCancelDialog() {
+    if (cancelDialog?.submitting) return;
+    cancelDialog = null;
+  }
+
+  async function confirmCancelWorkItem() {
+    if (!cancelDialog?.item?.id || cancelDialog.submitting) return;
+
+    cancelDialog = { ...cancelDialog, submitting: true };
+    cancelingWorkItem = true;
+    error = "";
+    notice = "";
+    try {
+      const result = await cancelWorkItem({
+        work_item_id: cancelDialog.item.id,
+        confirm_cancel: true,
+        cancel_note: cancelDialog.cancelNote?.trim() || undefined,
+      });
+      await loadGraph();
+      notice = `Cancelled ${result.work_item.id} and closed issue #${result.closed_issue.number}.`;
+      cancelDialog = null;
+    } catch (cancelError) {
+      error = cancelError.message;
+      cancelDialog = { ...cancelDialog, submitting: false };
+    } finally {
+      cancelingWorkItem = false;
+    }
+  }
+
   function openDeleteDialog(item = selectedItem) {
     if (!item?.id) return;
     const connectedEdges = graph.edges.filter((edge) => edge.from_id === item.id || edge.to_id === item.id);
@@ -537,6 +581,12 @@
       closeGraphContextMenu();
       if (planReview) {
         closePlanReview();
+      }
+      if (cancelDialog) {
+        closeCancelDialog();
+      }
+      if (deleteDialog) {
+        closeDeleteDialog();
       }
     }
   }
@@ -845,8 +895,10 @@
                   onCreateEdge={handleCreateEdge}
                   onDeleteEdge={handleDeleteEdge}
                   onCloseIssue={handleCloseIssue}
+                  onCancelWorkItem={openCancelDialog}
                   onDeleteWorkItem={openDeleteDialog}
                   {closingIssue}
+                  {cancelingWorkItem}
                   {deletingWorkItem}
                 />
               </div>
@@ -905,6 +957,8 @@
           } else if (event.detail.id === "review-plan") {
             handleReviewPlan(item, planStateById[item.id] ?? null);
             closeGraphContextMenu();
+          } else if (event.detail.id === "cancel-work-item") {
+            openCancelDialog(item);
           } else if (event.detail.id === "delete-work-item") {
             openDeleteDialog(item);
           }
@@ -937,6 +991,55 @@
             <button class="small" on:click={closePlanReview} aria-label="Close plan review">×</button>
           </header>
           <pre class="plan-review-body">{planReview.scratchpadContent}</pre>
+        </div>
+      </div>
+    {/if}
+
+    {#if cancelDialog}
+      <div class="plan-review-overlay" role="presentation" on:click={closeCancelDialog}>
+        <div
+          class="plan-review-card delete-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cancel-work-item-title"
+          on:click|stopPropagation
+        >
+          <header class="plan-review-header">
+            <h3 id="cancel-work-item-title">Cancel {cancelDialog.item.id}</h3>
+            <button class="small" on:click={closeCancelDialog} disabled={cancelDialog.submitting} aria-label="Close cancel dialog">×</button>
+          </header>
+
+          <div class="delete-dialog-body">
+            <p><strong>Cancel preserves the Studio node and history.</strong> This closes GitHub issue #{cancelDialog.item.issue_number} in {cancelDialog.item.repo}, archives any plan artifacts, and marks the work item <code>cancelled</code>.</p>
+            <label>
+              <span class="muted">Optional cancellation note</span>
+              <textarea
+                rows="4"
+                bind:value={cancelDialog.cancelNote}
+                placeholder="Optional note posted to the GitHub issue before it is closed."
+                disabled={cancelDialog.submitting}
+              ></textarea>
+            </label>
+            <label class="checkbox-row">
+              <input
+                type="checkbox"
+                checked={cancelDialog.confirmCancel}
+                on:change={(event) => cancelDialog = { ...cancelDialog, confirmCancel: event.currentTarget.checked }}
+              />
+              <span>I approve cancelling this work item and closing its GitHub issue.</span>
+            </label>
+          </div>
+
+          <footer class="delete-dialog-actions">
+            <button class="small" on:click={closeCancelDialog} disabled={cancelDialog.submitting}>Keep work item active</button>
+            <button
+              class="small"
+              on:click={confirmCancelWorkItem}
+              disabled={!cancelDialog.confirmCancel || cancelDialog.submitting}
+            >
+              {cancelDialog.submitting ? "Cancelling…" : "Cancel work item"}
+            </button>
+          </footer>
         </div>
       </div>
     {/if}

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -47,12 +47,14 @@
   export let onCreateEdge = () => {};
   export let onDeleteEdge = () => {};
   export let onCloseIssue = () => {};
+  export let onCancelWorkItem = () => {};
   export let onDeleteWorkItem = () => {};
   export let onLaunchExecution = () => {};
   export let onPreparePlan = () => {};
   export let onApprovePlan = () => {};
   export let onReviewPlan = () => {};
   export let closingIssue = false;
+  export let cancelingWorkItem = false;
   export let deletingWorkItem = false;
   export let preparingPlan = false;
   export let approvingPlan = false;
@@ -103,6 +105,10 @@
       && leafState(selectedItem?.state) === "merged_pr"
       && issueDetails?.state?.toLowerCase() !== "closed",
   );
+  $: canCancelWorkItem = selectedItem?.kind === "issue"
+    && !!selectedItem?.repo
+    && !!selectedItem?.issue_number
+    && ["planned", "drafting", "ready", "in_progress", "deferred"].includes(leafState(selectedItem?.state));
   $: canDeleteWorkItem = selectedItem?.kind === "issue"
     && !!selectedItem?.repo
     && !!selectedItem?.issue_number
@@ -189,6 +195,7 @@
   $: showReviewPlan = planSubState === "drafting" || planSubState === "ready";
   $: launchStateOk = leafState(selectedItem?.state) === "ready";
   $: launchIssueBacked = !!launchEligibility?.issue_backed;
+  $: showLaunchAction = launchIssueBacked && !["cancelled", "done", "archived", "closed"].includes(leafState(selectedItem?.state));
   $: launchAvailable = !!launchEligibility?.can_launch && launchStateOk && launchIssueBacked;
   $: launchDisabled = !launchAvailable
     || launchEligibilityLoading
@@ -298,6 +305,12 @@
                 {closingIssue ? 'Closing…' : 'Close issue'}
               </button>
             {/if}
+            {#if canCancelWorkItem}
+              <button class="small" on:click={() => onCancelWorkItem(selectedItem)} disabled={cancelingWorkItem}>
+                {cancelingWorkItem ? 'Cancelling…' : 'Cancel work item'}
+              </button>
+              <p class="muted">Cancel is non-destructive: it closes the linked GitHub issue, marks the node cancelled, and preserves planning history.</p>
+            {/if}
             {#if canDeleteWorkItem}
               <button class="danger small" on:click={() => onDeleteWorkItem(selectedItem)} disabled={deletingWorkItem}>
                 {deletingWorkItem ? 'Deleting…' : 'Delete work item'}
@@ -398,7 +411,7 @@
           {:else if launchAvailable}
             <p class="muted">Launch execution will start a run for this selected node.</p>
           {/if}
-          {#if launchIssueBacked}
+          {#if showLaunchAction}
             <button on:click={() => onLaunchExecution(selectedItem)} disabled={launchDisabled}>
               {launchingExecution ? "Launching..." : "Launch execution"}
             </button>

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -230,6 +230,14 @@ export function archiveAndCloseMergedPullRequest(workItemId) {
   });
 }
 
+export function cancelWorkItem(payload) {
+  return request("/api/execution/cancel-work-item", {
+    method: "POST",
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+}
+
 export function deleteWorkItem(payload) {
   return request("/api/execution/delete-work-item", {
     method: "POST",

--- a/web/src/lib/graph-node-actions.js
+++ b/web/src/lib/graph-node-actions.js
@@ -8,7 +8,9 @@ function leafState(state) {
   return state?.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
 }
 
+const CANCEL_ELIGIBLE_STATES = new Set(["planned", "drafting", "ready", "in_progress", "deferred"]);
 const DELETE_ELIGIBLE_STATES = new Set(["planned", "drafting", "ready"]);
+const HIDE_LAUNCH_STATES = new Set(["cancelled", "done", "archived", "closed"]);
 
 export function buildGraphNodeContextMenu({
   item,
@@ -19,6 +21,7 @@ export function buildGraphNodeContextMenu({
   planStateLoading = false,
   preparingPlan = false,
   approvingPlan = false,
+  cancelingWorkItem = false,
   deletingWorkItem = false,
   connectedEdges = [],
 } = {}) {
@@ -53,6 +56,10 @@ export function buildGraphNodeContextMenu({
         : formatDispatchNodeSummary(launchEligibility.dispatch_node);
 
   const actions = [];
+  const cancelEligible = item.kind === "issue"
+    && !!item.repo
+    && !!item.issue_number
+    && CANCEL_ELIGIBLE_STATES.has(workItemState);
   const deleteEligible = item.kind === "issue"
     && !!item.repo
     && !!item.issue_number
@@ -107,14 +114,27 @@ export function buildGraphNodeContextMenu({
     });
   }
 
-  actions.push({
-    id: "launch-execution",
-    kind: "button",
-    label: launchingExecution ? "Launching…" : "Launch execution",
-    description: launchDescription,
-    disabled: !launchGateOk,
-    emphasis: "primary",
-  });
+  if (!HIDE_LAUNCH_STATES.has(workItemState)) {
+    actions.push({
+      id: "launch-execution",
+      kind: "button",
+      label: launchingExecution ? "Launching…" : "Launch execution",
+      description: launchDescription,
+      disabled: !launchGateOk,
+      emphasis: "primary",
+    });
+  }
+
+  if (cancelEligible) {
+    actions.push({
+      id: "cancel-work-item",
+      kind: "button",
+      label: cancelingWorkItem ? "Cancelling…" : "Cancel work item",
+      description: "Non-destructive cancel. Closes the linked GitHub issue, marks the Studio node cancelled, and preserves planning history.",
+      disabled: cancelingWorkItem,
+      emphasis: "warn",
+    });
+  }
 
   if (deleteEligible) {
     actions.push({


### PR DESCRIPTION
## Summary
Execution run completed.

actual_files synced: 0 file(s).

## Context
- Work item: studio-136
- Issue: https://github.com/fusupo/escapement-studio/issues/136
- Base branch: develop
- Head branch: studio-136-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1776014902872
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-136-branch
- Scope hint: Add an approval-gated cancel flow that closes the GitHub issue and marks the corresponding graph work item cancelled without deleting historical planning data.

## Changed files
- (not recorded)