### PR TITLE
feat(execution): extract ScratchpadService (Phase 4c #232)

### DIFF
--- a/src/modules/execution/__tests__/build-scratchpad.test.ts
+++ b/src/modules/execution/__tests__/build-scratchpad.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { ExecutionService } from "../execution.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 import type { ExecutionRunRecord, ExecutionDispatchNodePreview } from "../types.js";
 
 /**
- * We test buildScratchpad by constructing a minimal service instance via
- * Object.create so we can call the public method without wiring up DI.
+ * Phase 4c (#232): buildScratchpad lives on ScratchpadService.
+ *
+ * The method is pure — it takes no state — so the harness constructs
+ * a ScratchpadService instance via Object.create without wiring any
+ * fields. No DI, no filesystem.
  */
 function callBuildScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
-  const service = Object.create(ExecutionService.prototype) as ExecutionService;
+  const service = Object.create(ScratchpadService.prototype) as ScratchpadService;
   return service.buildScratchpad(run, node);
 }
 

--- a/src/modules/execution/__tests__/execution-rehydrate.test.ts
+++ b/src/modules/execution/__tests__/execution-rehydrate.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { ExecutionService } from "../execution.service.js";
 import { RunStore } from "../run-store.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 import type { ExecutionRunRecord, ExecutionRunStatus } from "../types.js";
 import { canonicalScratchpadPath } from "../../../lib/context-layout.js";
 
@@ -71,6 +72,15 @@ function makeExecutionServiceHarness(
   (service as any).activeSessions = new Map();
   (service as any).now = () => "2026-04-10T06:00:00.000Z";
   (service as any).extractTextFromMessage = (message: any) => message?.text ?? null;
+  // Phase 4c (#232): the thin-wrapper HTTP getters
+  // (`getRunScratchpad` / `getRunChecklist`) delegate to a real
+  // ScratchpadService instance. Construct a bare-prototype
+  // ScratchpadService with the same artifactRoot so the rehydrate
+  // tests can exercise the canonical + worktree read paths.
+  const scratchpad = Object.create(ScratchpadService.prototype) as ScratchpadService;
+  (scratchpad as any).artifactRoot = artifactRoot;
+  (scratchpad as any).logger = { warn: vi.fn() };
+  (service as any).scratchpadService = scratchpad;
   Object.assign(service as any, extras);
   return service;
 }

--- a/src/modules/execution/__tests__/parse-checklist.test.ts
+++ b/src/modules/execution/__tests__/parse-checklist.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { ExecutionService } from "../execution.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 
+/**
+ * Phase 4c (#232): parseImplementationPlanChecklist lives on
+ * ScratchpadService. The method is a pure parser, so the harness
+ * constructs a bare ScratchpadService instance via Object.create.
+ */
 function parseChecklist(content: string) {
-  const service = Object.create(ExecutionService.prototype) as ExecutionService;
+  const service = Object.create(ScratchpadService.prototype) as ScratchpadService;
   return service.parseImplementationPlanChecklist(content);
 }
 

