### PR TITLE
feat(platform): install @nestjs/cqrs platform bus (Phase 0) (#220)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rxjs": "^7.8.2"
       },
       "devDependencies": {
+        "@nestjs/testing": "^11.1.18",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.14.1",
@@ -1781,6 +1782,34 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/testing": {
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.18.tgz",
+      "integrity": "sha512-frzwNlpBgtAzI3hp/qo57DZoRO4RMTH1wST3QUYEhRTHyfPkLpzkWz3jV/mhApXjD0yT56Ptlzn6zuYPLh87Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nuxt/opencollective": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mariozechner/pi-coding-agent": "^0.65.0",
         "@nestjs/common": "^11.1.6",
         "@nestjs/core": "^11.1.6",
+        "@nestjs/cqrs": "^11.0.3",
         "@nestjs/platform-express": "^11.1.6",
         "@nestjs/schedule": "^6.1.1",
         "@scion-scxml/core": "^2.6.24",
@@ -1734,6 +1735,18 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/cqrs": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/cqrs/-/cqrs-11.0.3.tgz",
+      "integrity": "sha512-2ezBftiXqVfNTzjCrmhazohYhIQzgm8rvM0aKndv73IOOBcVlNuNiQ3HHiHdd4c2w/3MOQDtsGbQHgZUuW6DPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0",
+        "rxjs": "^7.2.0"
       }
     },
     "node_modules/@nestjs/platform-express": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rxjs": "^7.8.2"
   },
   "devDependencies": {
+    "@nestjs/testing": "^11.1.18",
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.14.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mariozechner/pi-coding-agent": "^0.65.0",
     "@nestjs/common": "^11.1.6",
     "@nestjs/core": "^11.1.6",
+    "@nestjs/cqrs": "^11.0.3",
     "@nestjs/platform-express": "^11.1.6",
     "@nestjs/schedule": "^6.1.1",
     "@scion-scxml/core": "^2.6.24",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from "@nestjs/common";
 import { ScheduleModule } from "@nestjs/schedule";
+import { PlatformModule } from "./platform/platform.module.js";
 import { ExecutionModule } from "./modules/execution/execution.module.js";
 import { GitHubModule } from "./modules/github/github.module.js";
 import { GraphModule } from "./modules/graph/graph.module.js";
@@ -10,6 +11,17 @@ import { ReconciliationModule } from "./modules/reconciliation/reconciliation.mo
 import { SettingsModule } from "./modules/settings/settings.module.js";
 
 @Module({
-  imports: [ScheduleModule.forRoot(), ExecutionModule, GraphModule, HealthModule, GitHubModule, PlanningModule, PlansModule, ReconciliationModule, SettingsModule],
+  imports: [
+    PlatformModule,
+    ScheduleModule.forRoot(),
+    ExecutionModule,
+    GraphModule,
+    HealthModule,
+    GitHubModule,
+    PlanningModule,
+    PlansModule,
+    ReconciliationModule,
+    SettingsModule,
+  ],
 })
 export class AppModule {}

--- a/src/platform/__tests__/bus.smoke.test.ts
+++ b/src/platform/__tests__/bus.smoke.test.ts
@@ -1,0 +1,91 @@
+import { Inject, Injectable } from "@nestjs/common";
+import {
+  CommandBus,
+  CommandHandler,
+  EventBus,
+  EventsHandler,
+  ICommand,
+  ICommandHandler,
+  IEvent,
+  IEventHandler,
+} from "@nestjs/cqrs";
+import { Test } from "@nestjs/testing";
+import { beforeEach, describe, expect, it } from "vitest";
+import { PlatformModule } from "../platform.module.js";
+
+class PingCommand implements ICommand {
+  constructor(public readonly message: string) {}
+}
+
+class PongEvent implements IEvent {
+  constructor(public readonly echo: string) {}
+}
+
+// Explicit @Inject(EventBus) is required: this repo runs vitest with the
+// default esbuild transformer, which does not emit `design:paramtypes`
+// decorator metadata, so Nest cannot infer the constructor dependency
+// from the TypeScript type. Real production handlers compiled by `tsc`
+// will have metadata and can use the implicit form.
+@CommandHandler(PingCommand)
+@Injectable()
+class PingHandler implements ICommandHandler<PingCommand, string> {
+  constructor(@Inject(EventBus) private readonly eventBus: EventBus) {}
+
+  async execute(command: PingCommand): Promise<string> {
+    const response = `pong:${command.message}`;
+    this.eventBus.publish(new PongEvent(response));
+    return response;
+  }
+}
+
+@EventsHandler(PongEvent)
+@Injectable()
+class PongRecorder implements IEventHandler<PongEvent> {
+  readonly received: string[] = [];
+
+  handle(event: PongEvent): void {
+    this.received.push(event.echo);
+  }
+}
+
+describe("platform bus smoke test", () => {
+  let commandBus: CommandBus;
+  let recorder: PongRecorder;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [PlatformModule],
+      providers: [PingHandler, PongRecorder],
+    }).compile();
+
+    // CqrsModule registers decorated handlers during app bootstrap.
+    // Test.createTestingModule does not call onApplicationBootstrap
+    // automatically — init() triggers it.
+    await moduleRef.init();
+
+    commandBus = moduleRef.get(CommandBus);
+    recorder = moduleRef.get(PongRecorder);
+  });
+
+  it("routes a command through its handler and returns the result", async () => {
+    const result = await commandBus.execute<PingCommand, string>(
+      new PingCommand("hello"),
+    );
+    expect(result).toBe("pong:hello");
+  });
+
+  it("publishes an event from inside a handler and routes it to subscribers", async () => {
+    await commandBus.execute<PingCommand, string>(new PingCommand("world"));
+    expect(recorder.received).toEqual(["pong:world"]);
+  });
+
+  it("throws when a command has no registered handler", () => {
+    class UnregisteredCommand implements ICommand {}
+    // @nestjs/cqrs v11 throws synchronously from execute() when the
+    // command id lookup fails, before constructing a returnable promise,
+    // so the assertion uses a thunk rather than .rejects.
+    expect(() => commandBus.execute(new UnregisteredCommand())).toThrow(
+      /No handler found/,
+    );
+  });
+});

