### PR TITLE
refactor: extract RunDispositionService from the god class (Phase 3) (#223)

### DIFF
--- a/src/modules/execution/__tests__/archive-run-artifacts.test.ts
+++ b/src/modules/execution/__tests__/archive-run-artifacts.test.ts
@@ -3,17 +3,18 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
-import { ExecutionService } from "../execution.service.js";
+import { RunDispositionService } from "../run-disposition.service.js";
 import { archiveDir, runsRoot } from "../../../lib/context-layout.js";
 import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
 import type { WorkItemRecord } from "../../graph/types.js";
 
 /**
- * Issue #86: tests for the thin `ExecutionService.archiveRunArtifacts`
- * wrapper. Uses the same prototype-harness pattern as
- * `disposition.test.ts` \u2014 real filesystem root via `mkdtempSync`, mocked
- * `workItemsService`, stubbed `listRecentRuns`, and the service instance
- * built via `Object.create(ExecutionService.prototype)`.
+ * Issue #86 / Phase 3 (#223): tests for the `archiveRunArtifacts` wrapper,
+ * now owned by `RunDispositionService`. Uses the same prototype-harness
+ * pattern as `disposition.test.ts` \u2014 real filesystem root via `mkdtempSync`,
+ * mocked `workItemsService`, stubbed in-memory run buffer via a fake
+ * `executionService.listRecentRuns`, and the service instance built via
+ * `Object.create(RunDispositionService.prototype)`.
  */
 
 interface HarnessService {
@@ -23,8 +24,10 @@ interface HarnessService {
     get: (id: string) => WorkItemRecord;
     update: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
   };
-  listRecentRuns: () => ExecutionRunRecord[];
-  archiveRunArtifacts: ExecutionService["archiveRunArtifacts"];
+  executionService: {
+    listRecentRuns: () => ExecutionRunRecord[];
+  };
+  archiveRunArtifacts: RunDispositionService["archiveRunArtifacts"];
   assertNoActiveRunForWorkItem: (id: string) => void;
   getErrorMessage: (err: unknown) => string;
 }
@@ -84,7 +87,7 @@ function makeService(params: {
   workItem?: WorkItemRecord;
   runs?: ExecutionRunRecord[];
 }): HarnessService {
-  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  const service = Object.create(RunDispositionService.prototype) as HarnessService;
   const workItem = params.workItem ?? makeWorkItem();
 
   service.artifactRoot = params.artifactRoot;
@@ -96,11 +99,13 @@ function makeService(params: {
     },
     update: (_id, _patch) => workItem,
   };
-  service.listRecentRuns = () => params.runs ?? [];
+  service.executionService = {
+    listRecentRuns: () => params.runs ?? [],
+  };
   return service;
 }
 
-describe("ExecutionService.archiveRunArtifacts", () => {
+describe("RunDispositionService.archiveRunArtifacts", () => {
   let tmpRoot: string;
 
   beforeEach(() => {

--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
-import { ExecutionService } from "../execution.service.js";
+import { RunDispositionService } from "../run-disposition.service.js";
 import {
   archiveDir,
   canonicalScratchpadPath,
@@ -14,12 +14,20 @@ import type { CancelWorkItemResult, DeleteWorkItemResult, ExecutionDispatchPrevi
 import type { DispatchResult, WorkItemRecord, WorkItemState } from "../../graph/types.js";
 
 /**
- * ADR 014 step 7: disposition flow for `merged_pr → done` and plan dir
- * archival on done/cancelled.
+ * ADR 014 step 7 / Phase 3 (#223): disposition flow for `merged_pr → done`
+ * and plan dir archival on done/cancelled. All nine methods under test now
+ * live on `RunDispositionService`; the harness stubs the fields of the
+ * extracted sub-service directly via `Object.create`.
+ *
+ * Run buffer state (`recentRuns`) is now owned by `ExecutionService`. The
+ * harness stubs it through a fake `executionService` field that provides
+ * `listRecentRuns`, `disposeRunsForWorkItemInBuffer`, and
+ * `emitRunExecutionResult`. `removeRunsForWorkItem`'s in-memory walk
+ * happens inside the fake now; the on-disk portion still runs inside the
+ * real `RunDispositionService` method body.
  *
  * Tests use real `mkdtempSync` context roots so `planDir` / `archiveDir` /
- * `renameSync` exercise actual filesystem semantics. Harness pattern matches
- * scratchpad-canonical.test.ts / scratchpad-commit-guards.test.ts.
+ * `renameSync` exercise actual filesystem semantics.
  */
 
 interface HarnessService {
@@ -31,7 +39,6 @@ interface HarnessService {
     getConnectedEdges: (id: string) => Array<{ id: number; from_id: string; rel: string; to_id: string }>;
     deleteWithConnectedEdges: (id: string, edgeIds: number[]) => { deleted: true; id: string; removed_edge_ids: number[] };
   };
-  listRecentRuns: () => ExecutionRunRecord[];
 
   // studio-196 HSM dispatch
   hsmService: {
@@ -50,16 +57,33 @@ interface HarnessService {
     invalidate: ReturnType<typeof vi.fn>;
     invalidateAll: ReturnType<typeof vi.fn>;
   };
+  plansService: {
+    deletePlanArtifacts: ReturnType<typeof vi.fn>;
+  };
+
+  // Phase 3: the run buffer now lives on ExecutionService. The fake exposes
+  // the three public seams RunDispositionService uses to mutate / emit it.
+  executionService: {
+    listRecentRuns: () => ExecutionRunRecord[];
+    disposeRunsForWorkItemInBuffer: (
+      workItemId: string,
+      disposedAt: string,
+    ) => { newlyDisposed: ExecutionRunRecord[]; alreadyDisposedIds: string[] };
+    emitRunExecutionResult: (run: ExecutionRunRecord) => void;
+    getPreview: (repo?: string) => ExecutionDispatchPreview;
+  };
+
+  // Test fixtures (mirror the fields we wire onto the harness so tests can
+  // continue to poke the same arrays they did against the old service).
   recentRuns: ExecutionRunRecord[];
-  writeStatus: ReturnType<typeof vi.fn>;
   emitRun: ReturnType<typeof vi.fn>;
-  getPreview: (repo?: string) => ExecutionDispatchPreview;
+  writeStatus: ReturnType<typeof vi.fn>;
 
   // Methods under test (prototype — available via Object.create)
-  closeMergedPullRequest: ExecutionService["closeMergedPullRequest"];
-  archiveAndCloseMergedPullRequest: ExecutionService["archiveAndCloseMergedPullRequest"];
-  cancelWorkItem: ExecutionService["cancelWorkItem"];
-  deleteWorkItem: ExecutionService["deleteWorkItem"];
+  closeMergedPullRequest: RunDispositionService["closeMergedPullRequest"];
+  archiveAndCloseMergedPullRequest: RunDispositionService["archiveAndCloseMergedPullRequest"];
+  cancelWorkItem: RunDispositionService["cancelWorkItem"];
+  deleteWorkItem: RunDispositionService["deleteWorkItem"];
   // Private helpers exposed via prototype for direct testing
   assertWorkItemInMergedPr: (id: string) => WorkItemRecord;
   assertNoActiveRunForWorkItem: (id: string) => void;
@@ -145,7 +169,7 @@ function makeService(params: {
   updateImpl?: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
   hsmDispatch?: ReturnType<typeof vi.fn>;
 }): HarnessService {
-  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  const service = Object.create(RunDispositionService.prototype) as HarnessService;
   let currentWorkItem = params.workItem ?? makeWorkItem();
 
   service.artifactRoot = params.artifactRoot;
@@ -178,10 +202,11 @@ function makeService(params: {
     })) as HarnessService["workItemsService"]["deleteWithConnectedEdges"],
   };
 
-  // studio-87 close-flow deps. recentRuns is the real in-memory buffer
-  // (private field on ExecutionService) so we test the actual splice.
+  // Phase 3: `recentRuns` is no longer a field on the service under test.
+  // It lives on ExecutionService in production; the harness models it as
+  // a shared fixture array that the fake executionService seams walk and
+  // splice on behalf of RunDispositionService.removeRunsForWorkItem.
   service.recentRuns = [...(params.runs ?? [])];
-  service.listRecentRuns = () => [...service.recentRuns];
   service.githubService = {
     closeIssue: params.githubCloseIssue ??
       vi.fn(async (repo: string, issueNumber: number, _comment?: string | null) => ({
@@ -197,11 +222,60 @@ function makeService(params: {
       })),
     deleteIssue: params.githubDeleteIssue ?? vi.fn(async (repo: string, issueNumber: number) => ({ repo, number: issueNumber, deleted: true })),
   };
-  // Stub filesystem + event emission so we don't need real artifact dirs
-  // or a live Subject. The real method delegates to node:fs / rxjs.
-  service.writeStatus = vi.fn();
-  service.emitRun = vi.fn();
-  service.getPreview = vi.fn(() => makeDispatchPreviewStub()) as HarnessService["getPreview"];
+  // Filesystem + event emission spies. The fake executionService below
+  // calls these on behalf of RunDispositionService so the legacy
+  // assertions (`writeStatus` / `emitRun` call counts) keep working
+  // without having to reach into ExecutionService internals.
+  const writeStatus = vi.fn();
+  const emitRun = vi.fn();
+  service.emitRun = emitRun;
+  service.executionService = {
+    listRecentRuns: () => [...service.recentRuns],
+    disposeRunsForWorkItemInBuffer: vi.fn((workItemId: string, disposedAt: string) => {
+      const newlyDisposed: ExecutionRunRecord[] = [];
+      const alreadyDisposedIds: string[] = [];
+      for (let i = service.recentRuns.length - 1; i >= 0; i--) {
+        const run = service.recentRuns[i];
+        if (run.work_item_id !== workItemId) continue;
+        if (run.disposed_at) {
+          service.recentRuns.splice(i, 1);
+          alreadyDisposedIds.push(run.run_id);
+          continue;
+        }
+        const next: ExecutionRunRecord = {
+          ...run,
+          disposed_at: disposedAt,
+          updated_at: disposedAt,
+        };
+        // Production's disposeRunsForWorkItemInBuffer swallows ENOENT
+        // from writeStatus (the disk file may be missing after a partial
+        // failure / restart) but still treats the run as disposed. Mirror
+        // that contract here so the ENOENT idempotency test passes.
+        try {
+          writeStatus(next);
+        } catch (error) {
+          const isMissing =
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            (error as { code?: unknown }).code === "ENOENT";
+          if (!isMissing) {
+            throw error;
+          }
+        }
+        service.recentRuns.splice(i, 1);
+        newlyDisposed.push(next);
+      }
+      return { newlyDisposed, alreadyDisposedIds };
+    }),
+    emitRunExecutionResult: vi.fn((run: ExecutionRunRecord) => {
+      emitRun("execution_result", run);
+    }),
+    getPreview: vi.fn(() => makeDispatchPreviewStub()),
+  };
+  // Legacy field used by tests that assert on writeStatus calls directly.
+  // Bound to the same spy the fake executionService seam calls.
+  service.writeStatus = writeStatus;
 
   // studio-196: default HSM dispatch mock — transitions to done for user.finalize.
   // The mock updates currentWorkItem's state so workItemsService.get returns

--- a/src/modules/execution/__tests__/hsm-action-handlers.test.ts
+++ b/src/modules/execution/__tests__/hsm-action-handlers.test.ts
@@ -7,14 +7,6 @@ import type {
   WorkItemRecord,
 } from "../../graph/types.js";
 
-vi.mock("../run-archiver.js", () => ({
-  archiveRunArtifactsForWorkItem: vi.fn(),
-}));
-
-import { archiveRunArtifactsForWorkItem } from "../run-archiver.js";
-
-const archiveMock = vi.mocked(archiveRunArtifactsForWorkItem);
-
 function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
   return {
     id: "studio-221",
@@ -130,85 +122,43 @@ describe("HsmActionHandlers (execution module)", () => {
   });
 
   describe("runArchiver", () => {
-    function makeExecutionMock() {
-      return {
-        captureRunSnapshotForWorkItem: vi.fn(() => []),
-        movePlanDirToArchives: vi.fn(() => ({
-          moved: true,
-          archive_path: "/tmp/studio-archive/studio-221",
-        })),
-        getArtifactRoot: vi.fn(() => "/tmp/studio-artifact-root"),
-        logWarn: vi.fn(),
-      };
-    }
+    // Phase 3 collapsed runArchiver to a one-line delegation to
+    // RunDispositionService.archiveRunArtifactsAction. The orchestration
+    // (capture / move / archive / ctx mutation / error translation) moved
+    // to run-disposition.service.ts and is covered by the disposition
+    // test file. These tests only verify the delegation contract.
 
-    it("snapshots runs, moves the plan dir, archives, and stamps studio_archive meta", async () => {
-      const execution = makeExecutionMock();
-      archiveMock.mockReturnValue({
-        work_item_id: "studio-221",
-        archive_path: "/tmp/studio-archive/studio-221",
-        readme_path: "/tmp/studio-archive/studio-221/README.md",
-        archived_run_ids: ["exec_42"],
-        skipped_run_ids: [],
-      });
+    it("delegates to RunDispositionService.archiveRunArtifactsAction", async () => {
+      const archiveRunArtifactsAction = vi.fn().mockResolvedValue(undefined);
+      const disposition = { archiveRunArtifactsAction } as never;
       const handlers = new HsmActionHandlers(
         {} as never,
         {} as never,
-        execution as never,
+        disposition,
       );
+      const workItem = makeWorkItem({ state: "merged_pr" });
       const ctx = makeContext();
 
-      await handlers.runArchiver(
-        makeWorkItem({ state: "merged_pr" }),
-        archiveEvent,
-        ctx,
-      );
+      await handlers.runArchiver(workItem, archiveEvent, ctx);
 
-      expect(execution.captureRunSnapshotForWorkItem).toHaveBeenCalledWith("studio-221");
-      expect(execution.movePlanDirToArchives).toHaveBeenCalledWith("studio-221");
-      expect(archiveMock).toHaveBeenCalledTimes(1);
-      expect(ctx.meta.studio_archive).toMatchObject({
-        readme_path: "/tmp/studio-archive/studio-221/README.md",
-        archived_run_ids: ["exec_42"],
-        skipped_run_ids: [],
-      });
-      expect(ctx.patch_overrides.archive_path).toBe("/tmp/studio-archive/studio-221");
-      expect(ctx.handler_data.archive_result).toMatchObject({
-        archive_path: "/tmp/studio-archive/studio-221",
-        archived_run_ids: ["exec_42"],
-      });
+      expect(archiveRunArtifactsAction).toHaveBeenCalledTimes(1);
+      expect(archiveRunArtifactsAction).toHaveBeenCalledWith(workItem, archiveEvent, ctx);
     });
 
-    it("translates archive_run_active errors into BadRequestException", async () => {
-      const execution = makeExecutionMock();
-      archiveMock.mockImplementation(() => {
-        throw new Error("archive_run_active: run exec_99 still active");
-      });
+    it("propagates errors from RunDispositionService unchanged", async () => {
+      const archiveRunArtifactsAction = vi
+        .fn()
+        .mockRejectedValue(new BadRequestException("archive_run_active: exec_99"));
+      const disposition = { archiveRunArtifactsAction } as never;
       const handlers = new HsmActionHandlers(
         {} as never,
         {} as never,
-        execution as never,
+        disposition,
       );
 
       await expect(
         handlers.runArchiver(makeWorkItem(), archiveEvent, makeContext()),
       ).rejects.toThrow(BadRequestException);
-    });
-
-    it("propagates unrelated errors unchanged", async () => {
-      const execution = makeExecutionMock();
-      archiveMock.mockImplementation(() => {
-        throw new Error("disk full");
-      });
-      const handlers = new HsmActionHandlers(
-        {} as never,
-        {} as never,
-        execution as never,
-      );
-
-      await expect(
-        handlers.runArchiver(makeWorkItem(), archiveEvent, makeContext()),
-      ).rejects.toThrow(/^disk full$/);
     });
   });
 });

--- a/src/modules/execution/__tests__/run-buffer-seams.test.ts
+++ b/src/modules/execution/__tests__/run-buffer-seams.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { ExecutionService } from "../execution.service.js";
+import type { ExecutionRunRecord } from "../types.js";
+
+/**
+ * Phase 3 (#223) seams for RunDispositionService to mutate and emit
+ * events on the ExecutionService in-memory run buffer without reaching
+ * into private state. Phase 4 replaces these with RunStore methods and
+ * the forwardRef(() => ExecutionService) in RunDispositionService
+ * disappears.
+ *
+ * Tests use the Object.create(ExecutionService.prototype) harness pattern
+ * established elsewhere in the execution test suite, bypassing Nest DI.
+ */
+
+interface HarnessService {
+  recentRuns: ExecutionRunRecord[];
+  logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+  writeStatus: ReturnType<typeof vi.fn>;
+  emitRun: ReturnType<typeof vi.fn>;
+  disposeRunsForWorkItemInBuffer: ExecutionService["disposeRunsForWorkItemInBuffer"];
+  emitRunExecutionResult: ExecutionService["emitRunExecutionResult"];
+}
+
+function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecord {
+  return {
+    run_id: "exec_seam",
+    run_type: "execution",
+    work_item_id: "studio-seam",
+    work_item_name: "Seam test",
+    status: "completed",
+    created_at: "2026-04-12T00:00:00.000Z",
+    updated_at: "2026-04-12T00:00:00.000Z",
+    repo: "fusupo/escapement-studio",
+    issue_url: null,
+    branch: "seam",
+    base_ref: "develop",
+    worktree_path: "",
+    artifact_dir: "",
+    prompt: "",
+    activity_log: [],
+    safety_checks: [],
+    ...overrides,
+  };
+}
+
+function makeHarness(runs: ExecutionRunRecord[]): HarnessService {
+  const service = Object.create(ExecutionService.prototype) as HarnessService;
+  service.recentRuns = [...runs];
+  service.logger = { log: vi.fn(), warn: vi.fn() };
+  service.writeStatus = vi.fn();
+  service.emitRun = vi.fn();
+  return service;
+}
+
+describe("ExecutionService.disposeRunsForWorkItemInBuffer", () => {
+  it("splices matching runs and returns newly-disposed records", () => {
+    const service = makeHarness([
+      makeRun({ run_id: "exec_a", work_item_id: "studio-42" }),
+      makeRun({ run_id: "exec_other", work_item_id: "studio-999" }),
+      makeRun({ run_id: "exec_b", work_item_id: "studio-42", status: "error" }),
+    ]);
+
+    const { newlyDisposed, alreadyDisposedIds } =
+      service.disposeRunsForWorkItemInBuffer("studio-42", "2026-04-13T09:00:00.000Z");
+
+    expect(newlyDisposed.map((r) => r.run_id).sort()).toEqual(["exec_a", "exec_b"]);
+    expect(alreadyDisposedIds).toEqual([]);
+    expect(service.recentRuns.map((r) => r.run_id)).toEqual(["exec_other"]);
+    // writeStatus called for each newly disposed record
+    expect(service.writeStatus).toHaveBeenCalledTimes(2);
+    for (const call of service.writeStatus.mock.calls) {
+      const run = call[0] as ExecutionRunRecord;
+      expect(run.disposed_at).toBe("2026-04-13T09:00:00.000Z");
+      expect(run.updated_at).toBe("2026-04-13T09:00:00.000Z");
+    }
+  });
+
+  it("returns already-disposed run ids separately and does not re-stamp or call writeStatus", () => {
+    const service = makeHarness([
+      makeRun({
+        run_id: "exec_old",
+        work_item_id: "studio-42",
+        disposed_at: "2026-04-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const { newlyDisposed, alreadyDisposedIds } =
+      service.disposeRunsForWorkItemInBuffer("studio-42", "2026-04-13T09:00:00.000Z");
+
+    expect(newlyDisposed).toEqual([]);
+    expect(alreadyDisposedIds).toEqual(["exec_old"]);
+    expect(service.recentRuns).toEqual([]);
+    expect(service.writeStatus).not.toHaveBeenCalled();
+  });
+
+  it("swallows ENOENT from writeStatus and still treats the run as disposed", () => {
+    const service = makeHarness([
+      makeRun({ run_id: "exec_missing", work_item_id: "studio-42" }),
+    ]);
+    service.writeStatus.mockImplementation(() => {
+      const err = new Error("ENOENT: no such file or directory");
+      (err as Error & { code?: string }).code = "ENOENT";
+      throw err;
+    });
+
+    const { newlyDisposed } = service.disposeRunsForWorkItemInBuffer(
+      "studio-42",
+      "2026-04-13T09:00:00.000Z",
+    );
+
+    expect(newlyDisposed.map((r) => r.run_id)).toEqual(["exec_missing"]);
+    expect(service.recentRuns).toEqual([]);
+    expect(service.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("failed to stamp disposed_at"),
+    );
+  });
+
+  it("logs and continues on non-ENOENT writeStatus errors", () => {
+    const service = makeHarness([
+      makeRun({ run_id: "exec_io", work_item_id: "studio-42" }),
+    ]);
+    service.writeStatus.mockImplementation(() => {
+      throw new Error("EACCES: permission denied");
+    });
+
+    const { newlyDisposed } = service.disposeRunsForWorkItemInBuffer(
+      "studio-42",
+      "2026-04-13T09:00:00.000Z",
+    );
+
+    expect(newlyDisposed.map((r) => r.run_id)).toEqual(["exec_io"]);
+    expect(service.recentRuns).toEqual([]);
+    expect(service.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to stamp disposed_at for run exec_io"),
+    );
+  });
+
+  it("returns empty lists when no runs match", () => {
+    const service = makeHarness([
+      makeRun({ run_id: "exec_other", work_item_id: "studio-999" }),
+    ]);
+
+    const { newlyDisposed, alreadyDisposedIds } =
+      service.disposeRunsForWorkItemInBuffer("studio-42", "2026-04-13T09:00:00.000Z");
+
+    expect(newlyDisposed).toEqual([]);
+    expect(alreadyDisposedIds).toEqual([]);
+    expect(service.recentRuns).toHaveLength(1);
+  });
+});
+
+describe("ExecutionService.emitRunExecutionResult", () => {
+  it("emits an execution_result event via the private emitRun helper", () => {
+    const service = makeHarness([]);
+    const run = makeRun({ run_id: "exec_emit", disposed_at: "2026-04-13T09:00:00.000Z" });
+
+    service.emitRunExecutionResult(run);
+
+    expect(service.emitRun).toHaveBeenCalledTimes(1);
+    expect(service.emitRun).toHaveBeenCalledWith("execution_result", run);
+  });
+
+  it("swallows and warns when the underlying emitRun throws", () => {
+    const service = makeHarness([]);
+    service.emitRun.mockImplementation(() => {
+      throw new Error("rxjs stream closed");
+    });
+    const run = makeRun({ run_id: "exec_crash" });
+
+    expect(() => service.emitRunExecutionResult(run)).not.toThrow();
+    expect(service.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to emit execution_result for run exec_crash"),
+    );
+  });
+});

--- a/src/modules/execution/application/commands/__tests__/archive-and-close-merged-pull-request.handler.test.ts
+++ b/src/modules/execution/application/commands/__tests__/archive-and-close-merged-pull-request.handler.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { ArchiveAndCloseMergedPullRequestCommand } from "../archive-and-close-merged-pull-request.command.js";
+import { ArchiveAndCloseMergedPullRequestHandler } from "../archive-and-close-merged-pull-request.handler.js";
+
+describe("ArchiveAndCloseMergedPullRequestHandler", () => {
+  it("delegates to RunDispositionService.archiveAndCloseMergedPullRequest with the workItemId", async () => {
+    const archiveAndCloseMergedPullRequest = vi
+      .fn()
+      .mockResolvedValue({ work_item: { id: "studio-17", state: "archived" } });
+    const disposition = { archiveAndCloseMergedPullRequest } as never;
+    const handler = new ArchiveAndCloseMergedPullRequestHandler(disposition);
+
+    const result = await handler.execute(
+      new ArchiveAndCloseMergedPullRequestCommand("studio-17"),
+    );
+
+    expect(archiveAndCloseMergedPullRequest).toHaveBeenCalledWith("studio-17");
+    expect(result).toEqual({ work_item: { id: "studio-17", state: "archived" } });
+  });
+});

--- a/src/modules/execution/application/commands/__tests__/cancel-work-item.handler.test.ts
+++ b/src/modules/execution/application/commands/__tests__/cancel-work-item.handler.test.ts
@@ -3,10 +3,10 @@ import { CancelWorkItemCommand } from "../cancel-work-item.command.js";
 import { CancelWorkItemHandler } from "../cancel-work-item.handler.js";
 
 describe("CancelWorkItemHandler", () => {
-  it("delegates to ExecutionService.cancelWorkItem with the dto", async () => {
+  it("delegates to RunDispositionService.cancelWorkItem with the dto", async () => {
     const cancelWorkItem = vi.fn().mockResolvedValue({ cancelled: true });
-    const execution = { cancelWorkItem } as never;
-    const handler = new CancelWorkItemHandler(execution);
+    const disposition = { cancelWorkItem } as never;
+    const handler = new CancelWorkItemHandler(disposition);
 
     const result = await handler.execute(
       new CancelWorkItemCommand({

--- a/src/modules/execution/application/commands/__tests__/close-merged-pull-request.handler.test.ts
+++ b/src/modules/execution/application/commands/__tests__/close-merged-pull-request.handler.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { CloseMergedPullRequestCommand } from "../close-merged-pull-request.command.js";
+import { CloseMergedPullRequestHandler } from "../close-merged-pull-request.handler.js";
+
+describe("CloseMergedPullRequestHandler", () => {
+  it("delegates to RunDispositionService.closeMergedPullRequest with the workItemId", async () => {
+    const closeMergedPullRequest = vi
+      .fn()
+      .mockResolvedValue({ work_item: { id: "studio-17", state: "done" } });
+    const disposition = { closeMergedPullRequest } as never;
+    const handler = new CloseMergedPullRequestHandler(disposition);
+
+    const result = await handler.execute(
+      new CloseMergedPullRequestCommand("studio-17"),
+    );
+
+    expect(closeMergedPullRequest).toHaveBeenCalledWith("studio-17");
+    expect(result).toEqual({ work_item: { id: "studio-17", state: "done" } });
+  });
+});

--- a/src/modules/execution/application/commands/__tests__/delete-work-item.handler.test.ts
+++ b/src/modules/execution/application/commands/__tests__/delete-work-item.handler.test.ts
@@ -3,10 +3,10 @@ import { DeleteWorkItemCommand } from "../delete-work-item.command.js";
 import { DeleteWorkItemHandler } from "../delete-work-item.handler.js";
 
 describe("DeleteWorkItemHandler", () => {
-  it("delegates to ExecutionService.deleteWorkItem with the dto", async () => {
+  it("delegates to RunDispositionService.deleteWorkItem with the dto", async () => {
     const deleteWorkItem = vi.fn().mockResolvedValue({ deleted: true });
-    const execution = { deleteWorkItem } as never;
-    const handler = new DeleteWorkItemHandler(execution);
+    const disposition = { deleteWorkItem } as never;
+    const handler = new DeleteWorkItemHandler(disposition);
 
     const result = await handler.execute(
       new DeleteWorkItemCommand({

--- a/src/modules/execution/application/commands/archive-and-close-merged-pull-request.command.ts
+++ b/src/modules/execution/application/commands/archive-and-close-merged-pull-request.command.ts
@@ -1,0 +1,5 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class ArchiveAndCloseMergedPullRequestCommand implements ICommand {
+  constructor(public readonly workItemId: string) {}
+}

--- a/src/modules/execution/application/commands/archive-and-close-merged-pull-request.handler.ts
+++ b/src/modules/execution/application/commands/archive-and-close-merged-pull-request.handler.ts
@@ -1,0 +1,24 @@
+import { Inject } from "@nestjs/common";
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { RunDispositionService } from "../../run-disposition.service.js";
+import type { ArchiveAndCloseMergedPullRequestResult } from "../../types.js";
+import { ArchiveAndCloseMergedPullRequestCommand } from "./archive-and-close-merged-pull-request.command.js";
+
+@CommandHandler(ArchiveAndCloseMergedPullRequestCommand)
+export class ArchiveAndCloseMergedPullRequestHandler
+  implements
+    ICommandHandler<
+      ArchiveAndCloseMergedPullRequestCommand,
+      ArchiveAndCloseMergedPullRequestResult
+    >
+{
+  constructor(
+    @Inject(RunDispositionService) private readonly disposition: RunDispositionService,
+  ) {}
+
+  async execute(
+    command: ArchiveAndCloseMergedPullRequestCommand,
+  ): Promise<ArchiveAndCloseMergedPullRequestResult> {
+    return await this.disposition.archiveAndCloseMergedPullRequest(command.workItemId);
+  }
+}

--- a/src/modules/execution/application/commands/cancel-work-item.handler.ts
+++ b/src/modules/execution/application/commands/cancel-work-item.handler.ts
@@ -1,6 +1,6 @@
 import { Inject } from "@nestjs/common";
 import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
-import { ExecutionService } from "../../execution.service.js";
+import { RunDispositionService } from "../../run-disposition.service.js";
 import type { CancelWorkItemResult } from "../../types.js";
 import { CancelWorkItemCommand } from "./cancel-work-item.command.js";
 
@@ -9,10 +9,10 @@ export class CancelWorkItemHandler
   implements ICommandHandler<CancelWorkItemCommand, CancelWorkItemResult>
 {
   constructor(
-    @Inject(ExecutionService) private readonly execution: ExecutionService,
+    @Inject(RunDispositionService) private readonly disposition: RunDispositionService,
   ) {}
 
   async execute(command: CancelWorkItemCommand): Promise<CancelWorkItemResult> {
-    return await this.execution.cancelWorkItem(command.dto);
+    return await this.disposition.cancelWorkItem(command.dto);
   }
 }

--- a/src/modules/execution/application/commands/close-merged-pull-request.command.ts
+++ b/src/modules/execution/application/commands/close-merged-pull-request.command.ts
@@ -1,0 +1,5 @@
+import { ICommand } from "@nestjs/cqrs";
+
+export class CloseMergedPullRequestCommand implements ICommand {
+  constructor(public readonly workItemId: string) {}
+}

--- a/src/modules/execution/application/commands/close-merged-pull-request.handler.ts
+++ b/src/modules/execution/application/commands/close-merged-pull-request.handler.ts
@@ -1,0 +1,20 @@
+import { Inject } from "@nestjs/common";
+import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
+import { RunDispositionService } from "../../run-disposition.service.js";
+import type { CloseMergedPullRequestResult } from "../../types.js";
+import { CloseMergedPullRequestCommand } from "./close-merged-pull-request.command.js";
+
+@CommandHandler(CloseMergedPullRequestCommand)
+export class CloseMergedPullRequestHandler
+  implements ICommandHandler<CloseMergedPullRequestCommand, CloseMergedPullRequestResult>
+{
+  constructor(
+    @Inject(RunDispositionService) private readonly disposition: RunDispositionService,
+  ) {}
+
+  async execute(
+    command: CloseMergedPullRequestCommand,
+  ): Promise<CloseMergedPullRequestResult> {
+    return await this.disposition.closeMergedPullRequest(command.workItemId);
+  }
+}

--- a/src/modules/execution/application/commands/delete-work-item.handler.ts
+++ b/src/modules/execution/application/commands/delete-work-item.handler.ts
@@ -1,6 +1,6 @@
 import { Inject } from "@nestjs/common";
 import { CommandHandler, ICommandHandler } from "@nestjs/cqrs";
-import { ExecutionService } from "../../execution.service.js";
+import { RunDispositionService } from "../../run-disposition.service.js";
 import type { DeleteWorkItemResult } from "../../types.js";
 import { DeleteWorkItemCommand } from "./delete-work-item.command.js";
 
@@ -9,10 +9,10 @@ export class DeleteWorkItemHandler
   implements ICommandHandler<DeleteWorkItemCommand, DeleteWorkItemResult>
 {
   constructor(
-    @Inject(ExecutionService) private readonly execution: ExecutionService,
+    @Inject(RunDispositionService) private readonly disposition: RunDispositionService,
   ) {}
 
   async execute(command: DeleteWorkItemCommand): Promise<DeleteWorkItemResult> {
-    return await this.execution.deleteWorkItem(command.dto);
+    return await this.disposition.deleteWorkItem(command.dto);
   }
 }

--- a/src/modules/execution/execution.controller.ts
+++ b/src/modules/execution/execution.controller.ts
@@ -2,12 +2,15 @@ import { Body, Controller, Get, Inject, Param, Post, Query, Sse } from "@nestjs/
 import type { MessageEvent } from "@nestjs/common";
 import { CommandBus } from "@nestjs/cqrs";
 import { Observable } from "rxjs";
+import { ArchiveAndCloseMergedPullRequestCommand } from "./application/commands/archive-and-close-merged-pull-request.command.js";
 import { CancelWorkItemCommand } from "./application/commands/cancel-work-item.command.js";
+import { CloseMergedPullRequestCommand } from "./application/commands/close-merged-pull-request.command.js";
 import { DeleteWorkItemCommand } from "./application/commands/delete-work-item.command.js";
 import { TransitionInProgressToDraftingCommand } from "./application/commands/transition-in-progress-to-drafting.command.js";
 import { TransitionInProgressToReadyCommand } from "./application/commands/transition-in-progress-to-ready.command.js";
 import { ExecutionService } from "./execution.service.js";
 import type {
+  ArchiveAndCloseMergedPullRequestResult,
   CancelWorkItemDto,
   CancelWorkItemResult,
   CleanupWorktreeDto,
@@ -111,12 +114,19 @@ export class ExecutionController {
 
   @Post("close-merged")
   closeMergedPullRequest(@Body() body: TransitionWorkItemDto): Promise<CloseMergedPullRequestResult> {
-    return this.executionService.closeMergedPullRequest(body.work_item_id);
+    return this.commandBus.execute<CloseMergedPullRequestCommand, CloseMergedPullRequestResult>(
+      new CloseMergedPullRequestCommand(body.work_item_id),
+    );
   }
 
   @Post("archive-and-close-merged")
-  archiveAndCloseMergedPullRequest(@Body() body: TransitionWorkItemDto) {
-    return this.executionService.archiveAndCloseMergedPullRequest(body.work_item_id);
+  archiveAndCloseMergedPullRequest(
+    @Body() body: TransitionWorkItemDto,
+  ): Promise<ArchiveAndCloseMergedPullRequestResult> {
+    return this.commandBus.execute<
+      ArchiveAndCloseMergedPullRequestCommand,
+      ArchiveAndCloseMergedPullRequestResult
+    >(new ArchiveAndCloseMergedPullRequestCommand(body.work_item_id));
   }
 
   @Post("cancel-work-item")

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -3,7 +3,9 @@ import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { PlansModule } from "../plans/plans.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
+import { ArchiveAndCloseMergedPullRequestHandler } from "./application/commands/archive-and-close-merged-pull-request.handler.js";
 import { CancelWorkItemHandler } from "./application/commands/cancel-work-item.handler.js";
+import { CloseMergedPullRequestHandler } from "./application/commands/close-merged-pull-request.handler.js";
 import { DeleteWorkItemHandler } from "./application/commands/delete-work-item.handler.js";
 import { TransitionInProgressToDraftingHandler } from "./application/commands/transition-in-progress-to-drafting.handler.js";
 import { TransitionInProgressToReadyHandler } from "./application/commands/transition-in-progress-to-ready.handler.js";
@@ -31,6 +33,8 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
     DeleteWorkItemHandler,
     TransitionInProgressToReadyHandler,
     TransitionInProgressToDraftingHandler,
+    CloseMergedPullRequestHandler,
+    ArchiveAndCloseMergedPullRequestHandler,
   ],
   exports: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, RunDispositionService, WorkItemReconcilerService],
 })

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -13,6 +13,7 @@ import { GitHubCacheController } from "./github-cache.controller.js";
 import { GitHubCacheScheduler } from "./github-cache-scheduler.service.js";
 import { ExecutionService } from "./execution.service.js";
 import { HsmActionHandlers } from "./hsm-action-handlers.js";
+import { RunDispositionService } from "./run-disposition.service.js";
 import { WorkItemReconcilerController } from "./work-item-reconciler.controller.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 
@@ -24,12 +25,13 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
     GitHubBatchCache,
     GitHubCacheScheduler,
     HsmActionHandlers,
+    RunDispositionService,
     WorkItemReconcilerService,
     CancelWorkItemHandler,
     DeleteWorkItemHandler,
     TransitionInProgressToReadyHandler,
     TransitionInProgressToDraftingHandler,
   ],
-  exports: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, WorkItemReconcilerService],
+  exports: [ExecutionService, GitHubBatchCache, GitHubCacheScheduler, RunDispositionService, WorkItemReconcilerService],
 })
 export class ExecutionModule {}

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,16 +1,13 @@
-import { BadRequestException, Inject, Injectable, Logger, MessageEvent, NotFoundException, OnModuleInit, forwardRef } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, Logger, MessageEvent, NotFoundException, OnModuleInit } from "@nestjs/common";
 import { createAgentSession, createCodingTools, SessionManager, type AgentSessionEvent } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
 import {
-  archiveDir,
-  archivesRoot,
   canonicalScratchpadPath,
   ensurePlanDir,
-  planDir,
   readPlanMetadata,
   runDir,
   workItemSlug,
@@ -19,8 +16,7 @@ import {
 } from "../../lib/context-layout.js";
 import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
-import { loadRunRecordsForArtifactRoot, loadRunRecordsFromDisk } from "./run-disk-store.js";
-import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
+import { loadRunRecordsForArtifactRoot } from "./run-disk-store.js";
 import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
@@ -28,20 +24,13 @@ import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
-import { PlansService } from "../plans/plans.service.js";
 import { SettingsService } from "../settings/settings.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
 import type {
   ActivityLogEntry,
   ActivityLogEntryKind,
   ArchivedRunBundle,
-  ArchiveAndCloseMergedPullRequestResult,
-  ArchiveRunArtifactsResult,
-  CancelWorkItemDto,
-  CancelWorkItemResult,
   ChecklistItem,
-  ClosedGitHubIssueSummary,
-  CloseMergedPullRequestResult,
   CreateExecutionPullRequestDto,
   CreateExecutionPullRequestResult,
   ExecutionChecklistSnapshot,
@@ -59,8 +48,6 @@ import type {
   LaunchExecutionRunResult,
   CleanupWorktreeDto,
   CleanupWorktreeResult,
-  DeleteWorkItemDto,
-  DeleteWorkItemResult,
   ResolveDisambiguationDto,
   ResolveDisambiguationResult,
   RunChatHistory,
@@ -96,7 +83,6 @@ export class ExecutionService implements OnModuleInit {
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
     @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
-    @Inject(forwardRef(() => PlansService)) private readonly plansService: PlansService,
   ) {
     this.githubService.registerPullRequestTruthRefresher((pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options));
   }
@@ -2372,346 +2358,33 @@ export class ExecutionService implements OnModuleInit {
     return this.workItemsService.get(workItemId);
   }
 
-  /**
-   * ADR 014 step 7: disposition flow for `merged_pr → done`.
-   *
-   * Close variant — transitions the work item to `done` without creating an
-   * archive. Plan dir is left in place at `plans/<slug>/`. Used when the user
-   * decides the plan and scratchpad are still useful for reference and doesn't
-   * want them swept into `archives/`.
-   *
-   * Guards (checked in order):
-   *   1. Work item must exist and be in `merged_pr` state
-   *   2. No run for this work item may be active (`queued | preparing |
-   *      disambiguating | running`)
-   *
-   * Both guards throw `BadRequestException` on failure. The state guard
-   * prevents bypassing the state machine (the prior raw-PUT path from the
-   * frontend "Close issue" button is the side channel this endpoint replaces).
-   * The active-run guard prevents disposing work items that still have live
-   * runs — see `assertNoActiveRunForWorkItem` for the session-scope caveat.
-   */
-  /**
-   * studio-87: Full `merged_pr → done` close orchestration.
-   *
-   * Steps (ordered so every prefix is retry-safe):
-   *   1. assertWorkItemInMergedPr — guard the source state. Short-circuits
-   *      when the work item is already `done` so a retry after a partial
-   *      failure still performs the remaining finalizer steps (gh close
-   *      is idempotent, run removal can run twice safely).
-   *   2. assertNoActiveRunForWorkItem — refuse while a run is live.
-   *   3. `gh issue close` — skipped when the work item is not issue-backed
-   *      (kind != 'issue' or missing issue_number). On failure the
-   *      exception propagates and nothing else is mutated.
-   *   4. workItemsService.update({ state: 'done' }) — skipped when the
-   *      retry entered via an already-done short-circuit.
-   *   5. removeRunsForWorkItem — best-effort finalizer that splices
-   *      matching runs out of `recentRuns`, stamps `disposed_at` on each
-   *      `status.json`, and emits an `execution_result` event per run.
-   *
-   * Returns a full `CloseMergedPullRequestResult` envelope so the UI can
-   * reflect the combined outcome (state transition + gh close + run
-   * removal) in one round trip. Mirrors the shape of
-   * `syncMergedPullRequest` including a post-close `dispatch_preview`.
-   */
-  async closeMergedPullRequest(workItemId: string): Promise<CloseMergedPullRequestResult> {
-    // Pre-dispatch guard: refuse while a run is live (HSM doesn't know about runs).
-    this.assertNoActiveRunForWorkItem(workItemId);
-
-    const result = await this.hsmService.dispatch(workItemId, { type: "user.finalize" });
-
-    if (result.rejected) {
-      throw new BadRequestException(
-        `cannot_dispose: HSM rejected user.finalize from state ${result.prev_state}`,
-      );
-    }
-
-    // studio-197: write-through closed issue to batch cache.
-    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
-    if (closedIssue) {
-      const wi = this.workItemsService.get(workItemId);
-      if (wi.repo) {
-        this.githubBatchCache.upsertIssue(wi.repo, {
-          number: closedIssue.number,
-          state: "closed",
-          closed_at: new Date().toISOString(),
-          url: closedIssue.url,
-          title: closedIssue.title,
-        });
-      }
-    }
-
-    // Post-dispatch finalizer: dispose matching runs.
-    const removedRunIds = this.removeRunsForWorkItem(workItemId);
-
-    // Build the response envelope.
-    const updatedWorkItem = this.workItemsService.get(workItemId);
-
-    return {
-      work_item: {
-        id: updatedWorkItem.id,
-        state: updatedWorkItem.state,
-        branch: updatedWorkItem.branch,
-        archive_path: updatedWorkItem.archive_path,
-        actual_files: updatedWorkItem.actual_files,
-        meta: updatedWorkItem.meta,
-        updated_at: updatedWorkItem.updated_at,
-      },
-      closed_issue: closedIssue,
-      removed_run_ids: removedRunIds,
-      dispatch_preview: this.getPreview(updatedWorkItem.repo ?? undefined),
-    };
-  }
-
-  /**
-   * studio-87: best-effort finalizer for `closeMergedPullRequest`.
-   *
-   * Removes every run matching `workItemId` from the in-memory
-   * `recentRuns` buffer AND stamps `disposed_at` on each matching
-   * `status.json` on disk so hydration after a server restart will
-   * not resurrect them (see `loadRunRecordsFromDisk`'s
-   * `includeDisposed` filter).
-   *
-   * Handles three cases:
-   *   (a) run is currently in `recentRuns` — update status.json, splice,
-   *       emit `execution_result` so SSE clients see the removal.
-   *   (b) run exists on disk but was evicted from `recentRuns` by the
-   *       16-entry cap — update status.json directly.
-   *   (c) run already has `disposed_at` — skipped (idempotent replay).
-   *
-   * Failures are logged and swallowed; this is a finalizer and the caller
-   * has already completed the state transition. Returns the set of run
-   * ids that were updated or spliced.
-   */
-  private removeRunsForWorkItem(workItemId: string): string[] {
-    const timestamp = this.now();
-    const removedIds = new Set<string>();
-
-    // (a) In-memory recentRuns — walk back-to-front so splice is safe.
-    for (let i = this.recentRuns.length - 1; i >= 0; i--) {
-      const run = this.recentRuns[i];
-      if (run.work_item_id !== workItemId) continue;
-      if (run.disposed_at) {
-        // Already disposed; drop from the buffer but don't re-write.
-        this.recentRuns.splice(i, 1);
-        removedIds.add(run.run_id);
-        continue;
-      }
-      const disposed: ExecutionRunRecord = {
-        ...run,
-        disposed_at: timestamp,
-        updated_at: timestamp,
-      };
-      try {
-        this.writeStatus(disposed);
-      } catch (error) {
-        if (!this.isMissingFileError(error)) {
-          this.logger.warn(
-            `removeRunsForWorkItem: failed to stamp disposed_at for run ${run.run_id}: ${this.getErrorMessage(error)}`,
-          );
-        }
-      }
-      this.recentRuns.splice(i, 1);
-      removedIds.add(run.run_id);
-      try {
-        this.emitRun("execution_result", disposed);
-      } catch (error) {
-        this.logger.warn(
-          `removeRunsForWorkItem: failed to emit execution_result for run ${run.run_id}: ${this.getErrorMessage(error)}`,
-        );
-      }
-    }
-
-    // (b) On-disk runs that were not in recentRuns (hydration gap / cap
-    //     eviction). Pass includeDisposed so we can see already-disposed
-    //     records for idempotent replay, but skip them when writing.
-    try {
-      const runsDir = join(this.artifactRoot, "runs");
-      const diskRuns = loadRunRecordsFromDisk(runsDir, { includeDisposed: true });
-      for (const run of diskRuns) {
-        if (run.work_item_id !== workItemId) continue;
-        if (removedIds.has(run.run_id)) continue;
-        if (run.disposed_at) continue;
-        const disposed: ExecutionRunRecord = {
-          ...run,
-          disposed_at: timestamp,
-          updated_at: timestamp,
-        };
-        try {
-          writeFileSync(
-            join(run.artifact_dir, "status.json"),
-            JSON.stringify(disposed, null, 2),
-            "utf8",
-          );
-          removedIds.add(run.run_id);
-        } catch (error) {
-          if (!this.isMissingFileError(error)) {
-            this.logger.warn(
-              `removeRunsForWorkItem: failed to stamp disposed_at for on-disk run ${run.run_id}: ${this.getErrorMessage(error)}`,
-            );
-          }
-        }
-      }
-    } catch (error) {
-      this.logger.warn(
-        `removeRunsForWorkItem: failed to scan runs dir: ${this.getErrorMessage(error)}`,
-      );
-    }
-
-    return Array.from(removedIds);
-  }
-
-  /**
-   * studio-88: Full `merged_pr → done` archive-and-close orchestration.
-   *
-   * Mirrors `closeMergedPullRequest` beat-for-beat but adds the archival
-   * steps (plan-dir move + run-artifact move + README) between gh-close
-   * and the work item state update. Every prefix is designed to be
-   * retry-safe — a failure at any step leaves a consistent state that a
-   * subsequent retry can complete.
-   *
-   * Steps (ordered for retry safety):
-   *   1. Idempotent short-circuit — if the work item is already `done`
-   *      the previous attempt finished past the state transition but
-   *      may have failed in the finalizer. Skip guards + state update
-   *      but still run gh close (idempotent) and the run-removal
-   *      finalizer so leftover runs get disposed.
-   *   2. assertWorkItemInMergedPr — guard the source state.
-   *   3. assertNoActiveRunForWorkItem — refuse while a run is live.
-   *   4. Capture an authoritative run snapshot BEFORE any mutation. This
-   *      merges the in-memory `recentRuns` with the on-disk
-   *      `loadRunRecordsForArtifactRoot` scan, filtered to this work
-   *      item. The snapshot is handed to the archiver later via its
-   *      `runs` option so the archiver sees the runs even after the
-   *      finalizer stamps `disposed_at` on them (default disk scans skip
-   *      disposed records).
-   *   5. `gh issue close` — issue-backed work items only. Idempotent per
-   *      the gh CLI contract. On failure we throw
-   *      `close_merged_failed_github_close` before any filesystem
-   *      mutation so the retry can re-attempt the entire flow.
-   *   6. `movePlanDirToArchives` — no-op when the plan dir is already
-   *      gone (prior partial archive). Throws
-   *      `archive_already_exists` on a collision so operators can
-   *      resolve manually.
-   *   7. `archiveRunArtifactsForWorkItem` — bypasses the thin
-   *      `archiveRunArtifacts` wrapper because we already captured the
-   *      snapshot and re-ran the guards upstream. Writes runs into
-   *      `archives/<slug>/runs/<run_id>/` and renders `README.md`. A
-   *      source-missing run on retry is a warning, not a failure.
-   *   8. `workItemsService.update` to `done` with `archive_path` set and
-   *      `meta.studio_archive` recorded. Shallow-merges over any
-   *      existing `studio_post_merge_sync` block so neither clobbers
-   *      the other.
-   *   9. `removeRunsForWorkItem` — best-effort finalizer. Splices
-   *      matching runs out of `recentRuns` and stamps `disposed_at` on
-   *      each `status.json`.
-   *
-   * Returns a full `ArchiveAndCloseMergedPullRequestResult` envelope so
-   * the UI can reflect the combined outcome in one round trip.
-   */
-  async archiveAndCloseMergedPullRequest(
-    workItemId: string,
-  ): Promise<ArchiveAndCloseMergedPullRequestResult> {
-    // Pre-dispatch guard.
-    this.assertNoActiveRunForWorkItem(workItemId);
-
-    const result = await this.hsmService.dispatch(workItemId, {
-      type: "user.archive_and_finalize",
-    });
-
-    if (result.rejected) {
-      throw new BadRequestException(
-        `cannot_dispose: HSM rejected user.archive_and_finalize from state ${result.prev_state}`,
-      );
-    }
-
-    // studio-197: write-through closed issue to batch cache.
-    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
-    if (closedIssue) {
-      const wi = this.workItemsService.get(workItemId);
-      if (wi.repo) {
-        this.githubBatchCache.upsertIssue(wi.repo, {
-          number: closedIssue.number,
-          state: "closed",
-          closed_at: new Date().toISOString(),
-          url: closedIssue.url,
-          title: closedIssue.title,
-        });
-      }
-    }
-
-    // Post-dispatch finalizer.
-    const removedRunIds = this.removeRunsForWorkItem(workItemId);
-
-    const updatedWorkItem = this.workItemsService.get(workItemId);
-    const archiveData = result.handler_data?.archive_result as {
-      archive_path: string;
-      readme_path: string | null;
-      archived_run_ids: string[];
-      skipped_run_ids: Array<{ run_id: string; reason: string }>;
-    } | undefined;
-
-    return {
-      work_item: {
-        id: updatedWorkItem.id,
-        state: updatedWorkItem.state,
-        branch: updatedWorkItem.branch,
-        archive_path: updatedWorkItem.archive_path,
-        actual_files: updatedWorkItem.actual_files,
-        meta: updatedWorkItem.meta,
-        updated_at: updatedWorkItem.updated_at,
-      },
-      closed_issue: closedIssue,
-      removed_run_ids: removedRunIds,
-      archive: archiveData ?? {
-        archive_path: updatedWorkItem.archive_path ?? "",
-        readme_path: null,
-        archived_run_ids: [],
-        skipped_run_ids: [],
-      },
-      dispatch_preview: this.getPreview(updatedWorkItem.repo ?? undefined),
-    };
-  }
-
-  /**
-   * studio-88 helper: capture an authoritative run snapshot for a work
-   * item by merging the in-memory `recentRuns` buffer with the on-disk
-   * scan, deduped by `run_id` (in-memory wins). Used by
-   * `archiveAndCloseMergedPullRequest` to hand the archiver a list that
-   * survives the downstream `removeRunsForWorkItem` finalizer stamping
-   * `disposed_at` on each record.
-   */
-  // TODO(phase-3): delete once RunDispositionService owns the disposition path.
-  // Temporary seam exposed to the Phase 1 HsmActionHandlers so it can read
-  // the configured artifact root without referencing private state.
-  getArtifactRoot(): string {
-    return this.artifactRoot;
-  }
-
-  // TODO(phase-3): delete once RunDispositionService owns the disposition path.
-  // Temporary seam exposed to the Phase 1 HsmActionHandlers so it can route
-  // warnings through the same logger as the rest of ExecutionService.
-  logWarn(message: string): void {
-    this.logger.warn(message);
-  }
-
   // TODO(phase-4): delete once RunStore owns the in-memory run buffer.
   // Phase 3 seam: RunDispositionService.removeRunsForWorkItem calls this to
   // splice every buffered run for a work item out of recentRuns, stamp
   // disposed_at on each via writeStatus, and return the disposed copies so
   // the caller can emit execution_result events. Matches the back-to-front
   // walk of the original private method.
+  //
+  // Returns two slots: `newlyDisposed` are the records that just had
+  // disposed_at stamped (and for which the caller should emit an
+  // execution_result event), and `alreadyDisposedIds` are runs that were
+  // spliced out of the buffer but did not need their disposed_at updated
+  // (idempotent replay — the disposition flow still counts these as
+  // "removed" for the purposes of the caller's returned run-id list but
+  // does NOT re-emit events for them).
   disposeRunsForWorkItemInBuffer(
     workItemId: string,
     disposedAt: string,
-  ): ExecutionRunRecord[] {
-    const disposed: ExecutionRunRecord[] = [];
+  ): { newlyDisposed: ExecutionRunRecord[]; alreadyDisposedIds: string[] } {
+    const newlyDisposed: ExecutionRunRecord[] = [];
+    const alreadyDisposedIds: string[] = [];
     for (let i = this.recentRuns.length - 1; i >= 0; i--) {
       const run = this.recentRuns[i];
       if (run.work_item_id !== workItemId) continue;
       if (run.disposed_at) {
         // Already disposed; drop from the buffer but don't re-write.
         this.recentRuns.splice(i, 1);
+        alreadyDisposedIds.push(run.run_id);
         continue;
       }
       const next: ExecutionRunRecord = {
@@ -2729,9 +2402,9 @@ export class ExecutionService implements OnModuleInit {
         }
       }
       this.recentRuns.splice(i, 1);
-      disposed.push(next);
+      newlyDisposed.push(next);
     }
-    return disposed;
+    return { newlyDisposed, alreadyDisposedIds };
   }
 
   // TODO(phase-4): delete once RunStore owns the SSE event stream.
@@ -2745,342 +2418,6 @@ export class ExecutionService implements OnModuleInit {
         `emitRunExecutionResult: failed to emit execution_result for run ${run.run_id}: ${this.getErrorMessage(error)}`,
       );
     }
-  }
-
-  // TODO(phase-3): move to RunDispositionService once Phase 3 lands.
-  // Public so the moved HsmActionHandlers (Phase 1) can reach it without
-  // referencing private state.
-  captureRunSnapshotForWorkItem(workItemId: string): ExecutionRunRecord[] {
-    const seen = new Set<string>();
-    const merged: ExecutionRunRecord[] = [];
-    for (const run of this.listRecentRuns()) {
-      if (run.work_item_id !== workItemId) continue;
-      if (seen.has(run.run_id)) continue;
-      merged.push(run);
-      seen.add(run.run_id);
-    }
-    try {
-      const diskRuns = loadRunRecordsForArtifactRoot(this.artifactRoot);
-      for (const run of diskRuns) {
-        if (run.work_item_id !== workItemId) continue;
-        if (seen.has(run.run_id)) continue;
-        merged.push(run);
-        seen.add(run.run_id);
-      }
-    } catch (error) {
-      this.logger.warn(
-        `captureRunSnapshotForWorkItem: failed to scan disk for ${workItemId}: ${this.getErrorMessage(error)}`,
-      );
-    }
-    return merged;
-  }
-
-  /**
-   * ADR 014 step 7: cancellation path with plan dir archival.
-   *
-   * Handles the HSM-owned `user.cancel` workflow. Moves the plan dir into
-   * `archives/<slug>/` before updating state (same order-of-operations as
-   * archive-and-close). Called by `WorkItemsController.transition` after it
-   * verifies the event is enabled for the current state.
-   */
-  async cancelWorkItem(input: CancelWorkItemDto): Promise<CancelWorkItemResult> {
-    const workItemId = input.work_item_id?.trim();
-    if (!workItemId) {
-      throw new BadRequestException("work_item_id is required");
-    }
-    if (input.confirm_cancel !== true) {
-      throw new BadRequestException("confirm_cancel must be true");
-    }
-
-    const workItem = this.workItemsService.get(workItemId);
-    this.assertCancelEligible(workItem);
-    this.assertNoActiveRunForWorkItem(workItemId);
-
-    const closedIssue = await this.githubService.closeIssue(
-      workItem.repo ?? "",
-      Number(workItem.issue_number),
-      input.cancel_note,
-    );
-
-    const moveResult = this.movePlanDirToArchives(workItemId);
-    const result = await this.hsmService.dispatch(workItemId, { type: "user.cancel" });
-    if (result.rejected) {
-      throw new BadRequestException(
-        `cancel_work_item_transition_failed_after_github_close: HSM rejected user.cancel from state ${result.prev_state}`,
-      );
-    }
-
-    const nextArchivePath = moveResult.archive_path ?? this.workItemsService.get(workItemId).archive_path;
-    if (nextArchivePath) {
-      this.workItemsService.update(workItemId, { archive_path: nextArchivePath });
-    }
-
-    const updatedWorkItem = this.workItemsService.get(workItemId);
-    return {
-      cancelled: true,
-      work_item: {
-        id: updatedWorkItem.id,
-        state: updatedWorkItem.state,
-        archive_path: updatedWorkItem.archive_path,
-        updated_at: updatedWorkItem.updated_at,
-      },
-      closed_issue: {
-        repo: closedIssue.repo,
-        number: closedIssue.number,
-        url: closedIssue.url,
-        title: closedIssue.title,
-        state: closedIssue.state,
-      },
-      warnings: [],
-    };
-  }
-
-  async deleteWorkItem(input: DeleteWorkItemDto): Promise<DeleteWorkItemResult> {
-    const workItemId = input.work_item_id?.trim();
-    if (!workItemId) {
-      throw new BadRequestException("work_item_id is required");
-    }
-    if (input.confirm_delete !== true) {
-      throw new BadRequestException("confirm_delete must be true");
-    }
-
-    const workItem = this.workItemsService.get(workItemId);
-    this.assertDeleteEligible(workItem);
-    this.assertNoActiveRunForWorkItem(workItemId);
-
-    const connectedEdges = this.workItemsService.getConnectedEdges(workItemId);
-    if (connectedEdges.length > 0 && input.acknowledge_connected_edges !== true) {
-      throw new BadRequestException(
-        `delete_work_item_requires_connected_edge_acknowledgement: ${workItemId}`,
-      );
-    }
-
-    const warnings: string[] = [];
-    let githubIssue: DeleteWorkItemResult["github_issue"] = {
-      attempted: false,
-      deleted: false,
-      fallback_used: false,
-      message: null,
-    };
-
-    try {
-      githubIssue = {
-        attempted: true,
-        deleted: true,
-        fallback_used: false,
-        message: null,
-      };
-      await this.githubService.deleteIssue(workItem.repo ?? "", Number(workItem.issue_number));
-    } catch (error) {
-      const message = this.getErrorMessage(error);
-      if (input.allow_graph_delete_without_github !== true) {
-        throw new BadRequestException(`github_issue_delete_failed: ${message}`);
-      }
-      githubIssue = {
-        attempted: true,
-        deleted: false,
-        fallback_used: true,
-        message,
-      };
-      warnings.push(`GitHub issue was not deleted: ${message}`);
-    }
-
-    const planCleanup = this.plansService.deletePlanArtifacts(workItemId);
-    const graphResult = this.workItemsService.deleteWithConnectedEdges(workItemId, connectedEdges.map((edge) => edge.id));
-
-    return {
-      deleted: true,
-      work_item: {
-        id: workItem.id,
-        name: workItem.name,
-        state: workItem.state,
-        repo: workItem.repo,
-        issue_number: workItem.issue_number,
-        issue_url: workItem.issue_url,
-      },
-      graph: graphResult,
-      github_issue: githubIssue,
-      plan_cleanup: planCleanup,
-      warnings,
-    };
-  }
-
-  private leafState(state: string): string {
-    return state.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
-  }
-
-  private assertCancelEligible(workItem: WorkItemRecord): void {
-    const leafState = this.leafState(workItem.state);
-    const eligibleStates = new Set(["planned", "drafting", "ready", "in_progress", "deferred"]);
-
-    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
-      throw new BadRequestException(`cancel_work_item_not_issue_backed: ${workItem.id}`);
-    }
-    if (!eligibleStates.has(leafState)) {
-      throw new BadRequestException(
-        `cancel_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; cancel is limited to pre-PR issue-backed work items`,
-      );
-    }
-  }
-
-  private assertDeleteEligible(workItem: WorkItemRecord): void {
-    const leafState = this.leafState(workItem.state);
-    const eligibleStates = new Set(["planned", "drafting", "ready"]);
-
-    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
-      throw new BadRequestException(`delete_work_item_not_issue_backed: ${workItem.id}`);
-    }
-    if (!eligibleStates.has(leafState)) {
-      throw new BadRequestException(
-        `delete_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; destructive delete is limited to planned, drafting, or ready items`,
-      );
-    }
-  }
-
-  /**
-   * Guard: refuse disposition unless the work item is in `merged_pr`.
-   *
-   * `workItemsService.get` throws `NotFoundException` if the work item doesn't
-   * exist — we let that propagate.
-   */
-  private assertWorkItemInMergedPr(workItemId: string): WorkItemRecord {
-    const workItem = this.workItemsService.get(workItemId);
-    if (workItem.state !== "merged_pr") {
-      throw new BadRequestException(
-        `work_item_not_in_merged_pr: cannot dispose ${workItemId} (state is ${workItem.state}, requires merged_pr)`,
-      );
-    }
-    return workItem;
-  }
-
-  /**
-   * Guard: refuse plan dir moves and disposition transitions if any run for
-   * this work item is currently active.
-   *
-   * Active set: `queued | preparing | disambiguating | running`. These are
-   * the statuses in `ExecutionRunStatus` that indicate the run has not yet
-   * finished (successfully or otherwise).
-   *
-   * Limitation: `listRecentRuns` reads from the in-memory `recentRuns` array
-   * capped at 16 entries. On server restart this array is empty, so a
-   * previously-active run is undetectable by this guard. This is acceptable
-   * for ADR 014 V1 because disposition requires `merged_pr`, which requires
-   * the run to have reached `open_pr` successfully — meaning any run this
-   * guard would flag is effectively "stuck but shouldn't be blocking
-   * disposition anyway". If a run is genuinely in progress when the server
-   * restarts and the operator immediately calls disposition, they'll get
-   * a silent pass. Document the restart gap and move on.
-   */
-  private assertNoActiveRunForWorkItem(workItemId: string): void {
-    const activeStatuses = ["queued", "preparing", "disambiguating", "running"] as const;
-    const activeRun = this.listRecentRuns().find(
-      (run) =>
-        run.work_item_id === workItemId &&
-        (activeStatuses as readonly string[]).includes(run.status),
-    );
-    if (activeRun) {
-      throw new BadRequestException(
-        `cannot_dispose_work_item_active_run: run ${activeRun.run_id} is ${activeRun.status} for work item ${workItemId}. ` +
-          `Wait for the run to finish or clean it up first.`,
-      );
-    }
-  }
-
-  /**
-   * Move the plan dir for a work item into `archives/<slug>/`.
-   *
-   * Returns `{ moved: true, archive_path }` on a successful move,
-   * `{ moved: false, archive_path: null }` if the plan dir didn't exist
-   * (warning logged).
-   *
-   * Throws `BadRequestException("archive_already_exists")` if the
-   * destination already exists — we refuse to clobber an existing archive.
-   *
-   * Called by `archiveAndCloseMergedPullRequest` and (eventually) the
-   * `cancelled` disposition path.
-   */
-  /**
-   * Issue #86: archive execution run artifacts + a generated README for a
-   * completed work item.
-   *
-   * Thin wrapper around `archiveRunArtifactsForWorkItem` — loads the work
-   * item, re-uses `assertNoActiveRunForWorkItem` as the pre-archive guard
-   * (which provides a `BadRequestException` for a consistent HTTP surface),
-   * hands the disk-scanned run list to the helper so the archiver and the
-   * active-run guard share the same source of truth, and returns the
-   * helper's `ArchiveRunArtifactsResult` unchanged.
-   *
-   * Deliberately NOT yet called from `archiveAndCloseMergedPullRequest` —
-   * that wiring belongs to issue #88's disposition flow so #86 can land
-   * and be reviewed as a self-contained backend slice.
-   */
-  archiveRunArtifacts(workItemId: string): ArchiveRunArtifactsResult {
-    const normalized = workItemId?.trim();
-    if (!normalized) {
-      throw new BadRequestException("work_item_id is required");
-    }
-    const workItem = this.workItemsService.get(normalized);
-    this.assertNoActiveRunForWorkItem(normalized);
-
-    // Merge in-memory `recentRuns` with the disk scan so the archiver sees
-    // runs that exist only on disk (post-restart) and in-memory runs that
-    // haven't been flushed. Dedupe by run_id — in-memory wins because it
-    // carries the freshest activity log.
-    const diskRuns = loadRunRecordsForArtifactRoot(this.artifactRoot);
-    const seen = new Set<string>();
-    const merged: ExecutionRunRecord[] = [];
-    for (const run of this.listRecentRuns()) {
-      if (run.work_item_id !== normalized) continue;
-      if (seen.has(run.run_id)) continue;
-      merged.push(run);
-      seen.add(run.run_id);
-    }
-    for (const run of diskRuns) {
-      if (run.work_item_id !== normalized) continue;
-      if (seen.has(run.run_id)) continue;
-      merged.push(run);
-      seen.add(run.run_id);
-    }
-
-    try {
-      return archiveRunArtifactsForWorkItem(this.artifactRoot, workItem, {
-        runs: merged,
-        onWarn: (message) => this.logger.warn(message),
-      });
-    } catch (error) {
-      const message = this.getErrorMessage(error);
-      // Translate the archiver's raw Error codes into BadRequestException
-      // so the HTTP surface matches the other disposition guards.
-      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
-        throw new BadRequestException(message);
-      }
-      throw error;
-    }
-  }
-
-  // TODO(phase-3): move to RunDispositionService once Phase 3 lands.
-  // Public so the moved HsmActionHandlers (Phase 1) can reach it without
-  // referencing private state.
-  movePlanDirToArchives(workItemId: string): { moved: boolean; archive_path: string | null } {
-    const src = planDir(this.artifactRoot, workItemId);
-    const dest = archiveDir(this.artifactRoot, workItemId);
-
-    if (!existsSync(src)) {
-      this.logger.warn(
-        `movePlanDirToArchives: plan dir ${src} does not exist for work item ${workItemId}; archive step is a no-op`,
-      );
-      return { moved: false, archive_path: null };
-    }
-
-    if (existsSync(dest)) {
-      throw new BadRequestException(
-        `archive_already_exists: refusing to move plan dir for ${workItemId} — destination ${dest} already exists. Resolve the collision manually before retrying.`,
-      );
-    }
-
-    mkdirSync(archivesRoot(this.artifactRoot), { recursive: true });
-    renameSync(src, dest);
-    return { moved: true, archive_path: dest };
   }
 
   private async resolvePullRequestFromWorkItem(workItem: WorkItemRecord) {

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -2695,6 +2695,58 @@ export class ExecutionService implements OnModuleInit {
     this.logger.warn(message);
   }
 
+  // TODO(phase-4): delete once RunStore owns the in-memory run buffer.
+  // Phase 3 seam: RunDispositionService.removeRunsForWorkItem calls this to
+  // splice every buffered run for a work item out of recentRuns, stamp
+  // disposed_at on each via writeStatus, and return the disposed copies so
+  // the caller can emit execution_result events. Matches the back-to-front
+  // walk of the original private method.
+  disposeRunsForWorkItemInBuffer(
+    workItemId: string,
+    disposedAt: string,
+  ): ExecutionRunRecord[] {
+    const disposed: ExecutionRunRecord[] = [];
+    for (let i = this.recentRuns.length - 1; i >= 0; i--) {
+      const run = this.recentRuns[i];
+      if (run.work_item_id !== workItemId) continue;
+      if (run.disposed_at) {
+        // Already disposed; drop from the buffer but don't re-write.
+        this.recentRuns.splice(i, 1);
+        continue;
+      }
+      const next: ExecutionRunRecord = {
+        ...run,
+        disposed_at: disposedAt,
+        updated_at: disposedAt,
+      };
+      try {
+        this.writeStatus(next);
+      } catch (error) {
+        if (!this.isMissingFileError(error)) {
+          this.logger.warn(
+            `disposeRunsForWorkItemInBuffer: failed to stamp disposed_at for run ${run.run_id}: ${this.getErrorMessage(error)}`,
+          );
+        }
+      }
+      this.recentRuns.splice(i, 1);
+      disposed.push(next);
+    }
+    return disposed;
+  }
+
+  // TODO(phase-4): delete once RunStore owns the SSE event stream.
+  // Phase 3 seam: RunDispositionService emits execution_result events on
+  // disposed runs without reaching into ExecutionService's private emitRun.
+  emitRunExecutionResult(run: ExecutionRunRecord): void {
+    try {
+      this.emitRun("execution_result", run);
+    } catch (error) {
+      this.logger.warn(
+        `emitRunExecutionResult: failed to emit execution_result for run ${run.run_id}: ${this.getErrorMessage(error)}`,
+      );
+    }
+  }
+
   // TODO(phase-3): move to RunDispositionService once Phase 3 lands.
   // Public so the moved HsmActionHandlers (Phase 1) can reach it without
   // referencing private state.

--- a/src/modules/execution/hsm-action-handlers.ts
+++ b/src/modules/execution/hsm-action-handlers.ts
@@ -1,12 +1,7 @@
 import { BadRequestException, Inject, Injectable, OnModuleInit } from "@nestjs/common";
-import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
-import { ExecutionService } from "./execution.service.js";
 import { GitHubService } from "../github/github.service.js";
 import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
-import type {
-  ArchiveRunArtifactsResult,
-  StudioArchiveMeta,
-} from "./types.js";
+import { RunDispositionService } from "./run-disposition.service.js";
 import type {
   HsmActionHandlerContext,
   WorkItemHsmEvent,
@@ -45,7 +40,7 @@ export class HsmActionHandlers implements OnModuleInit {
   constructor(
     @Inject(WorkItemHsmService) private readonly hsm: WorkItemHsmService,
     @Inject(GitHubService) private readonly github: GitHubService,
-    @Inject(ExecutionService) private readonly execution: ExecutionService,
+    @Inject(RunDispositionService) private readonly disposition: RunDispositionService,
   ) {}
 
   onModuleInit(): void {
@@ -88,46 +83,10 @@ export class HsmActionHandlers implements OnModuleInit {
 
   async runArchiver(
     workItem: WorkItemRecord,
-    _event: WorkItemHsmEvent,
+    event: WorkItemHsmEvent,
     ctx: HsmActionHandlerContext,
   ): Promise<void> {
-    const runSnapshot = this.execution.captureRunSnapshotForWorkItem(workItem.id);
-    const moveResult = this.execution.movePlanDirToArchives(workItem.id);
-
-    let archiveResult: ArchiveRunArtifactsResult;
-    try {
-      archiveResult = archiveRunArtifactsForWorkItem(
-        this.execution.getArtifactRoot(),
-        workItem,
-        {
-          runs: runSnapshot,
-          onWarn: (message) => this.execution.logWarn(message),
-        },
-      );
-    } catch (error) {
-      const message = this.getErrorMessage(error);
-      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
-        throw new BadRequestException(message);
-      }
-      throw error;
-    }
-
-    const archivePath =
-      archiveResult.archive_path ?? moveResult.archive_path ?? workItem.archive_path;
-    const studioArchive: StudioArchiveMeta = {
-      archived_at: new Date().toISOString(),
-      readme_path: archiveResult.readme_path,
-      archived_run_ids: archiveResult.archived_run_ids,
-      skipped_run_ids: archiveResult.skipped_run_ids,
-    };
-    ctx.meta.studio_archive = studioArchive;
-    ctx.patch_overrides.archive_path = archivePath;
-    ctx.handler_data.archive_result = {
-      archive_path: archivePath,
-      readme_path: archiveResult.readme_path,
-      archived_run_ids: archiveResult.archived_run_ids,
-      skipped_run_ids: archiveResult.skipped_run_ids,
-    };
+    await this.disposition.archiveRunArtifactsAction(workItem, event, ctx);
   }
 
   private getErrorMessage(error: unknown): string {

--- a/src/modules/execution/run-disposition.service.ts
+++ b/src/modules/execution/run-disposition.service.ts
@@ -447,12 +447,18 @@ export class RunDispositionService {
 
     // (a) In-memory recentRuns — ExecutionService owns the buffer. The
     // Phase 3 seam walks the buffer back-to-front, splices matches,
-    // stamps disposed_at on the disk status file, and returns the
-    // disposed records so we can emit execution_result events here.
-    const disposed = this.executionService.disposeRunsForWorkItemInBuffer(workItemId, timestamp);
-    for (const run of disposed) {
+    // stamps disposed_at on the disk status file, and returns both
+    // newly-disposed records (for which we emit events) and
+    // already-disposed run ids (which are still "removed" from the
+    // caller's perspective but should not re-emit execution_result).
+    const { newlyDisposed, alreadyDisposedIds } =
+      this.executionService.disposeRunsForWorkItemInBuffer(workItemId, timestamp);
+    for (const run of newlyDisposed) {
       removedIds.add(run.run_id);
       this.executionService.emitRunExecutionResult(run);
+    }
+    for (const runId of alreadyDisposedIds) {
+      removedIds.add(runId);
     }
 
     // (b) On-disk runs that were not in recentRuns (hydration gap / cap

--- a/src/modules/execution/run-disposition.service.ts
+++ b/src/modules/execution/run-disposition.service.ts
@@ -1,0 +1,593 @@
+import { BadRequestException, Inject, Injectable, Logger, forwardRef } from "@nestjs/common";
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import { archiveDir, archivesRoot, planDir } from "../../lib/context-layout.js";
+import { GitHubService } from "../github/github.service.js";
+import type {
+  HsmActionHandlerContext,
+  WorkItemHsmEvent,
+  WorkItemRecord,
+} from "../graph/types.js";
+import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
+import { WorkItemsService } from "../graph/work-items.service.js";
+import { PlansService } from "../plans/plans.service.js";
+import { ExecutionService } from "./execution.service.js";
+import { GitHubBatchCache } from "./github-batch-cache.service.js";
+import { loadRunRecordsForArtifactRoot, loadRunRecordsFromDisk } from "./run-disk-store.js";
+import { archiveRunArtifactsForWorkItem } from "./run-archiver.js";
+import type {
+  ArchiveAndCloseMergedPullRequestResult,
+  ArchiveRunArtifactsResult,
+  CancelWorkItemDto,
+  CancelWorkItemResult,
+  ClosedGitHubIssueSummary,
+  CloseMergedPullRequestResult,
+  DeleteWorkItemDto,
+  DeleteWorkItemResult,
+  ExecutionRunRecord,
+  StudioArchiveMeta,
+} from "./types.js";
+
+/**
+ * Phase 3 of the cqrs refactor (#223): owns the "given a work item,
+ * put it into a terminal state and tidy up the filesystem + GitHub +
+ * run buffer" responsibility. Extracted verbatim from `ExecutionService`
+ * to break the ~800-line disposition cluster out of the god class.
+ *
+ * Methods:
+ *   - closeMergedPullRequest / archiveAndCloseMergedPullRequest
+ *     — merged_pr → done/archived orchestration
+ *   - cancelWorkItem / deleteWorkItem — pre-PR cancellation + delete
+ *   - archiveRunArtifacts — standalone archival helper
+ *   - archiveRunArtifactsAction — HSM action adapter for runArchiver
+ *   - captureRunSnapshotForWorkItem / movePlanDirToArchives (private)
+ *   - removeRunsForWorkItem (private finalizer)
+ *   - disposition guards: assertCancelEligible / assertDeleteEligible /
+ *     assertWorkItemInMergedPr / assertNoActiveRunForWorkItem / leafState
+ *
+ * Temporary deps on `ExecutionService`:
+ *   - `listRecentRuns()` — read the in-memory run buffer
+ *   - `disposeRunsForWorkItemInBuffer()` — splice buffer entries and
+ *     stamp disposed_at (added in the previous commit)
+ *   - `emitRunExecutionResult()` — emit SSE events for disposed runs
+ *   - `getPreview()` — build the dispatch-preview envelope
+ *
+ * Phase 4 extracts a `RunStore` sub-service that absorbs these four
+ * methods; at that point the forwardRef ExecutionService injection
+ * on this class becomes a one-way RunStore injection and the
+ * Graph ↔ Execution cycle is gone.
+ */
+@Injectable()
+export class RunDispositionService {
+  private readonly logger = new Logger(RunDispositionService.name);
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+
+  constructor(
+    @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
+    @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
+    @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
+    @Inject(forwardRef(() => PlansService)) private readonly plansService: PlansService,
+    @Inject(forwardRef(() => ExecutionService)) private readonly executionService: ExecutionService,
+  ) {}
+
+  async closeMergedPullRequest(workItemId: string): Promise<CloseMergedPullRequestResult> {
+    // Pre-dispatch guard: refuse while a run is live (HSM doesn't know about runs).
+    this.assertNoActiveRunForWorkItem(workItemId);
+
+    const result = await this.hsmService.dispatch(workItemId, { type: "user.finalize" });
+
+    if (result.rejected) {
+      throw new BadRequestException(
+        `cannot_dispose: HSM rejected user.finalize from state ${result.prev_state}`,
+      );
+    }
+
+    // studio-197: write-through closed issue to batch cache.
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
+    if (closedIssue) {
+      const wi = this.workItemsService.get(workItemId);
+      if (wi.repo) {
+        this.githubBatchCache.upsertIssue(wi.repo, {
+          number: closedIssue.number,
+          state: "closed",
+          closed_at: new Date().toISOString(),
+          url: closedIssue.url,
+          title: closedIssue.title,
+        });
+      }
+    }
+
+    // Post-dispatch finalizer: dispose matching runs.
+    const removedRunIds = this.removeRunsForWorkItem(workItemId);
+
+    // Build the response envelope.
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+
+    return {
+      work_item: {
+        id: updatedWorkItem.id,
+        state: updatedWorkItem.state,
+        branch: updatedWorkItem.branch,
+        archive_path: updatedWorkItem.archive_path,
+        actual_files: updatedWorkItem.actual_files,
+        meta: updatedWorkItem.meta,
+        updated_at: updatedWorkItem.updated_at,
+      },
+      closed_issue: closedIssue,
+      removed_run_ids: removedRunIds,
+      dispatch_preview: this.executionService.getPreview(updatedWorkItem.repo ?? undefined),
+    };
+  }
+
+  async archiveAndCloseMergedPullRequest(
+    workItemId: string,
+  ): Promise<ArchiveAndCloseMergedPullRequestResult> {
+    // Pre-dispatch guard.
+    this.assertNoActiveRunForWorkItem(workItemId);
+
+    const result = await this.hsmService.dispatch(workItemId, {
+      type: "user.archive_and_finalize",
+    });
+
+    if (result.rejected) {
+      throw new BadRequestException(
+        `cannot_dispose: HSM rejected user.archive_and_finalize from state ${result.prev_state}`,
+      );
+    }
+
+    // studio-197: write-through closed issue to batch cache.
+    const closedIssue = (result.handler_data?.closed_issue as ClosedGitHubIssueSummary) ?? null;
+    if (closedIssue) {
+      const wi = this.workItemsService.get(workItemId);
+      if (wi.repo) {
+        this.githubBatchCache.upsertIssue(wi.repo, {
+          number: closedIssue.number,
+          state: "closed",
+          closed_at: new Date().toISOString(),
+          url: closedIssue.url,
+          title: closedIssue.title,
+        });
+      }
+    }
+
+    // Post-dispatch finalizer.
+    const removedRunIds = this.removeRunsForWorkItem(workItemId);
+
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+    const archiveData = result.handler_data?.archive_result as {
+      archive_path: string;
+      readme_path: string | null;
+      archived_run_ids: string[];
+      skipped_run_ids: Array<{ run_id: string; reason: string }>;
+    } | undefined;
+
+    return {
+      work_item: {
+        id: updatedWorkItem.id,
+        state: updatedWorkItem.state,
+        branch: updatedWorkItem.branch,
+        archive_path: updatedWorkItem.archive_path,
+        actual_files: updatedWorkItem.actual_files,
+        meta: updatedWorkItem.meta,
+        updated_at: updatedWorkItem.updated_at,
+      },
+      closed_issue: closedIssue,
+      removed_run_ids: removedRunIds,
+      archive: archiveData ?? {
+        archive_path: updatedWorkItem.archive_path ?? "",
+        readme_path: null,
+        archived_run_ids: [],
+        skipped_run_ids: [],
+      },
+      dispatch_preview: this.executionService.getPreview(updatedWorkItem.repo ?? undefined),
+    };
+  }
+
+  async cancelWorkItem(input: CancelWorkItemDto): Promise<CancelWorkItemResult> {
+    const workItemId = input.work_item_id?.trim();
+    if (!workItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    if (input.confirm_cancel !== true) {
+      throw new BadRequestException("confirm_cancel must be true");
+    }
+
+    const workItem = this.workItemsService.get(workItemId);
+    this.assertCancelEligible(workItem);
+    this.assertNoActiveRunForWorkItem(workItemId);
+
+    const closedIssue = await this.githubService.closeIssue(
+      workItem.repo ?? "",
+      Number(workItem.issue_number),
+      input.cancel_note,
+    );
+
+    const moveResult = this.movePlanDirToArchives(workItemId);
+    const result = await this.hsmService.dispatch(workItemId, { type: "user.cancel" });
+    if (result.rejected) {
+      throw new BadRequestException(
+        `cancel_work_item_transition_failed_after_github_close: HSM rejected user.cancel from state ${result.prev_state}`,
+      );
+    }
+
+    const nextArchivePath = moveResult.archive_path ?? this.workItemsService.get(workItemId).archive_path;
+    if (nextArchivePath) {
+      this.workItemsService.update(workItemId, { archive_path: nextArchivePath });
+    }
+
+    const updatedWorkItem = this.workItemsService.get(workItemId);
+    return {
+      cancelled: true,
+      work_item: {
+        id: updatedWorkItem.id,
+        state: updatedWorkItem.state,
+        archive_path: updatedWorkItem.archive_path,
+        updated_at: updatedWorkItem.updated_at,
+      },
+      closed_issue: {
+        repo: closedIssue.repo,
+        number: closedIssue.number,
+        url: closedIssue.url,
+        title: closedIssue.title,
+        state: closedIssue.state,
+      },
+      warnings: [],
+    };
+  }
+
+  async deleteWorkItem(input: DeleteWorkItemDto): Promise<DeleteWorkItemResult> {
+    const workItemId = input.work_item_id?.trim();
+    if (!workItemId) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    if (input.confirm_delete !== true) {
+      throw new BadRequestException("confirm_delete must be true");
+    }
+
+    const workItem = this.workItemsService.get(workItemId);
+    this.assertDeleteEligible(workItem);
+    this.assertNoActiveRunForWorkItem(workItemId);
+
+    const connectedEdges = this.workItemsService.getConnectedEdges(workItemId);
+    if (connectedEdges.length > 0 && input.acknowledge_connected_edges !== true) {
+      throw new BadRequestException(
+        `delete_work_item_requires_connected_edge_acknowledgement: ${workItemId}`,
+      );
+    }
+
+    const warnings: string[] = [];
+    let githubIssue: DeleteWorkItemResult["github_issue"] = {
+      attempted: false,
+      deleted: false,
+      fallback_used: false,
+      message: null,
+    };
+
+    try {
+      githubIssue = {
+        attempted: true,
+        deleted: true,
+        fallback_used: false,
+        message: null,
+      };
+      await this.githubService.deleteIssue(workItem.repo ?? "", Number(workItem.issue_number));
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      if (input.allow_graph_delete_without_github !== true) {
+        throw new BadRequestException(`github_issue_delete_failed: ${message}`);
+      }
+      githubIssue = {
+        attempted: true,
+        deleted: false,
+        fallback_used: true,
+        message,
+      };
+      warnings.push(`GitHub issue was not deleted: ${message}`);
+    }
+
+    const planCleanup = this.plansService.deletePlanArtifacts(workItemId);
+    const graphResult = this.workItemsService.deleteWithConnectedEdges(workItemId, connectedEdges.map((edge) => edge.id));
+
+    return {
+      deleted: true,
+      work_item: {
+        id: workItem.id,
+        name: workItem.name,
+        state: workItem.state,
+        repo: workItem.repo,
+        issue_number: workItem.issue_number,
+        issue_url: workItem.issue_url,
+      },
+      graph: graphResult,
+      github_issue: githubIssue,
+      plan_cleanup: planCleanup,
+      warnings,
+    };
+  }
+
+  archiveRunArtifacts(workItemId: string): ArchiveRunArtifactsResult {
+    const normalized = workItemId?.trim();
+    if (!normalized) {
+      throw new BadRequestException("work_item_id is required");
+    }
+    const workItem = this.workItemsService.get(normalized);
+    this.assertNoActiveRunForWorkItem(normalized);
+
+    // Merge in-memory `recentRuns` with the disk scan so the archiver sees
+    // runs that exist only on disk (post-restart) and in-memory runs that
+    // haven't been flushed. Dedupe by run_id — in-memory wins because it
+    // carries the freshest activity log.
+    const diskRuns = loadRunRecordsForArtifactRoot(this.artifactRoot);
+    const seen = new Set<string>();
+    const merged: ExecutionRunRecord[] = [];
+    for (const run of this.executionService.listRecentRuns()) {
+      if (run.work_item_id !== normalized) continue;
+      if (seen.has(run.run_id)) continue;
+      merged.push(run);
+      seen.add(run.run_id);
+    }
+    for (const run of diskRuns) {
+      if (run.work_item_id !== normalized) continue;
+      if (seen.has(run.run_id)) continue;
+      merged.push(run);
+      seen.add(run.run_id);
+    }
+
+    try {
+      return archiveRunArtifactsForWorkItem(this.artifactRoot, workItem, {
+        runs: merged,
+        onWarn: (message) => this.logger.warn(message),
+      });
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      // Translate the archiver's raw Error codes into BadRequestException
+      // so the HTTP surface matches the other disposition guards.
+      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
+        throw new BadRequestException(message);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * HSM action adapter called by `HsmActionHandlers.runArchiver` during
+   * the `archive_and_close_merged` / `archive_and_close_closed` transitions.
+   *
+   * Orchestrates capture + plan-dir move + run-artifact archival and
+   * mutates the HSM context with the results. Mirrors what the Phase 1
+   * HsmActionHandlers.runArchiver did internally, but now lives on the
+   * owning sub-service so the handler can be a one-liner.
+   */
+  async archiveRunArtifactsAction(
+    workItem: WorkItemRecord,
+    _event: WorkItemHsmEvent,
+    ctx: HsmActionHandlerContext,
+  ): Promise<void> {
+    const runSnapshot = this.captureRunSnapshotForWorkItem(workItem.id);
+    const moveResult = this.movePlanDirToArchives(workItem.id);
+
+    let archiveResult: ArchiveRunArtifactsResult;
+    try {
+      archiveResult = archiveRunArtifactsForWorkItem(this.artifactRoot, workItem, {
+        runs: runSnapshot,
+        onWarn: (message) => this.logger.warn(message),
+      });
+    } catch (error) {
+      const message = this.getErrorMessage(error);
+      if (/^archive_run_active|^archive_already_exists_run/.test(message)) {
+        throw new BadRequestException(message);
+      }
+      throw error;
+    }
+
+    const archivePath =
+      archiveResult.archive_path ?? moveResult.archive_path ?? workItem.archive_path;
+    const studioArchive: StudioArchiveMeta = {
+      archived_at: this.now(),
+      readme_path: archiveResult.readme_path,
+      archived_run_ids: archiveResult.archived_run_ids,
+      skipped_run_ids: archiveResult.skipped_run_ids,
+    };
+    ctx.meta.studio_archive = studioArchive;
+    ctx.patch_overrides.archive_path = archivePath;
+    ctx.handler_data.archive_result = {
+      archive_path: archivePath,
+      readme_path: archiveResult.readme_path,
+      archived_run_ids: archiveResult.archived_run_ids,
+      skipped_run_ids: archiveResult.skipped_run_ids,
+    };
+  }
+
+  /**
+   * studio-88 helper: capture an authoritative run snapshot for a work
+   * item by merging the in-memory `recentRuns` buffer with the on-disk
+   * scan, deduped by `run_id` (in-memory wins).
+   */
+  private captureRunSnapshotForWorkItem(workItemId: string): ExecutionRunRecord[] {
+    const seen = new Set<string>();
+    const merged: ExecutionRunRecord[] = [];
+    for (const run of this.executionService.listRecentRuns()) {
+      if (run.work_item_id !== workItemId) continue;
+      if (seen.has(run.run_id)) continue;
+      merged.push(run);
+      seen.add(run.run_id);
+    }
+    try {
+      const diskRuns = loadRunRecordsForArtifactRoot(this.artifactRoot);
+      for (const run of diskRuns) {
+        if (run.work_item_id !== workItemId) continue;
+        if (seen.has(run.run_id)) continue;
+        merged.push(run);
+        seen.add(run.run_id);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `captureRunSnapshotForWorkItem: failed to scan disk for ${workItemId}: ${this.getErrorMessage(error)}`,
+      );
+    }
+    return merged;
+  }
+
+  /**
+   * studio-87: best-effort finalizer for `closeMergedPullRequest`.
+   *
+   * Splices every matching run out of the ExecutionService in-memory
+   * buffer (via the phase-3 seam) and stamps `disposed_at` on on-disk
+   * status files so hydration after a restart won't resurrect them.
+   *
+   * Failures are logged and swallowed; this is a finalizer and the
+   * caller has already completed the state transition. Returns the
+   * set of run ids that were updated or spliced.
+   */
+  private removeRunsForWorkItem(workItemId: string): string[] {
+    const timestamp = this.now();
+    const removedIds = new Set<string>();
+
+    // (a) In-memory recentRuns — ExecutionService owns the buffer. The
+    // Phase 3 seam walks the buffer back-to-front, splices matches,
+    // stamps disposed_at on the disk status file, and returns the
+    // disposed records so we can emit execution_result events here.
+    const disposed = this.executionService.disposeRunsForWorkItemInBuffer(workItemId, timestamp);
+    for (const run of disposed) {
+      removedIds.add(run.run_id);
+      this.executionService.emitRunExecutionResult(run);
+    }
+
+    // (b) On-disk runs that were not in recentRuns (hydration gap / cap
+    //     eviction). Pass includeDisposed so we can see already-disposed
+    //     records for idempotent replay, but skip them when writing.
+    try {
+      const runsDir = join(this.artifactRoot, "runs");
+      const diskRuns = loadRunRecordsFromDisk(runsDir, { includeDisposed: true });
+      for (const run of diskRuns) {
+        if (run.work_item_id !== workItemId) continue;
+        if (removedIds.has(run.run_id)) continue;
+        if (run.disposed_at) continue;
+        const nextRun: ExecutionRunRecord = {
+          ...run,
+          disposed_at: timestamp,
+          updated_at: timestamp,
+        };
+        try {
+          writeFileSync(
+            join(run.artifact_dir, "status.json"),
+            JSON.stringify(nextRun, null, 2),
+            "utf8",
+          );
+          removedIds.add(run.run_id);
+        } catch (error) {
+          if (!this.isMissingFileError(error)) {
+            this.logger.warn(
+              `removeRunsForWorkItem: failed to stamp disposed_at for on-disk run ${run.run_id}: ${this.getErrorMessage(error)}`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.warn(
+        `removeRunsForWorkItem: failed to scan runs dir: ${this.getErrorMessage(error)}`,
+      );
+    }
+
+    return Array.from(removedIds);
+  }
+
+  private movePlanDirToArchives(workItemId: string): { moved: boolean; archive_path: string | null } {
+    const src = planDir(this.artifactRoot, workItemId);
+    const dest = archiveDir(this.artifactRoot, workItemId);
+
+    if (!existsSync(src)) {
+      this.logger.warn(
+        `movePlanDirToArchives: plan dir ${src} does not exist for work item ${workItemId}; archive step is a no-op`,
+      );
+      return { moved: false, archive_path: null };
+    }
+
+    if (existsSync(dest)) {
+      throw new BadRequestException(
+        `archive_already_exists: refusing to move plan dir for ${workItemId} — destination ${dest} already exists. Resolve the collision manually before retrying.`,
+      );
+    }
+
+    mkdirSync(archivesRoot(this.artifactRoot), { recursive: true });
+    renameSync(src, dest);
+    return { moved: true, archive_path: dest };
+  }
+
+  private leafState(state: string): string {
+    return state.startsWith("pre_pr.") ? state.slice("pre_pr.".length) : state;
+  }
+
+  private assertCancelEligible(workItem: WorkItemRecord): void {
+    const leafState = this.leafState(workItem.state);
+    const eligibleStates = new Set(["planned", "drafting", "ready", "in_progress", "deferred"]);
+
+    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
+      throw new BadRequestException(`cancel_work_item_not_issue_backed: ${workItem.id}`);
+    }
+    if (!eligibleStates.has(leafState)) {
+      throw new BadRequestException(
+        `cancel_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; cancel is limited to pre-PR issue-backed work items`,
+      );
+    }
+  }
+
+  private assertDeleteEligible(workItem: WorkItemRecord): void {
+    const leafState = this.leafState(workItem.state);
+    const eligibleStates = new Set(["planned", "drafting", "ready"]);
+
+    if (workItem.kind !== "issue" || !workItem.repo || !workItem.issue_number) {
+      throw new BadRequestException(`delete_work_item_not_issue_backed: ${workItem.id}`);
+    }
+    if (!eligibleStates.has(leafState)) {
+      throw new BadRequestException(
+        `delete_work_item_ineligible_state: ${workItem.id} is ${workItem.state}; destructive delete is limited to planned, drafting, or ready items`,
+      );
+    }
+  }
+
+  private assertWorkItemInMergedPr(workItemId: string): WorkItemRecord {
+    const workItem = this.workItemsService.get(workItemId);
+    if (workItem.state !== "merged_pr") {
+      throw new BadRequestException(
+        `work_item_not_in_merged_pr: cannot dispose ${workItemId} (state is ${workItem.state}, requires merged_pr)`,
+      );
+    }
+    return workItem;
+  }
+
+  private assertNoActiveRunForWorkItem(workItemId: string): void {
+    const activeStatuses = ["queued", "preparing", "disambiguating", "running"] as const;
+    const activeRun = this.executionService.listRecentRuns().find(
+      (run) =>
+        run.work_item_id === workItemId &&
+        (activeStatuses as readonly string[]).includes(run.status),
+    );
+    if (activeRun) {
+      throw new BadRequestException(
+        `cannot_dispose_work_item_active_run: run ${activeRun.run_id} is ${activeRun.status} for work item ${workItemId}. ` +
+          `Wait for the run to finish or clean it up first.`,
+      );
+    }
+  }
+
+  // Duplicated trivial helpers — see SCRATCHPAD_223 §"Helpers" decision.
+  // Phase 9 can extract these to a shared util if it wants.
+
+  private now(): string {
+    return new Date().toISOString();
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  private isMissingFileError(error: unknown): boolean {
+    return typeof error === "object"
+      && error !== null
+      && "code" in error
+      && (error as { code?: unknown }).code === "ENOENT";
+  }
+}


### PR DESCRIPTION
## Summary
Phase 3 of the cqrs refactor series. Extracts the merged-PR
disposition cluster — nine methods, ~800 lines — out of
\`ExecutionService\` into a dedicated \`RunDispositionService\`.
\`ExecutionService\` shrinks from **3238 → 2627 lines (−611)**, well
under the proposal's 2700-line target.

Methods moved:

  - \`closeMergedPullRequest\` / \`archiveAndCloseMergedPullRequest\`
  - \`cancelWorkItem\` / \`deleteWorkItem\`
  - \`archiveRunArtifacts\` (the public wrapper) + new
    \`archiveRunArtifactsAction\` HSM adapter
  - \`captureRunSnapshotForWorkItem\` / \`movePlanDirToArchives\`
    (private)
  - \`removeRunsForWorkItem\` (private finalizer)
  - Disposition guards: \`assertCancelEligible\` /
    \`assertDeleteEligible\` / \`assertWorkItemInMergedPr\` /
    \`assertNoActiveRunForWorkItem\` / \`leafState\`

Consumers rewired to the new sub-service:

  - \`HsmActionHandlers.runArchiver\` — drops
    \`@Inject(ExecutionService)\`, injects \`RunDispositionService\`
    instead, collapses to a one-liner delegating to
    \`archiveRunArtifactsAction\`. The Phase 1 seams
    (\`getArtifactRoot\`, \`logWarn\`, public
    \`captureRunSnapshotForWorkItem\`, public
    \`movePlanDirToArchives\`) are deleted from ExecutionService
    as a consequence.
  - Phase 2 \`CancelWorkItemHandler\` and \`DeleteWorkItemHandler\`
    swap their constructor to inject \`RunDispositionService\`.
  - **Two new command handlers** bridge a Phase 2 scope gap:
    \`CloseMergedPullRequestCommand\` and
    \`ArchiveAndCloseMergedPullRequestCommand\`. Registered on
    \`ExecutionModule\`, dispatched by the corresponding
    \`ExecutionController\` routes.

After this PR, every disposition entrypoint
(\`/api/work-items/:id/transition\` \u2192 cancel,
\`/api/execution/cancel-work-item\`,
\`/api/execution/delete-work-item\`,
\`/api/execution/close-merged\`,
\`/api/execution/archive-and-close-merged\`,
HSM \`runArchiver\` action) routes through the bus and is handled by
\`RunDispositionService\`. The methods on \`ExecutionService\` are
gone.

Closes #223. Full scope:
[\`docs/proposals/phase-3-run-disposition-service.md\`](docs/proposals/phase-3-run-disposition-service.md).

## forwardRef count
**8 → 8 (unchanged.)** \`RunDispositionService\` still
\`forwardRef()\`s \`ExecutionService\` for the run-buffer mutation
seams (\`disposeRunsForWorkItemInBuffer\`,
\`emitRunExecutionResult\`). Phase 4 extracts \`RunStore\` and that
forwardRef becomes a one-way \`RunStore\` injection.

\`\`\`
grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l
\`\`\`

## Key changes
- \`refactor(execution)\`: add \`disposeRunsForWorkItemInBuffer\` +
  \`emitRunExecutionResult\` public seams on \`ExecutionService\`
  (marked \`TODO(phase-4)\`)
- \`feat(execution)\`: new \`src/modules/execution/run-disposition.service.ts\`
  with the full disposition cluster lifted verbatim; own
  \`artifactRoot\` / \`logger\`; forwardRef'd dependency on
  \`ExecutionService\` for the run-buffer seams
- \`refactor(execution)\`: \`HsmActionHandlers.runArchiver\`
  collapses to a one-liner
- \`refactor(execution)\`: Phase 2 Cancel + Delete handlers rewire
- \`feat(execution)\`: two new Close / ArchiveAndClose command
  handlers + controller dispatch (Phase 2 scope gap fix)
- \`refactor(execution)\`: delete 611 lines of duplicated methods
  from \`ExecutionService\`; rewrite \`disposition.test.ts\` (900
  lines) + \`archive-run-artifacts.test.ts\` to point at
  \`RunDispositionService.prototype\`
- \`test(execution)\`: new \`run-buffer-seams.test.ts\` with 7 cases
  covering the Phase 4 seams directly (dispose + emit + ENOENT
  swallowing + failure paths)

## Deviations from the proposal
1. **Seam signature widened.** The proposal specified
   \`disposeRunFromBuffer(runId, disposedAt) -> ExecutionRunRecord | null\`.
   The actual seam is plural —
   \`disposeRunsForWorkItemInBuffer(workItemId, disposedAt)\` —
   which encapsulates the back-to-front splice loop. Then
   widened further to return
   \`{ newlyDisposed, alreadyDisposedIds }\` because the singular
   list silently regressed the idempotent-replay case (a
   previously-disposed run being re-removed from the buffer on
   replay was counted as "not removed" because it wasn't in
   the \`disposed\` list). Caught by the rewritten disposition
   test on the first full test run.
2. **Field naming matches \`ExecutionService\` convention**
   (\`workItemsService\`, \`hsmService\`, \`githubService\`,
   \`githubBatchCache\`, \`plansService\`) instead of the
   proposal's shorter names (\`workItems\`, \`hsm\`, \`github\`,
   \`cache\`, \`plans\`). The 900-line \`disposition.test.ts\`
   harness accesses fields by name via
   \`Object.create(...prototype)\`; keeping the conventional
   names turned the rewrite from a full case-by-case
   adaptation into a narrow prototype-swap plus a few new
   \`executionService\` field stubs.
3. **Two new command handlers created** (Close + Archive) that
   the proposal's acceptance criteria assumed existed from
   Phase 2. Phase 2 only created six handlers and these two
   weren't among them — Phase 3 bridges the gap.
4. **\`plansService\` injection removed from \`ExecutionService\`**.
   Nothing in the surviving ExecutionService calls
   \`this.plansService.X()\` anymore, so the unused constructor
   parameter and its \`forwardRef\` wrapper came out. The
   module-level \`forwardRef(() => PlansModule)\` in
   \`ExecutionModule.imports\` stays because
   \`RunDispositionService\` still injects \`PlansService\`.
5. **Seven commits instead of the scratchpad's six.** Several
   task pairs had to collapse into single commits to keep every
   commit boundary green under tsc + the 900-line test suite
   that accesses service internals via prototype.

## Test plan
- [x] \`npm run check\` (tsc) — clean
- [x] \`npm test\` — **528/528** (521 + 7 new run-buffer seam
  tests). Pre-existing disposition coverage (45 cases) preserved
  through the test rewrite.
- [x] \`npm run build:web\` — clean
- [x] \`wc -l src/modules/execution/execution.service.ts\` →
  **2627** (under 2700)
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\`
  → **8** (unchanged from Phase 2)
- [x] \`grep closeMergedPullRequest src/modules/execution/execution.service.ts\`
  → 0 hits
- [x] \`grep 'async cancelWorkItem\\|cancelWorkItem(input' src/modules/execution/execution.service.ts\`
  → 0 method definitions (only the controller-level dispatch
  helpers remain elsewhere)
- [x] \`grep 'getArtifactRoot\\|logWarn' src/modules/execution/execution.service.ts\`
  → 0 hits (Phase 1 seams deleted)
- [x] \`PORT=3030 npm start\` boots; \`GET /health\` →
  \`{"ok":true,"db":{...}}\`
- [ ] **Deferred manual smoke:** merged-PR close, merged-PR
  archive-and-close, pre-PR cancel, pre-PR delete end-to-end
  against real work items. Not exercised in this session —
  relying on the rewritten \`disposition.test.ts\` (45 cases),
  the handler delegation tests, the full unit suite, clean tsc,
  and clean dev boot to cover the wiring path. Reviewer to
  confirm or run themselves.

## Commit grouping rationale
Seven commits split for review ergonomics; every commit is
independently buildable + testable:

1. \`2adba29\` — add the two ExecutionService run-buffer seams
   (\`disposeRunsForWorkItemInBuffer\`, \`emitRunExecutionResult\`)
   alone, no consumers yet
2. \`c1321d4\` — create \`RunDispositionService\` with the full
   disposition cluster lifted verbatim, register on
   \`ExecutionModule\`; old ExecutionService methods still in
   place as duplicates so the branch stays green
3. \`a444faa\` — \`HsmActionHandlers.runArchiver\` rewires to
   \`RunDispositionService\`
4. \`6816738\` — Phase 2 Cancel + Delete handlers rewire
5. \`205ad83\` — new Close / Archive commands + handlers +
   controller dispatch
6. \`b1fc864\` — delete 611 lines of duplicated ExecutionService
   methods and rewrite \`disposition.test.ts\` +
   \`archive-run-artifacts.test.ts\` + cleanup stale
   \`runArchiver\` behavior tests from
   \`hsm-action-handlers.test.ts\` (collapsed into one commit
   because the controller/handler/test prototypes all need to
   shift at the same boundary for tsc to stay clean)
7. \`24120c1\` — new \`run-buffer-seams.test.ts\` with 7 cases
   directly covering the Phase 4 seams

## What's next
Phase 4 extracts the remaining clusters from
\`ExecutionService\` — \`WorktreeService\`, \`PullRequestService\`,
\`ScratchpadService\`, \`RunInteractionService\`, and \`RunStore\`.
\`RunStore\` is the one that absorbs the two
\`disposeRunsForWorkItemInBuffer\` / \`emitRunExecutionResult\`
seams added here and finally breaks the \`RunDispositionService →
ExecutionService\` forwardRef, taking the forwardRef count below 8.