--- a/src/modules/execution/__tests__/parse-scratchpad-open-items.test.ts
+++ b/src/modules/execution/__tests__/parse-scratchpad-open-items.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { ExecutionService } from "../execution.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 
 /**
- * Unit tests for the private `parseScratchpadOpenItems` helper.
+ * Unit tests for the `parseScratchpadOpenItems` helper.
  *
- * Uses the `Object.create(ExecutionService.prototype)` harness pattern
- * from scratchpad-canonical.test.ts / build-scratchpad.test.ts so we can
- * exercise the pure method without booting Nest DI.
+ * Phase 4c (#232): the parser lives on ScratchpadService. Uses the
+ * `Object.create(ScratchpadService.prototype)` harness pattern so we
+ * can exercise the pure method without booting Nest DI.
  */
 
 interface Harness {
@@ -16,10 +16,10 @@ interface Harness {
 }
 
 function makeHarness(): Harness {
-  return Object.create(ExecutionService.prototype) as Harness;
+  return Object.create(ScratchpadService.prototype) as Harness;
 }
 
-describe("ExecutionService.parseScratchpadOpenItems", () => {
+describe("ScratchpadService.parseScratchpadOpenItems", () => {
   it("parses items from both sections when both are populated", () => {
     const h = makeHarness();
     const content = [

--- a/src/modules/execution/__tests__/scratchpad-canonical.test.ts
+++ b/src/modules/execution/__tests__/scratchpad-canonical.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ExecutionService } from "../execution.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 import type { ExecutionDispatchNodePreview, ExecutionRunRecord } from "../types.js";
 import {
   canonicalScratchpadPath,
@@ -14,32 +15,30 @@ import {
 /**
  * Canonical scratchpad behavior (ADR 014 step 2).
  *
- * Tests use Object.create to bypass DI and inject the artifactRoot + a
- * minimal run record, matching the pattern in build-scratchpad.test.ts and
- * launch-eligibility.test.ts.
+ * Phase 4c (#232): the pure scratchpad methods live on
+ * ScratchpadService. The HTTP getters stay on ExecutionService as thin
+ * orchestrator wrappers that delegate to the injected scratchpadService.
+ * `appendRunIdToPlanMetadata` stays on ExecutionService.
+ *
+ * Tests use `Object.create` to bypass DI and inject the minimal set of
+ * fields each method under test needs.
  */
 
-interface HarnessService {
+// ─── ScratchpadService harness (pure scratchpad methods) ──────────────
+
+interface ScratchpadHarness {
   artifactRoot: string;
   logger: { warn: (msg: string) => void };
   warnings: string[];
-  syncScratchpadToCanonical: ExecutionService["syncScratchpadToCanonical"];
-  getRunScratchpad: ExecutionService["getRunScratchpad"];
-  getRunChecklist: ExecutionService["getRunChecklist"];
-  writeScratchpad: (
-    run: ExecutionRunRecord,
-    node: ExecutionDispatchNodePreview,
-  ) => { path: string; source: "canonical_ready" | "carried_forward" | "synthesized" };
-  appendRunIdToPlanMetadata: (workItemId: string, runId: string) => void;
-  buildScratchpad: (run: ExecutionRunRecord, node: ExecutionDispatchNodePreview) => string;
-  getErrorMessage: (error: unknown) => string;
-  runStore: {
-    getRun: (runId: string) => ExecutionRunRecord | null;
-  };
+  syncScratchpadToCanonical: ScratchpadService["syncScratchpadToCanonical"];
+  getRunScratchpad: ScratchpadService["getRunScratchpad"];
+  getRunChecklist: ScratchpadService["getRunChecklist"];
+  writeScratchpad: ScratchpadService["writeScratchpad"];
+  buildScratchpad: ScratchpadService["buildScratchpad"];
 }
 
-function makeService(artifactRoot: string, run?: ExecutionRunRecord): HarnessService {
-  const service = Object.create(ExecutionService.prototype) as HarnessService;
+function makeScratchpadService(artifactRoot: string): ScratchpadHarness {
+  const service = Object.create(ScratchpadService.prototype) as ScratchpadHarness;
   service.artifactRoot = artifactRoot;
   service.warnings = [];
   service.logger = {
@@ -47,18 +46,55 @@ function makeService(artifactRoot: string, run?: ExecutionRunRecord): HarnessSer
       service.warnings.push(msg);
     },
   };
-  // Phase 4a (#230): getRun lives on RunStore. The harness provides
-  // a minimal runStore field so ExecutionService methods (still on
-  // the prototype) can reach it via `this.runStore.getRun(runId)`.
-  service.runStore = {
-    getRun: (runId: string) => (run && run.run_id === runId ? run : null),
-  };
-  // buildScratchpad touches other private helpers we don't stub; override
-  // with a deterministic stub so `writeScratchpad` synthesis tests don't
-  // trip on missing dependencies.
+  // writeScratchpad falls back to buildScratchpad when the canonical
+  // file is missing. buildScratchpad is pure so the real implementation
+  // works, but we override with a deterministic stub so the synthesis
+  // test is stable.
   (service as any).buildScratchpad = () => "synthesized skeleton content";
   return service;
 }
+
+// ─── ExecutionService harness (thin-wrapper HTTP getters + appendRunIdToPlanMetadata) ──
+
+interface ExecutionHarness {
+  artifactRoot: string;
+  logger: { warn: (msg: string) => void };
+  warnings: string[];
+  getRunScratchpad: ExecutionService["getRunScratchpad"];
+  getRunChecklist: ExecutionService["getRunChecklist"];
+  appendRunIdToPlanMetadata: (workItemId: string, runId: string) => void;
+  getErrorMessage: (error: unknown) => string;
+  runStore: {
+    getRun: (runId: string) => ExecutionRunRecord | null;
+  };
+  scratchpadService: ScratchpadService;
+}
+
+function makeExecutionService(artifactRoot: string, run?: ExecutionRunRecord): ExecutionHarness {
+  const service = Object.create(ExecutionService.prototype) as ExecutionHarness;
+  service.artifactRoot = artifactRoot;
+  service.warnings = [];
+  service.logger = {
+    warn: (msg: string) => {
+      service.warnings.push(msg);
+    },
+  };
+  // Phase 4a (#230): getRun lives on RunStore.
+  service.runStore = {
+    getRun: (runId: string) => (run && run.run_id === runId ? run : null),
+  };
+  // Phase 4c (#232): the thin-wrapper getters delegate to a real
+  // ScratchpadService. Construct a ScratchpadService-prototype harness
+  // and wire it up; the instance doesn't need RunStore/WorktreeService
+  // for the getter paths under test.
+  const scratchpad = Object.create(ScratchpadService.prototype) as ScratchpadService;
+  (scratchpad as any).artifactRoot = artifactRoot;
+  (scratchpad as any).logger = { warn: () => {} };
+  service.scratchpadService = scratchpad;
+  return service;
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────
 
 function makeNode(workItemId: string): ExecutionDispatchNodePreview {
   const branch = `${workItemId}-branch`;
@@ -104,7 +140,7 @@ function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecor
   };
 }
 
-describe("ExecutionService scratchpad canonical flow", () => {
+describe("ScratchpadService canonical flow", () => {
   let tmpRoot: string;
   let worktree: string;
 
@@ -121,7 +157,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
   describe("syncScratchpadToCanonical", () => {
     it("copies the worktree scratchpad to canonical when present", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // Seed the canonical plan dir and the worktree scratchpad
       mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
@@ -137,7 +173,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
 
     it("leaves canonical unchanged and logs a warning when worktree file is missing", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // Seed canonical with prior content; no worktree scratchpad
       mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
@@ -150,92 +186,13 @@ describe("ExecutionService scratchpad canonical flow", () => {
     });
   });
 
-  describe("getRunScratchpad", () => {
-    it("prefers the canonical plan file", () => {
-      const run = makeRun({
-        worktree_path: worktree,
-        artifact_dir: join(tmpRoot, "runs", "exec_test"),
-      });
-      const service = makeService(tmpRoot, run);
-
-      mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
-      writeFileSync(canonicalScratchpadPath(tmpRoot, run.work_item_id), "canonical content", "utf8");
-      // Also write a worktree copy — canonical should win
-      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree content", "utf8");
-
-      const result = service.getRunScratchpad("exec_test");
-      expect(result.content).toBe("canonical content");
-      expect(result).not.toHaveProperty("source");
-    });
-
-    it("falls back to the worktree live copy when canonical is absent", () => {
-      const run = makeRun({
-        worktree_path: worktree,
-        artifact_dir: join(tmpRoot, "runs", "exec_test"),
-      });
-      const service = makeService(tmpRoot, run);
-
-      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree only", "utf8");
-
-      const result = service.getRunScratchpad("exec_test");
-      expect(result.content).toBe("worktree only");
-    });
-
-    it("returns null content when neither canonical nor worktree exists", () => {
-      const run = makeRun({
-        worktree_path: worktree,
-        artifact_dir: join(tmpRoot, "runs", "exec_test"),
-      });
-      const service = makeService(tmpRoot, run);
-
-      const result = service.getRunScratchpad("exec_test");
-      expect(result.content).toBe(null);
-    });
-
-    it("returns null content when run is not found", () => {
-      const service = makeService(tmpRoot);
-      const result = service.getRunScratchpad("nonexistent");
-      expect(result.content).toBe(null);
-    });
-  });
-
-  describe("getRunChecklist", () => {
-    it("reconstructs checklist state from the surviving worktree scratchpad", () => {
-      const run = makeRun({
-        worktree_path: worktree,
-        artifact_dir: join(tmpRoot, "runs", "exec_test"),
-      });
-      const service = makeService(tmpRoot, run);
-
-      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), [
-        "# Scratchpad",
-        "",
-        "## Implementation Plan",
-        "- [x] Finish persistence layer",
-        "- [ ] Verify restart hydration",
-        "",
-        "## Work Log",
-      ].join("\n"), "utf8");
-
-      expect(service.getRunChecklist("exec_test")).toEqual({
-        run_id: "exec_test",
-        items: [
-          { text: "Finish persistence layer", checked: true },
-          { text: "Verify restart hydration", checked: false },
-        ],
-        completed: 1,
-        total: 2,
-      });
-    });
-  });
-
   // ADR 014 step 5: writeScratchpad must source content differently depending
   // on the plan metadata state, returning a discriminated result so the
   // caller knows whether to run the setup phase.
   describe("writeScratchpad (ADR 014 step 5)", () => {
     it("copies canonical into the worktree when plan state is 'ready'", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // Seed a ready plan: canonical scratchpad + metadata marked ready
       ensurePlanDir(tmpRoot, run.work_item_id);
@@ -259,7 +216,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
 
     it("throws ready_plan_scratchpad_missing when plan is ready but canonical is absent", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // Seed metadata as ready but do NOT create the canonical scratchpad
       ensurePlanDir(tmpRoot, run.work_item_id);
@@ -281,7 +238,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
 
     it("carries existing canonical forward when plan state is null (legacy)", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // Seed canonical but leave metadata.state as null (drafting/untouched)
       ensurePlanDir(tmpRoot, run.work_item_id);
@@ -295,7 +252,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
 
     it("synthesizes a skeleton when no canonical file exists (fallback)", () => {
       const run = makeRun({ worktree_path: worktree });
-      const service = makeService(tmpRoot, run);
+      const service = makeScratchpadService(tmpRoot);
 
       // No plan dir, no canonical file — ensurePlanDir will create the dir
       const result = service.writeScratchpad(run, makeNode(run.work_item_id));
@@ -307,13 +264,107 @@ describe("ExecutionService scratchpad canonical flow", () => {
       expect(readFileSync(canonical, "utf8")).toBe("synthesized skeleton content");
     });
   });
+});
+
+describe("ExecutionService scratchpad orchestration", () => {
+  let tmpRoot: string;
+  let worktree: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "studio-152-exec-"));
+    worktree = join(tmpRoot, "wt");
+    mkdirSync(worktree, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe("getRunScratchpad thin wrapper", () => {
+    it("prefers the canonical plan file", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeExecutionService(tmpRoot, run);
+
+      mkdirSync(planDir(tmpRoot, run.work_item_id), { recursive: true });
+      writeFileSync(canonicalScratchpadPath(tmpRoot, run.work_item_id), "canonical content", "utf8");
+      // Also write a worktree copy — canonical should win
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree content", "utf8");
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe("canonical content");
+      expect(result).not.toHaveProperty("source");
+    });
+
+    it("falls back to the worktree live copy when canonical is absent", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeExecutionService(tmpRoot, run);
+
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), "worktree only", "utf8");
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe("worktree only");
+    });
+
+    it("returns null content when neither canonical nor worktree exists", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeExecutionService(tmpRoot, run);
+
+      const result = service.getRunScratchpad("exec_test");
+      expect(result.content).toBe(null);
+    });
+
+    it("returns null content when run is not found", () => {
+      const service = makeExecutionService(tmpRoot);
+      const result = service.getRunScratchpad("nonexistent");
+      expect(result.content).toBe(null);
+    });
+  });
+
+  describe("getRunChecklist thin wrapper", () => {
+    it("reconstructs checklist state from the surviving worktree scratchpad", () => {
+      const run = makeRun({
+        worktree_path: worktree,
+        artifact_dir: join(tmpRoot, "runs", "exec_test"),
+      });
+      const service = makeExecutionService(tmpRoot, run);
+
+      writeFileSync(join(worktree, "SCRATCHPAD_studio_999.md"), [
+        "# Scratchpad",
+        "",
+        "## Implementation Plan",
+        "- [x] Finish persistence layer",
+        "- [ ] Verify restart hydration",
+        "",
+        "## Work Log",
+      ].join("\n"), "utf8");
+
+      expect(service.getRunChecklist("exec_test")).toEqual({
+        run_id: "exec_test",
+        items: [
+          { text: "Finish persistence layer", checked: true },
+          { text: "Verify restart hydration", checked: false },
+        ],
+        completed: 1,
+        total: 2,
+      });
+    });
+  });
 
   // ADR 014 step 5: plan metadata.run_ids tracks every run attempt.
   describe("appendRunIdToPlanMetadata (ADR 014 step 5)", () => {
     it("appends a run ID to the plan metadata run_ids array", () => {
       const workItemId = "studio-999";
       ensurePlanDir(tmpRoot, workItemId);
-      const service = makeService(tmpRoot);
+      const service = makeExecutionService(tmpRoot);
 
       service.appendRunIdToPlanMetadata(workItemId, "exec_111");
 
@@ -324,7 +375,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
     it("is idempotent — appending the same run ID twice is a no-op", () => {
       const workItemId = "studio-999";
       ensurePlanDir(tmpRoot, workItemId);
-      const service = makeService(tmpRoot);
+      const service = makeExecutionService(tmpRoot);
 
       service.appendRunIdToPlanMetadata(workItemId, "exec_111");
       service.appendRunIdToPlanMetadata(workItemId, "exec_111");
@@ -336,7 +387,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
     it("appends multiple distinct run IDs in order", () => {
       const workItemId = "studio-999";
       ensurePlanDir(tmpRoot, workItemId);
-      const service = makeService(tmpRoot);
+      const service = makeExecutionService(tmpRoot);
 
       service.appendRunIdToPlanMetadata(workItemId, "exec_111");
       service.appendRunIdToPlanMetadata(workItemId, "exec_222");
@@ -347,7 +398,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
     });
 
     it("is a no-op when plan metadata is missing", () => {
-      const service = makeService(tmpRoot);
+      const service = makeExecutionService(tmpRoot);
 
       // No ensurePlanDir — metadata does not exist
       expect(() => service.appendRunIdToPlanMetadata("studio-999", "exec_111")).not.toThrow();
@@ -357,7 +408,7 @@ describe("ExecutionService scratchpad canonical flow", () => {
     it("logs a warning and does not throw when the write fails", () => {
       const workItemId = "studio-999";
       ensurePlanDir(tmpRoot, workItemId);
-      const service = makeService(tmpRoot);
+      const service = makeExecutionService(tmpRoot);
       // Provide a getErrorMessage shim (used by the warning path)
       (service as any).getErrorMessage = (err: unknown) => (err instanceof Error ? err.message : String(err));
 

--- a/src/modules/execution/__tests__/scratchpad-commit-guards.test.ts
+++ b/src/modules/execution/__tests__/scratchpad-commit-guards.test.ts
@@ -4,46 +4,91 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BadRequestException } from "@nestjs/common";
 import { ExecutionService } from "../execution.service.js";
+import { ScratchpadService } from "../scratchpad.service.js";
 import type { ExecutionRunRecord } from "../types.js";
 import type { WorkItemRecord } from "../../graph/types.js";
 
 /**
  * ADR 014 step 6: scratchpad commit guards.
  *
- * These tests focus on guard behavior, not the OS process boundary.
- * The service methods already centralize git access through `runGitIn()`,
- * so the test harness stubs command output instead of shelling out to a
- * real `git` binary. That keeps the assertions deterministic and avoids
- * sandbox-related child-process failures.
+ * Phase 4c (#232): the commit-guard helpers
+ * (`findStagedScratchpadViolations`, `findCommittedScratchpadViolations`,
+ * `isScratchpadPath`) live on ScratchpadService. The pull-request-creation
+ * and auto-stage-commit methods that call those guards still live on
+ * ExecutionService; they will migrate to PullRequestService in Phase 4e.
+ *
+ * This file therefore uses two harnesses:
+ *   - ScratchpadHarness: Object.create(ScratchpadService.prototype)
+ *     with a stubbed worktreeService.runGitIn. Exercises the pure
+ *     commit-guard helpers directly.
+ *   - ExecutionHarness: Object.create(ExecutionService.prototype) with
+ *     a scratchpadService field that stubs findStagedScratchpadViolations
+ *     / findCommittedScratchpadViolations / isScratchpadPath plus the
+ *     existing runStore + worktreeService fields. Exercises
+ *     autoStageAndCommit / createPullRequest end to end.
  */
 
-interface HarnessService {
+// ─── ScratchpadService harness (pure commit guards) ───────────────────
+
+interface ScratchpadHarness {
+  logger: { warn: ReturnType<typeof vi.fn> };
+  worktreeService: {
+    runGitIn: ReturnType<typeof vi.fn>;
+  };
+  findStagedScratchpadViolations: ScratchpadService["findStagedScratchpadViolations"];
+  findCommittedScratchpadViolations: ScratchpadService["findCommittedScratchpadViolations"];
+  isScratchpadPath: ScratchpadService["isScratchpadPath"];
+}
+
+function makeScratchpadHarness(gitResponses: Record<string, string> = {}): ScratchpadHarness {
+  const service = Object.create(ScratchpadService.prototype) as ScratchpadHarness;
+  service.logger = { warn: vi.fn() };
+  service.worktreeService = {
+    runGitIn: vi.fn((_cwd: string, args: string[], options?: { allowFailure?: boolean }) => {
+      const key = args.join(" ");
+      const response = gitResponses[key];
+      if (response != null) {
+        return response;
+      }
+      if (options?.allowFailure) {
+        return "";
+      }
+      return "";
+    }),
+  };
+  return service;
+}
+
+// ─── ExecutionService harness (autoStageAndCommit + createPullRequest) ──
+
+interface ExecutionHarness {
   artifactRoot: string;
   logger: { log: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
   workItemsService: { get: (id: string) => WorkItemRecord; update: ReturnType<typeof vi.fn> };
-  // Phase 4a: appendEvent, updateRun, getRun, writeSummary moved to RunStore.
   runStore: {
     appendEvent: ReturnType<typeof vi.fn>;
     updateRun: ReturnType<typeof vi.fn>;
     getRun: (runId: string) => ExecutionRunRecord | null;
     writeSummary: ReturnType<typeof vi.fn>;
   };
-  // Phase 4b (#231): runGhIn / runGitIn / listChangedFiles moved to
-  // WorktreeService. The harness installs a worktreeService field with
-  // all three stubbed so the scratchpad commit guards (still on
-  // ExecutionService.prototype) can reach them via
-  // `this.worktreeService.runGitIn(...)`.
   worktreeService: {
     runGhIn: ReturnType<typeof vi.fn>;
     runGitIn: ReturnType<typeof vi.fn>;
     listChangedFiles: ReturnType<typeof vi.fn>;
   };
+  // Phase 4c (#232): commit guards + isScratchpadPath live on
+  // ScratchpadService. The ExecutionService orchestrator reaches them
+  // via `this.scratchpadService.X(...)`, so the harness provides
+  // stubs for the three helpers that autoStageAndCommit /
+  // createPullRequest call.
+  scratchpadService: {
+    findStagedScratchpadViolations: ReturnType<typeof vi.fn>;
+    findCommittedScratchpadViolations: ReturnType<typeof vi.fn>;
+    isScratchpadPath: ReturnType<typeof vi.fn>;
+  };
   buildPullRequestTitle: (workItem: WorkItemRecord) => string;
   buildPullRequestBody: (run: ExecutionRunRecord, workItem: WorkItemRecord, baseRef: string) => string;
 
-  findStagedScratchpadViolations: ExecutionService["findStagedScratchpadViolations"];
-  findCommittedScratchpadViolations: ExecutionService["findCommittedScratchpadViolations"];
-  isScratchpadPath: ExecutionService["isScratchpadPath"];
   autoStageAndCommit: (run: ExecutionRunRecord, workItem: WorkItemRecord, commitMessage?: string) => void;
   createPullRequest: ExecutionService["createPullRequest"];
 }
@@ -90,13 +135,19 @@ function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
   };
 }
 
-function makeService(params: {
+function isScratchpadPath(path: string): boolean {
+  return /(?:^|\/)SCRATCHPAD_[^/]*\.md$/.test(path);
+}
+
+function makeExecutionHarness(params: {
   run?: ExecutionRunRecord;
   workItem?: WorkItemRecord;
   gitResponses?: Record<string, string>;
+  stagedViolations?: string[];
+  committedViolations?: string[];
   changedFiles?: string[];
-} = {}): HarnessService {
-  const service = Object.create(ExecutionService.prototype) as HarnessService;
+} = {}): ExecutionHarness {
+  const service = Object.create(ExecutionService.prototype) as ExecutionHarness;
   const workItem = params.workItem ?? makeWorkItem();
   const gitResponses = params.gitResponses ?? {};
 
@@ -106,9 +157,6 @@ function makeService(params: {
     get: (_id: string) => workItem,
     update: vi.fn((_id: string, patch: Partial<WorkItemRecord>) => ({ ...workItem, ...patch })),
   };
-  // Phase 4a (#230): these methods moved to RunStore. Harness provides
-  // a runStore field with spies so assertions like
-  // `expect(service.runStore.appendEvent).toHaveBeenCalled(...)` work.
   service.runStore = {
     appendEvent: vi.fn(),
     updateRun: vi.fn((_runId: string, patch: Partial<ExecutionRunRecord>) => ({
@@ -118,9 +166,6 @@ function makeService(params: {
     getRun: (runId: string) => (params.run && params.run.run_id === runId ? params.run : null),
     writeSummary: vi.fn(),
   };
-  // Phase 4b (#231): runGhIn / runGitIn / listChangedFiles live on
-  // WorktreeService. The harness provides a worktreeService field with
-  // all three stubbed.
   service.worktreeService = {
     runGhIn: vi.fn(() => {
       throw new Error("runGhIn should not be called when guard rejects");
@@ -137,6 +182,29 @@ function makeService(params: {
       return "";
     }),
     listChangedFiles: vi.fn(() => params.changedFiles ?? []),
+  };
+  // Phase 4c (#232): the thin-wrapper stubs for the commit-guard methods
+  // that ExecutionService now calls via `this.scratchpadService.X(...)`.
+  // Each stub returns the fixture list the test parameterized or honors
+  // the parser-driven default (derive from gitResponses + basename check).
+  const derivedStagedViolations = params.stagedViolations
+    ?? (gitResponses["diff --cached --name-only"] ?? "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && isScratchpadPath(line));
+  const derivedCommittedViolations = params.committedViolations
+    ?? (() => {
+      const key = Object.keys(gitResponses).find((k) => k.startsWith("diff --name-only "));
+      if (!key) return [];
+      return gitResponses[key]
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0 && isScratchpadPath(line));
+    })();
+  service.scratchpadService = {
+    findStagedScratchpadViolations: vi.fn(() => derivedStagedViolations),
+    findCommittedScratchpadViolations: vi.fn(() => derivedCommittedViolations),
+    isScratchpadPath: vi.fn(isScratchpadPath),
   };
   service.buildPullRequestTitle = () => "title";
   service.buildPullRequestBody = () => "body";
@@ -156,8 +224,8 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  describe("isScratchpadPath", () => {
-    const service = Object.create(ExecutionService.prototype) as HarnessService;
+  describe("ScratchpadService.isScratchpadPath", () => {
+    const service = Object.create(ScratchpadService.prototype) as ScratchpadHarness;
 
     it("matches SCRATCHPAD_<slug>.md at worktree root", () => {
       expect(service.isScratchpadPath("SCRATCHPAD_studio_156.md")).toBe(true);
@@ -176,78 +244,64 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     });
   });
 
-  describe("findStagedScratchpadViolations", () => {
+  describe("ScratchpadService.findStagedScratchpadViolations", () => {
     it("returns [] when the index is clean", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --cached --name-only": "",
-        },
+      const service = makeScratchpadHarness({
+        "diff --cached --name-only": "",
       });
       expect(service.findStagedScratchpadViolations(worktree)).toEqual([]);
     });
 
     it("returns [] when only non-scratchpad files are staged", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --cached --name-only": "src.ts\nREADME.md\n",
-        },
+      const service = makeScratchpadHarness({
+        "diff --cached --name-only": "src.ts\nREADME.md\n",
       });
       expect(service.findStagedScratchpadViolations(worktree)).toEqual([]);
     });
 
     it("detects a staged SCRATCHPAD_*.md at the root", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --cached --name-only": "SCRATCHPAD_studio_156.md\n",
-        },
+      const service = makeScratchpadHarness({
+        "diff --cached --name-only": "SCRATCHPAD_studio_156.md\n",
       });
       expect(service.findStagedScratchpadViolations(worktree)).toEqual(["SCRATCHPAD_studio_156.md"]);
     });
 
     it("detects a staged SCRATCHPAD_*.md at a nested path", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --cached --name-only": "docs/plans/SCRATCHPAD_x.md\nsrc.ts\n",
-        },
+      const service = makeScratchpadHarness({
+        "diff --cached --name-only": "docs/plans/SCRATCHPAD_x.md\nsrc.ts\n",
       });
       expect(service.findStagedScratchpadViolations(worktree)).toEqual(["docs/plans/SCRATCHPAD_x.md"]);
     });
   });
 
-  describe("findCommittedScratchpadViolations", () => {
+  describe("ScratchpadService.findCommittedScratchpadViolations", () => {
     it("returns [] when the branch is clean relative to base", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --name-only main...HEAD": "",
-        },
+      const service = makeScratchpadHarness({
+        "diff --name-only main...HEAD": "",
       });
       expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual([]);
     });
 
     it("returns [] when only non-scratchpad files were committed", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --name-only main...HEAD": "src.ts\nREADME.md\n",
-        },
+      const service = makeScratchpadHarness({
+        "diff --name-only main...HEAD": "src.ts\nREADME.md\n",
       });
       expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual([]);
     });
 
     it("detects a scratchpad committed to the branch", () => {
-      const service = makeService({
-        gitResponses: {
-          "diff --name-only main...HEAD": "SCRATCHPAD_studio_156.md\nsrc.ts\n",
-        },
+      const service = makeScratchpadHarness({
+        "diff --name-only main...HEAD": "SCRATCHPAD_studio_156.md\nsrc.ts\n",
       });
       expect(service.findCommittedScratchpadViolations(worktree, "main")).toEqual(["SCRATCHPAD_studio_156.md"]);
     });
   });
 
-  describe("autoStageAndCommit", () => {
+  describe("ExecutionService.autoStageAndCommit", () => {
     it("commits normally when no scratchpad is staged", () => {
       const run = makeRun({ worktree_path: worktree });
       const workItem = makeWorkItem();
-      const service = makeService({
+      const service = makeExecutionHarness({
         run,
         workItem,
         gitResponses: {
@@ -270,7 +324,7 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     it("is a no-op when the worktree is clean", () => {
       const run = makeRun({ worktree_path: worktree });
       const workItem = makeWorkItem();
-      const service = makeService({
+      const service = makeExecutionHarness({
         run,
         workItem,
         gitResponses: {
@@ -287,7 +341,7 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     it("throws and emits an event when a scratchpad is staged (does not create a commit)", () => {
       const run = makeRun({ worktree_path: worktree });
       const workItem = makeWorkItem();
-      const service = makeService({
+      const service = makeExecutionHarness({
         run,
         workItem,
         gitResponses: {
@@ -311,11 +365,11 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     });
   });
 
-  describe("createPullRequest guards", () => {
+  describe("ExecutionService.createPullRequest guards", () => {
     it("rejects with phase=pull_request when the index contains a scratchpad (auto_commit: false)", async () => {
       const run = makeRun({ worktree_path: worktree });
       const workItem = makeWorkItem();
-      const service = makeService({
+      const service = makeExecutionHarness({
         run,
         workItem,
         gitResponses: {
@@ -346,7 +400,7 @@ describe("ADR 014 step 6: scratchpad commit guards", () => {
     it("rejects with phase=pull_request_history when the branch has a committed scratchpad", async () => {
       const run = makeRun({ worktree_path: worktree });
       const workItem = makeWorkItem();
-      const service = makeService({
+      const service = makeExecutionHarness({
         run,
         workItem,
         gitResponses: {

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -17,6 +17,7 @@ import { ExecutionService } from "./execution.service.js";
 import { HsmActionHandlers } from "./hsm-action-handlers.js";
 import { RunDispositionService } from "./run-disposition.service.js";
 import { RunStore } from "./run-store.service.js";
+import { ScratchpadService } from "./scratchpad.service.js";
 import { WorkItemReconcilerController } from "./work-item-reconciler.controller.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
@@ -31,6 +32,7 @@ import { WorktreeService } from "./worktree.service.js";
     HsmActionHandlers,
     RunDispositionService,
     RunStore,
+    ScratchpadService,
     WorktreeService,
     WorkItemReconcilerService,
     CancelWorkItemHandler,
@@ -46,6 +48,7 @@ import { WorktreeService } from "./worktree.service.js";
     GitHubCacheScheduler,
     RunDispositionService,
     RunStore,
+    ScratchpadService,
     WorktreeService,
     WorkItemReconcilerService,
   ],

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -4,8 +4,6 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
 import {
-  canonicalScratchpadPath,
-  ensurePlanDir,
   readPlanMetadata,
   runDir,
   workItemSlug,
@@ -16,6 +14,7 @@ import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-w
 import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { RunStore } from "./run-store.service.js";
+import { ScratchpadService } from "./scratchpad.service.js";
 import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
 import { GitHubService } from "../github/github.service.js";
@@ -28,7 +27,6 @@ import type {
   ActivityLogEntry,
   ActivityLogEntryKind,
   ArchivedRunBundle,
-  ChecklistItem,
   CreateExecutionPullRequestDto,
   CreateExecutionPullRequestResult,
   ExecutionChecklistSnapshot,
@@ -62,8 +60,6 @@ export class ExecutionService implements OnModuleInit {
   // Chat history derived from activity_log (agent_message + user_message entries)
   /** Disambiguation gate resolvers — calling the stored function unblocks the coding phase */
   private readonly disambiguationGates = new Map<string, { resolve: (additionalContext?: string) => void }>();
-  /** Last-emitted checklist snapshots per run — used for dedup */
-  private readonly lastChecklistSnapshots = new Map<string, string>();
 
   constructor(
     @Inject(GraphService) private readonly graphService: GraphService,
@@ -74,6 +70,7 @@ export class ExecutionService implements OnModuleInit {
     @Inject(SettingsService) private readonly settingsService: SettingsService,
     @Inject(WorkItemReconcilerService) private readonly workItemReconciler: WorkItemReconcilerService,
     @Inject(RunStore) private readonly runStore: RunStore,
+    @Inject(ScratchpadService) private readonly scratchpadService: ScratchpadService,
     @Inject(WorktreeService) private readonly worktreeService: WorktreeService,
   ) {
     this.githubService.registerPullRequestTruthRefresher((pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options));
@@ -373,7 +370,7 @@ export class ExecutionService implements OnModuleInit {
     // auto_commit: false (the auto-commit guard is inside an optional
     // branch) and they cover both the current staged state and the
     // branch's full committed history relative to the base ref.
-    const prStagedViolations = this.findStagedScratchpadViolations(run.worktree_path);
+    const prStagedViolations = this.scratchpadService.findStagedScratchpadViolations(run.worktree_path);
     if (prStagedViolations.length > 0) {
       this.runStore.appendEvent(run, {
         type: "scratchpad_commit_blocked",
@@ -386,7 +383,7 @@ export class ExecutionService implements OnModuleInit {
       );
     }
 
-    const committedViolations = this.findCommittedScratchpadViolations(run.worktree_path, baseRef);
+    const committedViolations = this.scratchpadService.findCommittedScratchpadViolations(run.worktree_path, baseRef);
     if (committedViolations.length > 0) {
       this.runStore.appendEvent(run, {
         type: "scratchpad_commit_blocked",
@@ -689,7 +686,7 @@ export class ExecutionService implements OnModuleInit {
     // the canonical scratchpad is the executable contract — copied into the
     // worktree verbatim and the setup-phase agent turn is skipped below.
     // Otherwise (fallback for `planned` items) a skeleton is synthesized.
-    const scratchpadResult = this.writeScratchpad(run, node);
+    const scratchpadResult = this.scratchpadService.writeScratchpad(run, node);
     const scratchpadPath = scratchpadResult.path;
     const hasApprovedPlan = scratchpadResult.source === "canonical_ready";
     this.pushActivity(
@@ -700,7 +697,7 @@ export class ExecutionService implements OnModuleInit {
         : `Scratchpad written to ${scratchpadPath}`,
     );
     this.runStore.appendEvent(run, { type: "scratchpad_written", path: scratchpadPath });
-    this.emitChecklistIfChanged(run);
+    this.scratchpadService.emitChecklistIfChanged(run);
 
     // --- Create agent session ---
     const { session, modelFallbackMessage } = await createAgentSession({
@@ -761,7 +758,7 @@ export class ExecutionService implements OnModuleInit {
           };
           try {
             const scratchpadContent = readFileSync(scratchpadPath, "utf8");
-            openItems = this.parseScratchpadOpenItems(scratchpadContent);
+            openItems = this.scratchpadService.parseScratchpadOpenItems(scratchpadContent);
           } catch (error) {
             this.logger.warn(
               `executeRun: failed to read approved scratchpad at ${scratchpadPath} ` +
@@ -803,8 +800,8 @@ export class ExecutionService implements OnModuleInit {
               await session.prompt(
                 `The approved plan for ${run.work_item_id} (${run.work_item_name}) had open items that the user just resolved with this additional context:\n\n${additionalContext}\n\nRead ${scratchpadName} in the current worktree, update the "### Clarifications Needed" and "## Blockers" sections to reflect the resolution, and make any other edits implied by the user's feedback. Then confirm you're ready to start coding.`,
               );
-              this.syncScratchpadToCanonical(run);
-              this.emitChecklistIfChanged(run);
+              this.scratchpadService.syncScratchpadToCanonical(run);
+              this.scratchpadService.emitChecklistIfChanged(run);
             }
 
             run = this.runStore.updateRun(runId, {
@@ -830,10 +827,10 @@ export class ExecutionService implements OnModuleInit {
 
         // Sync the agent's scratchpad edits back to the canonical plan file
         // (end of setup phase, before the approval gate).
-        this.syncScratchpadToCanonical(run);
+        this.scratchpadService.syncScratchpadToCanonical(run);
 
         // Setup prompt finished — now switch to disambiguating so the UI shows the approval gate
-        this.emitChecklistIfChanged(run);
+        this.scratchpadService.emitChecklistIfChanged(run);
         run = this.runStore.updateRun(runId, {
           status: "disambiguating",
           progress_message: "Setup complete. Review the implementation plan and approve to start coding.",
@@ -852,8 +849,8 @@ export class ExecutionService implements OnModuleInit {
           await session.prompt(
             `The user provided feedback on your plan:\n\n${additionalContext}\n\nUpdate the ${scratchpadName} implementation plan accordingly, then confirm you're ready to start coding.`
           );
-          this.syncScratchpadToCanonical(run);
-          this.emitChecklistIfChanged(run);
+          this.scratchpadService.syncScratchpadToCanonical(run);
+          this.scratchpadService.emitChecklistIfChanged(run);
         }
 
         run = this.runStore.updateRun(runId, {
@@ -874,9 +871,9 @@ export class ExecutionService implements OnModuleInit {
 
       // Sync the agent's final scratchpad state back to canonical
       // (end of do-work phase).
-      this.syncScratchpadToCanonical(run);
+      this.scratchpadService.syncScratchpadToCanonical(run);
 
-      this.emitChecklistIfChanged(run);
+      this.scratchpadService.emitChecklistIfChanged(run);
     } finally {
       unsubscribe();
       this.disambiguationGates.delete(run.run_id);
@@ -934,13 +931,7 @@ export class ExecutionService implements OnModuleInit {
     if (!run) {
       return { run_id: runId, items: [], completed: 0, total: 0 };
     }
-    const items = this.readChecklistFromWorktree(run);
-    return {
-      run_id: runId,
-      items,
-      completed: items.filter((i) => i.checked).length,
-      total: items.length,
-    };
+    return this.scratchpadService.getRunChecklist(run);
   }
 
   getRunScratchpad(runId: string): { run_id: string; content: string | null } {
@@ -948,21 +939,7 @@ export class ExecutionService implements OnModuleInit {
     if (!run) {
       return { run_id: runId, content: null };
     }
-
-    // Prefer the canonical plan file (source of truth, synced at each phase boundary)
-    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
-    if (existsSync(canonicalPath)) {
-      return { run_id: runId, content: readFileSync(canonicalPath, "utf8") };
-    }
-
-    // Fall back to the live worktree copy (active run before first sync-back)
-    const slug = workItemSlug(run.work_item_id);
-    const worktreePath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
-    if (existsSync(worktreePath)) {
-      return { run_id: runId, content: readFileSync(worktreePath, "utf8") };
-    }
-
-    return { run_id: runId, content: null };
+    return this.scratchpadService.getRunScratchpad(run);
   }
 
   listArchivedRunBundles(): ArchivedRunBundle[] {
@@ -1085,8 +1062,8 @@ export class ExecutionService implements OnModuleInit {
       await session.prompt(message);
       // ADR 014 step 5: sync the agent's scratchpad edits back to canonical
       // at follow-up turn completion (phase boundary).
-      this.syncScratchpadToCanonical(run);
-      this.emitChecklistIfChanged(run);
+      this.scratchpadService.syncScratchpadToCanonical(run);
+      this.scratchpadService.emitChecklistIfChanged(run);
     } finally {
       unsubscribe();
       this.activeSessions.delete(run.run_id);
@@ -1134,7 +1111,7 @@ export class ExecutionService implements OnModuleInit {
       this.runStore.appendEvent(run, { type: event.type, tool_name: toolName });
       this.pushActivity(runId, "tool_end", `Tool finished: ${toolName ?? "unknown"}`);
       this.runStore.updateRun(runId, { progress_message: `${toolName ?? "tool"} finished.` });
-      this.emitChecklistIfChanged(run);
+      this.scratchpadService.emitChecklistIfChanged(run);
       return;
     }
 
@@ -1161,64 +1138,6 @@ export class ExecutionService implements OnModuleInit {
       this.pushActivity(runId, "turn_end", "Execution turn completed.");
       this.runStore.updateRun(runId, { progress_message: "Execution turn completed." });
     }
-  }
-
-  /**
-   * Parse checklist items from the ## Implementation Plan section of a scratchpad.
-   * Only matches `- [ ]` and `- [x]` lines within that section.
-   */
-  parseImplementationPlanChecklist(content: string): ChecklistItem[] {
-    const lines = content.split("\n");
-    const items: ChecklistItem[] = [];
-    let inSection = false;
-
-    for (const line of lines) {
-      // Detect heading boundaries
-      if (/^##\s/.test(line)) {
-        inSection = /^##\s+Implementation Plan/i.test(line);
-        continue;
-      }
-      if (inSection) {
-        const match = line.match(/^\s*-\s+\[([\sxX])\]\s+(.+)$/);
-        if (match) {
-          items.push({
-            checked: match[1].toLowerCase() === "x",
-            text: match[2].trim(),
-          });
-        }
-      }
-    }
-    return items;
-  }
-
-  private readChecklistFromWorktree(run: ExecutionRunRecord): ChecklistItem[] {
-    const slug = workItemSlug(run.work_item_id);
-    const scratchpadPath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
-    if (!existsSync(scratchpadPath)) {
-      return [];
-    }
-    try {
-      const content = readFileSync(scratchpadPath, "utf8");
-      return this.parseImplementationPlanChecklist(content);
-    } catch {
-      return [];
-    }
-  }
-
-  private emitChecklistIfChanged(run: ExecutionRunRecord): void {
-    const items = this.readChecklistFromWorktree(run);
-    const snapshot: ExecutionChecklistSnapshot = {
-      run_id: run.run_id,
-      items,
-      completed: items.filter((i) => i.checked).length,
-      total: items.length,
-    };
-    const key = JSON.stringify(snapshot.items);
-    if (this.lastChecklistSnapshots.get(run.run_id) === key) {
-      return; // No change
-    }
-    this.lastChecklistSnapshots.set(run.run_id, key);
-    this.runStore.emitEvent("execution_checklist", run.run_id, snapshot);
   }
 
   private pushActivity(runId: string, kind: ActivityLogEntryKind, message: string, detail?: string) {
@@ -1483,83 +1402,6 @@ export class ExecutionService implements OnModuleInit {
     return `Execute work item ${workItem.id}: ${workItem.name}`;
   }
 
-  /** Build a structured scratchpad markdown document for the execution worktree. */
-  buildScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
-    const owned = node.files_owned.length
-      ? node.files_owned.map((path) => `- ${path}`).join("\n")
-      : "- (none predicted)";
-    const shared = node.files_shared.length
-      ? node.files_shared.map((file) => `- ${file.path} (${file.assessment}/${file.confidence})`).join("\n")
-      : "- (none)";
-    const forbidden = node.files_forbidden.length
-      ? node.files_forbidden.map((path) => `- ${path}`).join("\n")
-      : "- (none)";
-
-    return [
-      `# Scratchpad: ${run.work_item_id} — ${run.work_item_name}`,
-      "",
-      "## Context",
-      `- **Repo:** ${run.repo ?? "(not set)"}`,
-      `- **Issue:** ${run.issue_url ?? "(not linked)"}`,
-      `- **Branch:** ${run.branch}`,
-      `- **Base ref:** ${run.base_ref}`,
-      `- **Scope hint:** ${node.scope_hint ?? "(not set)"}`,
-      `- **Created:** ${run.created_at}`,
-      "",
-      "## File Ownership",
-      "",
-      "### Owned",
-      owned,
-      "",
-      "### Shared",
-      shared,
-      "",
-      "### Forbidden",
-      forbidden,
-      "",
-      "## Acceptance Criteria",
-      "<!-- Fill in from the issue body during setup phase -->",
-      "",
-      "- [ ] (to be filled by setup phase)",
-      "",
-      "## Implementation Plan",
-      "<!-- The setup phase agent will replace these with specific, concrete tasks -->",
-      "",
-      "- [ ] Analyze scope and identify changes needed",
-      "- [ ] Implement changes",
-      "- [ ] Run tests / verify",
-      "- [ ] Summarize results",
-      "",
-      "## Affected Files",
-      "<!-- List specific files that will be modified, with what changes -->",
-      "",
-      "## Quality Checks",
-      "- [ ] TypeScript compilation passes (`npm run check`)",
-      "- [ ] Tests pass (`npm test`)",
-      "- [ ] Build succeeds (`npm run build:web`)",
-      "",
-      "## Questions / Concerns",
-      "<!-- Surface any ambiguities during setup — resolve with user before coding -->",
-      "",
-      "## Work Log",
-      "",
-      `### ${new Date().toISOString().slice(0, 10)} - Setup`,
-      "- Scratchpad created by Studio execution service",
-      `- Branch: ${run.branch}`,
-      "",
-      "## Blockers",
-      "",
-    ].join("\n");
-  }
-
-  /**
-   * Sync the agent's worktree scratchpad back to the canonical plan file.
-   *
-   * Called at each phase boundary in executeRun. If the worktree copy is
-   * missing (e.g. the agent deleted it), logs a warning and leaves the
-   * canonical file unchanged — the canonical retains its last-known-good
-   * state.
-   */
   /**
    * ADR 014 step 5: record a run ID on the plan metadata.
    *
@@ -1588,136 +1430,6 @@ export class ExecutionService implements OnModuleInit {
           this.getErrorMessage(error),
       );
     }
-  }
-
-  /**
-   * Parse a scratchpad's `### Clarifications Needed` and `## Blockers`
-   * sections into string arrays of open items.
-   *
-   * Contract: matches the shape written by `PlansService.prepare`
-   * (plans.service.ts ~lines 383–415) — flat top-level `- ` bullets,
-   * or a single `_(none)_` sentinel when the drafter surfaced no items.
-   *
-   * Behavior:
-   *   - Scans line-by-line for the two headings.
-   *   - Collects lines starting with `- ` as bullet items until the next
-   *     `#`-prefixed heading line (any level — keeps the parser simple
-   *     and matches the flat structure the drafter emits).
-   *   - Filters out blank lines and the `_(none)_` sentinel so an empty
-   *     section reads as an empty array.
-   *   - Missing heading → empty array for that section.
-   *
-   * Used by `executeRun` when an approved plan is loaded to decide
-   * whether the disambiguation gate should fire before coding starts.
-   */
-  private parseScratchpadOpenItems(content: string): {
-    questions: string[];
-    blockers: string[];
-  } {
-    const lines = content.split(/\r?\n/);
-    const collect = (headingMatch: (line: string) => boolean): string[] => {
-      const items: string[] = [];
-      let i = 0;
-      while (i < lines.length) {
-        if (headingMatch(lines[i])) {
-          i += 1;
-          while (i < lines.length) {
-            const line = lines[i];
-            if (/^\s*#/.test(line)) break;
-            const trimmed = line.trim();
-            if (trimmed.startsWith("- ")) {
-              const body = trimmed.slice(2).trim();
-              if (body && body !== "_(none)_") {
-                items.push(body);
-              }
-            }
-            i += 1;
-          }
-          break;
-        }
-        i += 1;
-      }
-      return items;
-    };
-    const questions = collect((line) => /^\s*###\s+Clarifications Needed\s*$/.test(line));
-    const blockers = collect((line) => /^\s*##\s+Blockers\s*$/.test(line));
-    return { questions, blockers };
-  }
-
-  private syncScratchpadToCanonical(run: ExecutionRunRecord): void {
-    const slug = workItemSlug(run.work_item_id);
-    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
-    const canonical = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
-    if (!existsSync(worktreeScratchpad)) {
-      this.logger.warn(
-        `syncScratchpadToCanonical: worktree scratchpad missing for run ${run.run_id} ` +
-          `at ${worktreeScratchpad}; canonical left unchanged.`,
-      );
-      return;
-    }
-    writeFileSync(canonical, readFileSync(worktreeScratchpad, "utf8"), "utf8");
-  }
-
-  /**
-   * Seed the worktree scratchpad from the canonical plan file.
-   *
-   * ADR 014 step 2/4/5: the canonical scratchpad lives at
-   * `plans/<slug>/SCRATCHPAD_<slug>.md` and is the source of truth.
-   *
-   * After ADR 014 step 4 lands, a work item that reached `ready` state via
-   * `PlansService.approve` already has an approved canonical scratchpad —
-   * no skeleton synthesis happens here and the setup-phase agent turn is
-   * skipped upstream (caller uses the returned `source` field).
-   *
-   * The fallback path (no plan metadata or plan state is null/drafting, for
-   * `planned` items under the step 5 transitional gate) still generates a
-   * skeleton via `buildScratchpad` and writes it to canonical. This path
-   * goes away when every launch goes through prepare→approve.
-   *
-   * Returns `{ path, source }`:
-   *   - `canonical_ready`    — plan was approved, content came from canonical
-   *   - `carried_forward`    — canonical existed but plan state was not `ready`
-   *                            (e.g. legacy plan dir with no metadata state)
-   *   - `synthesized`        — no canonical file existed; skeleton generated
-   */
-  private writeScratchpad(
-    run: ExecutionRunRecord,
-    node: ExecutionDispatchNodePreview,
-  ): { path: string; source: "canonical_ready" | "carried_forward" | "synthesized" } {
-    ensurePlanDir(this.artifactRoot, run.work_item_id);
-    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
-    const metadata = readPlanMetadata(this.artifactRoot, run.work_item_id);
-
-    let content: string;
-    let source: "canonical_ready" | "carried_forward" | "synthesized";
-
-    if (metadata?.state === "ready") {
-      // Step 5 happy path: an approved plan must have a canonical scratchpad.
-      if (!existsSync(canonicalPath)) {
-        throw new BadRequestException(
-          `ready_plan_scratchpad_missing: work item ${run.work_item_id} is marked ready ` +
-            `but canonical scratchpad is missing at ${canonicalPath}`,
-        );
-      }
-      content = readFileSync(canonicalPath, "utf8");
-      source = "canonical_ready";
-    } else if (existsSync(canonicalPath)) {
-      // Legacy / fallback: canonical exists but plan is not in `ready` state.
-      // Carry the existing plan forward — edits from prior runs survive.
-      content = readFileSync(canonicalPath, "utf8");
-      source = "carried_forward";
-    } else {
-      // Fallback: first run for this work item, no canonical exists.
-      // Generate a skeleton and persist to canonical.
-      content = this.buildScratchpad(run, node);
-      writeFileSync(canonicalPath, content, "utf8");
-      source = "synthesized";
-    }
-
-    const slug = workItemSlug(run.work_item_id);
-    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
-    writeFileSync(worktreeScratchpad, content, "utf8");
-    return { path: worktreeScratchpad, source };
   }
 
   createHsmRunRecord(workItem: WorkItemRecord, options: {
@@ -1867,7 +1579,7 @@ export class ExecutionService implements OnModuleInit {
 
     // ADR 014 step 6: hard guard against committing `SCRATCHPAD_*.md`.
     // Replaces the silent `.gitignore` trick — disobedience is now visible.
-    const stagedViolations = this.findStagedScratchpadViolations(run.worktree_path);
+    const stagedViolations = this.scratchpadService.findStagedScratchpadViolations(run.worktree_path);
     if (stagedViolations.length > 0) {
       this.runStore.appendEvent(run, {
         type: "scratchpad_commit_blocked",
@@ -1888,42 +1600,6 @@ export class ExecutionService implements OnModuleInit {
     if (changedFiles.length > 0) {
       this.runStore.updateRun(run.run_id, { changed_files: changedFiles });
     }
-  }
-
-  /**
-   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files in the git index.
-   *
-   * Basename match at any path depth. Returns an empty array when the
-   * index is clean. Callers use the list both for the rejection error
-   * message and for the `scratchpad_commit_blocked` event payload.
-   */
-  private findStagedScratchpadViolations(worktreePath: string): string[] {
-    const output = this.worktreeService.runGitIn(worktreePath, ["diff", "--cached", "--name-only"], { allowFailure: true });
-    return output
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
-  }
-
-  /**
-   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files introduced by this
-   * branch relative to its base ref.
-   *
-   * Uses three-dot `$base...HEAD` (merge-base relative) so files that
-   * changed on the base branch are not spuriously flagged. This matches
-   * what GitHub shows in a pull-request diff.
-   */
-  private findCommittedScratchpadViolations(worktreePath: string, baseRef: string): string[] {
-    const output = this.worktreeService.runGitIn(worktreePath, ["diff", "--name-only", `${baseRef}...HEAD`], { allowFailure: true });
-    return output
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
-  }
-
-  /** Basename match for `SCRATCHPAD_*.md` at any path depth. */
-  private isScratchpadPath(path: string): boolean {
-    return /(?:^|\/)SCRATCHPAD_[^/]*\.md$/.test(path);
   }
 
   private buildCommitMessage(workItem: WorkItemRecord): string {

--- a/src/modules/execution/scratchpad.service.ts
+++ b/src/modules/execution/scratchpad.service.ts
@@ -1,0 +1,385 @@
+import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { getConfig } from "../../config.js";
+import {
+  canonicalScratchpadPath,
+  ensurePlanDir,
+  readPlanMetadata,
+  workItemSlug,
+} from "../../lib/context-layout.js";
+import { RunStore } from "./run-store.service.js";
+import { WorktreeService } from "./worktree.service.js";
+import type {
+  ChecklistItem,
+  ExecutionChecklistSnapshot,
+  ExecutionDispatchNodePreview,
+  ExecutionRunRecord,
+} from "./types.js";
+
+/**
+ * Phase 4c of the cqrs refactor (#232): owns canonical scratchpad
+ * management, the ADR-014 phase-boundary sync dance, the
+ * `SCRATCHPAD_*.md` commit guards, and the implementation-plan
+ * checklist parser. Extracted verbatim from ExecutionService.
+ *
+ * Injects both WorktreeService (for `runGitIn` in the commit guards)
+ * and RunStore (for `emitEvent` in the checklist SSE push). First
+ * Phase 4 sub-service with inter-sibling dependencies; neither
+ * dependency is circular so no forwardRef is required.
+ *
+ * HTTP getters (`getRunChecklist` / `getRunScratchpad`) take an
+ * `ExecutionRunRecord` directly rather than doing their own lookup;
+ * ExecutionService is the orchestrator that resolves the run via
+ * RunStore before delegating, matching the Phase 4b `cleanupWorktree`
+ * passthrough pattern.
+ */
+@Injectable()
+export class ScratchpadService {
+  private readonly logger = new Logger(ScratchpadService.name);
+  private readonly artifactRoot = resolve(getConfig().artifactRoot);
+  /** Last-emitted checklist snapshots per run — used for dedup */
+  private readonly lastChecklistSnapshots = new Map<string, string>();
+
+  constructor(
+    @Inject(RunStore) private readonly runStore: RunStore,
+    @Inject(WorktreeService) private readonly worktreeService: WorktreeService,
+  ) {}
+
+  // ─── HTTP getter helpers ──────────────────────────────────────────
+
+  getRunChecklist(run: ExecutionRunRecord): ExecutionChecklistSnapshot {
+    const items = this.readChecklistFromWorktree(run);
+    return {
+      run_id: run.run_id,
+      items,
+      completed: items.filter((i) => i.checked).length,
+      total: items.length,
+    };
+  }
+
+  getRunScratchpad(run: ExecutionRunRecord): { run_id: string; content: string | null } {
+    // Prefer the canonical plan file (source of truth, synced at each phase boundary)
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+    if (existsSync(canonicalPath)) {
+      return { run_id: run.run_id, content: readFileSync(canonicalPath, "utf8") };
+    }
+
+    // Fall back to the live worktree copy (active run before first sync-back)
+    const slug = workItemSlug(run.work_item_id);
+    const worktreePath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    if (existsSync(worktreePath)) {
+      return { run_id: run.run_id, content: readFileSync(worktreePath, "utf8") };
+    }
+
+    return { run_id: run.run_id, content: null };
+  }
+
+  // ─── Checklist parsing + SSE push ─────────────────────────────────
+
+  /**
+   * Parse checklist items from the ## Implementation Plan section of a scratchpad.
+   * Only matches `- [ ]` and `- [x]` lines within that section.
+   */
+  parseImplementationPlanChecklist(content: string): ChecklistItem[] {
+    const lines = content.split("\n");
+    const items: ChecklistItem[] = [];
+    let inSection = false;
+
+    for (const line of lines) {
+      // Detect heading boundaries
+      if (/^##\s/.test(line)) {
+        inSection = /^##\s+Implementation Plan/i.test(line);
+        continue;
+      }
+      if (inSection) {
+        const match = line.match(/^\s*-\s+\[([\sxX])\]\s+(.+)$/);
+        if (match) {
+          items.push({
+            checked: match[1].toLowerCase() === "x",
+            text: match[2].trim(),
+          });
+        }
+      }
+    }
+    return items;
+  }
+
+  readChecklistFromWorktree(run: ExecutionRunRecord): ChecklistItem[] {
+    const slug = workItemSlug(run.work_item_id);
+    const scratchpadPath = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    if (!existsSync(scratchpadPath)) {
+      return [];
+    }
+    try {
+      const content = readFileSync(scratchpadPath, "utf8");
+      return this.parseImplementationPlanChecklist(content);
+    } catch {
+      return [];
+    }
+  }
+
+  emitChecklistIfChanged(run: ExecutionRunRecord): void {
+    const items = this.readChecklistFromWorktree(run);
+    const snapshot: ExecutionChecklistSnapshot = {
+      run_id: run.run_id,
+      items,
+      completed: items.filter((i) => i.checked).length,
+      total: items.length,
+    };
+    const key = JSON.stringify(snapshot.items);
+    if (this.lastChecklistSnapshots.get(run.run_id) === key) {
+      return; // No change
+    }
+    this.lastChecklistSnapshots.set(run.run_id, key);
+    this.runStore.emitEvent("execution_checklist", run.run_id, snapshot);
+  }
+
+  // ─── Scratchpad rendering + canonical sync ────────────────────────
+
+  /** Build a structured scratchpad markdown document for the execution worktree. */
+  buildScratchpad(run: ExecutionRunRecord, node: ExecutionDispatchNodePreview): string {
+    const owned = node.files_owned.length
+      ? node.files_owned.map((path) => `- ${path}`).join("\n")
+      : "- (none predicted)";
+    const shared = node.files_shared.length
+      ? node.files_shared.map((file) => `- ${file.path} (${file.assessment}/${file.confidence})`).join("\n")
+      : "- (none)";
+    const forbidden = node.files_forbidden.length
+      ? node.files_forbidden.map((path) => `- ${path}`).join("\n")
+      : "- (none)";
+
+    return [
+      `# Scratchpad: ${run.work_item_id} — ${run.work_item_name}`,
+      "",
+      "## Context",
+      `- **Repo:** ${run.repo ?? "(not set)"}`,
+      `- **Issue:** ${run.issue_url ?? "(not linked)"}`,
+      `- **Branch:** ${run.branch}`,
+      `- **Base ref:** ${run.base_ref}`,
+      `- **Scope hint:** ${node.scope_hint ?? "(not set)"}`,
+      `- **Created:** ${run.created_at}`,
+      "",
+      "## File Ownership",
+      "",
+      "### Owned",
+      owned,
+      "",
+      "### Shared",
+      shared,
+      "",
+      "### Forbidden",
+      forbidden,
+      "",
+      "## Acceptance Criteria",
+      "<!-- Fill in from the issue body during setup phase -->",
+      "",
+      "- [ ] (to be filled by setup phase)",
+      "",
+      "## Implementation Plan",
+      "<!-- The setup phase agent will replace these with specific, concrete tasks -->",
+      "",
+      "- [ ] Analyze scope and identify changes needed",
+      "- [ ] Implement changes",
+      "- [ ] Run tests / verify",
+      "- [ ] Summarize results",
+      "",
+      "## Affected Files",
+      "<!-- List specific files that will be modified, with what changes -->",
+      "",
+      "## Quality Checks",
+      "- [ ] TypeScript compilation passes (`npm run check`)",
+      "- [ ] Tests pass (`npm test`)",
+      "- [ ] Build succeeds (`npm run build:web`)",
+      "",
+      "## Questions / Concerns",
+      "<!-- Surface any ambiguities during setup — resolve with user before coding -->",
+      "",
+      "## Work Log",
+      "",
+      `### ${new Date().toISOString().slice(0, 10)} - Setup`,
+      "- Scratchpad created by Studio execution service",
+      `- Branch: ${run.branch}`,
+      "",
+      "## Blockers",
+      "",
+    ].join("\n");
+  }
+
+  /**
+   * Parse a scratchpad's `### Clarifications Needed` and `## Blockers`
+   * sections into string arrays of open items.
+   *
+   * Contract: matches the shape written by `PlansService.prepare`
+   * (plans.service.ts ~lines 383–415) — flat top-level `- ` bullets,
+   * or a single `_(none)_` sentinel when the drafter surfaced no items.
+   *
+   * Behavior:
+   *   - Scans line-by-line for the two headings.
+   *   - Collects lines starting with `- ` as bullet items until the next
+   *     `#`-prefixed heading line (any level — keeps the parser simple
+   *     and matches the flat structure the drafter emits).
+   *   - Filters out blank lines and the `_(none)_` sentinel so an empty
+   *     section reads as an empty array.
+   *   - Missing heading → empty array for that section.
+   *
+   * Used by `executeRun` when an approved plan is loaded to decide
+   * whether the disambiguation gate should fire before coding starts.
+   */
+  parseScratchpadOpenItems(content: string): {
+    questions: string[];
+    blockers: string[];
+  } {
+    const lines = content.split(/\r?\n/);
+    const collect = (headingMatch: (line: string) => boolean): string[] => {
+      const items: string[] = [];
+      let i = 0;
+      while (i < lines.length) {
+        if (headingMatch(lines[i])) {
+          i += 1;
+          while (i < lines.length) {
+            const line = lines[i];
+            if (/^\s*#/.test(line)) break;
+            const trimmed = line.trim();
+            if (trimmed.startsWith("- ")) {
+              const body = trimmed.slice(2).trim();
+              if (body && body !== "_(none)_") {
+                items.push(body);
+              }
+            }
+            i += 1;
+          }
+          break;
+        }
+        i += 1;
+      }
+      return items;
+    };
+    const questions = collect((line) => /^\s*###\s+Clarifications Needed\s*$/.test(line));
+    const blockers = collect((line) => /^\s*##\s+Blockers\s*$/.test(line));
+    return { questions, blockers };
+  }
+
+  /**
+   * Sync the agent's worktree scratchpad back to the canonical plan file.
+   *
+   * Called at each phase boundary in executeRun. If the worktree copy is
+   * missing (e.g. the agent deleted it), logs a warning and leaves the
+   * canonical file unchanged — the canonical retains its last-known-good
+   * state.
+   */
+  syncScratchpadToCanonical(run: ExecutionRunRecord): void {
+    const slug = workItemSlug(run.work_item_id);
+    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    const canonical = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+    if (!existsSync(worktreeScratchpad)) {
+      this.logger.warn(
+        `syncScratchpadToCanonical: worktree scratchpad missing for run ${run.run_id} ` +
+          `at ${worktreeScratchpad}; canonical left unchanged.`,
+      );
+      return;
+    }
+    writeFileSync(canonical, readFileSync(worktreeScratchpad, "utf8"), "utf8");
+  }
+
+  /**
+   * Seed the worktree scratchpad from the canonical plan file.
+   *
+   * ADR 014 step 2/4/5: the canonical scratchpad lives at
+   * `plans/<slug>/SCRATCHPAD_<slug>.md` and is the source of truth.
+   *
+   * After ADR 014 step 4 lands, a work item that reached `ready` state via
+   * `PlansService.approve` already has an approved canonical scratchpad —
+   * no skeleton synthesis happens here and the setup-phase agent turn is
+   * skipped upstream (caller uses the returned `source` field).
+   *
+   * The fallback path (no plan metadata or plan state is null/drafting, for
+   * `planned` items under the step 5 transitional gate) still generates a
+   * skeleton via `buildScratchpad` and writes it to canonical. This path
+   * goes away when every launch goes through prepare→approve.
+   *
+   * Returns `{ path, source }`:
+   *   - `canonical_ready`    — plan was approved, content came from canonical
+   *   - `carried_forward`    — canonical existed but plan state was not `ready`
+   *                            (e.g. legacy plan dir with no metadata state)
+   *   - `synthesized`        — no canonical file existed; skeleton generated
+   */
+  writeScratchpad(
+    run: ExecutionRunRecord,
+    node: ExecutionDispatchNodePreview,
+  ): { path: string; source: "canonical_ready" | "carried_forward" | "synthesized" } {
+    ensurePlanDir(this.artifactRoot, run.work_item_id);
+    const canonicalPath = canonicalScratchpadPath(this.artifactRoot, run.work_item_id);
+    const metadata = readPlanMetadata(this.artifactRoot, run.work_item_id);
+
+    let content: string;
+    let source: "canonical_ready" | "carried_forward" | "synthesized";
+
+    if (metadata?.state === "ready") {
+      // Step 5 happy path: an approved plan must have a canonical scratchpad.
+      if (!existsSync(canonicalPath)) {
+        throw new BadRequestException(
+          `ready_plan_scratchpad_missing: work item ${run.work_item_id} is marked ready ` +
+            `but canonical scratchpad is missing at ${canonicalPath}`,
+        );
+      }
+      content = readFileSync(canonicalPath, "utf8");
+      source = "canonical_ready";
+    } else if (existsSync(canonicalPath)) {
+      // Legacy / fallback: canonical exists but plan is not in `ready` state.
+      // Carry the existing plan forward — edits from prior runs survive.
+      content = readFileSync(canonicalPath, "utf8");
+      source = "carried_forward";
+    } else {
+      // Fallback: first run for this work item, no canonical exists.
+      // Generate a skeleton and persist to canonical.
+      content = this.buildScratchpad(run, node);
+      writeFileSync(canonicalPath, content, "utf8");
+      source = "synthesized";
+    }
+
+    const slug = workItemSlug(run.work_item_id);
+    const worktreeScratchpad = join(run.worktree_path, `SCRATCHPAD_${slug}.md`);
+    writeFileSync(worktreeScratchpad, content, "utf8");
+    return { path: worktreeScratchpad, source };
+  }
+
+  // ─── Commit guards ────────────────────────────────────────────────
+
+  /**
+   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files currently staged in
+   * the worktree's index.
+   *
+   * Basename match at any path depth. Returns an empty array when the
+   * index is clean. Callers use the list both for the rejection error
+   * message and for the `scratchpad_commit_blocked` event payload.
+   */
+  findStagedScratchpadViolations(worktreePath: string): string[] {
+    const output = this.worktreeService.runGitIn(worktreePath, ["diff", "--cached", "--name-only"], { allowFailure: true });
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
+  }
+
+  /**
+   * ADR 014 step 6: detect `SCRATCHPAD_*.md` files introduced by this
+   * branch relative to its base ref.
+   *
+   * Uses three-dot `$base...HEAD` (merge-base relative) so files that
+   * changed on the base branch are not spuriously flagged. This matches
+   * what GitHub shows in a pull-request diff.
+   */
+  findCommittedScratchpadViolations(worktreePath: string, baseRef: string): string[] {
+    const output = this.worktreeService.runGitIn(worktreePath, ["diff", "--name-only", `${baseRef}...HEAD`], { allowFailure: true });
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && this.isScratchpadPath(line));
+  }
+
+  /** Basename match for `SCRATCHPAD_*.md` at any path depth. */
+  isScratchpadPath(path: string): boolean {
+    return /(?:^|\/)SCRATCHPAD_[^/]*\.md$/.test(path);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4c of the CQRS refactor (#232). Extracts the canonical scratchpad management cluster out of `ExecutionService` into a new `ScratchpadService`, completing the Phase 4 sub-service decomposition of the scratchpad / commit-guards / checklist SSE responsibilities.

- **New service:** `src/modules/execution/scratchpad.service.ts` (385 lines). Owns `buildScratchpad`, `writeScratchpad`, `syncScratchpadToCanonical`, `readChecklistFromWorktree`, `parseImplementationPlanChecklist`, `emitChecklistIfChanged`, `parseScratchpadOpenItems`, the ADR-014 step-6 commit guards (`findStagedScratchpadViolations` / `findCommittedScratchpadViolations` / `isScratchpadPath`), and the HTTP getter helpers `getRunChecklist(run)` / `getRunScratchpad(run)`. Owns the `lastChecklistSnapshots` dedup map.
- **First Phase 4 sibling with inter-deps:** injects both `RunStore` (for `emitEvent` in the `execution_checklist` SSE push) and `WorktreeService` (for `runGitIn` in the commit guards). Both are already exported from `ExecutionModule` after Phase 4a/4b, so standard Nest injection works — no `forwardRef` needed.
- **Thin orchestrator wrappers retained:** `getRunChecklist` / `getRunScratchpad` stay on `ExecutionService`, look up the run via `runStore.getRun(runId)`, and delegate to the service. Matches the Phase 4b `cleanupWorktree` passthrough pattern.
- **ExecutionService line drop:** 2207 → 1883 (-324 lines). Drops `lastChecklistSnapshots` field and the dead `canonicalScratchpadPath`, `ensurePlanDir`, `ChecklistItem` imports.
- **Test harness rewire (6 files):** the five scratchpad-adjacent test files plus `execution-rehydrate.test.ts` either retarget to `ScratchpadService.prototype` or grow a `scratchpadService` field on their `ExecutionService.prototype` harness. `scratchpad-commit-guards.test.ts` splits into two harnesses in one file per the approved plan — pure-guard tests on ScratchpadService + integration tests on ExecutionService with stubbed guard helpers.

## Changes

- \`4168238\` feat(execution): add ScratchpadService owning scratchpad management and commit guards
- \`faa5225\` refactor(execution): migrate scratchpad cluster to ScratchpadService
- \`edb842c\` test(execution): wire scratchpadService into rehydrate test harness

## Test plan

- [x] \`npm run check\` clean (tsc --noEmit)
- [x] \`npx vitest run --no-file-parallelism\` — 561/561 tests pass
- [x] \`npm run build:web\` clean
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\` → **8** (unchanged from develop)
- [x] \`wc -l src/modules/execution/execution.service.ts\` → **1883** (down from 2207)
- [ ] Server boots; \`GET /api/execution/runs/:id/checklist\` and \`GET /api/execution/runs/:id/scratchpad\` return live data

## Follow-ups

- Phase 4d (#233) — RunInteractionService (extract \`handleAgentMessage\` / disambiguation gate plumbing)
- Phase 4e (#234) — PullRequestService (will inject ScratchpadService for the commit guards currently reached via \`this.scratchpadService.X(...)\` inside \`autoStageAndCommit\` / \`createPullRequest\`)

Closes #232.