--- a/src/platform/platform.module.ts
+++ b/src/platform/platform.module.ts
@@ -1,0 +1,26 @@
+import { Global, Module } from "@nestjs/common";
+import { CqrsModule } from "@nestjs/cqrs";
+
+/**
+ * Global platform infrastructure. Every feature module gets access to
+ * CommandBus, EventBus, and QueryBus (from @nestjs/cqrs) without having
+ * to import PlatformModule explicitly — the @Global() decorator makes
+ * its exports available to every module.
+ *
+ * Feature modules MUST NOT import other feature modules directly.
+ * Cross-context communication routes through:
+ *
+ *   - CommandBus.execute(new OtherContextCommand(...))  — when one caller
+ *     expects one handler to run and return a result
+ *   - EventBus.publish(new SomethingHappenedEvent(...))  — when N
+ *     subscribers react to a domain fact, fire-and-forget
+ *
+ * See docs/proposals/phase-0-platform-bus.md for the conventions the bus
+ * imposes and the rationale for the module star-shape.
+ */
+@Global()
+@Module({
+  imports: [CqrsModule],
+  exports: [CqrsModule],
+})
+export class PlatformModule {}


### PR DESCRIPTION
## Summary
Phase 0 of the cqrs refactor series. Installs `@nestjs/cqrs@^11` and wires
a new `@Global() PlatformModule` into `AppModule` so `CommandBus`,
`EventBus`, and `QueryBus` are ambient for every feature module. Adds a
throwaway smoke test that proves command + event round-trip end-to-end.

**No production code is migrated onto the bus.** This PR is strictly the
plumbing seam that Phase 2+ depends on. Phase 1 (HSM action handlers) is
independent and does not consume the bus.

Closes #220. Full scope: [`docs/proposals/phase-0-platform-bus.md`](docs/proposals/phase-0-platform-bus.md).

## Key changes
- `chore(deps)`: `@nestjs/cqrs@^11.0.3` runtime dep, `@nestjs/testing@^11.1.18` dev dep
- `feat(platform)`: new `src/platform/platform.module.ts` (`@Global`, exports `CqrsModule`) — first feature import in `AppModule`
- `test(platform)`: `src/platform/__tests__/bus.smoke.test.ts` covering command round-trip, handler-published event reaching a separate subscriber, and unregistered-command error

## forwardRef count
**11 → 11 (unchanged.)** Phase 0 does not remove any cycles; that's Phase 2+ work. Verified via:

\`\`\`
grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l
\`\`\`

## Deviations from the proposal
1. **\`@nestjs/testing\` was not in the project.** Added as a devDependency at \`^11.1.18\` to enable \`Test.createTestingModule\`. The proposal assumed it was present.
2. **Smoke test handler uses explicit \`@Inject(EventBus)\`.** Vitest's default esbuild transformer does not emit \`design:paramtypes\` decorator metadata, so Nest cannot infer the constructor dependency from the TypeScript type. Production handlers compiled by \`tsc\` will not need this. Documented inline in the test.
3. **Third smoke test asserts via \`expect(() => …).toThrow()\` rather than \`.rejects.toThrow()\`.** \`@nestjs/cqrs@11\` throws synchronously from \`CommandBus.execute()\` when the command id lookup fails, before constructing a returnable promise.

## Test plan
- [x] \`npm run check\` (tsc) — clean
- [x] \`npm test\` — 518/518 pass (3 new smoke tests in \`src/platform/__tests__/bus.smoke.test.ts\`)
- [x] \`npm run build:web\` — clean
- [x] \`npm ls @nestjs/cqrs\` → single \`11.0.3\` entry, no peer warnings
- [x] \`npm start\` boots; \`GET /health\` → \`{"ok":true,"db":{...}}\`
- [x] \`forwardRef\` count unchanged (11)

## What's next
Phase 1 ([\`docs/proposals/phase-1-hsm-action-handlers.md\`](docs/proposals/phase-1-hsm-action-handlers.md)) is independent of the bus and can land in parallel.

Phase 2 ([\`docs/proposals/phase-2-work-items-controller-command-bus.md\`](docs/proposals/phase-2-work-items-controller-command-bus.md)) is the first phase that actually dispatches through this bus — it moves \`cancelWorkItem\` / \`deleteWorkItem\` out of \`ExecutionService\` into command handlers and removes the \`GraphModule → ExecutionModule\` forwardRef.