### PR TITLE
[#251] Studio: make details-panel sidebar sections collapsible for edges and create-work-item flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ This runs the server TypeScript check plus the production frontend build.
 35. Refresh the page and confirm recent transcript state plus the latest active proposal/memory change/GitHub sync results, recent specialist runs, recent execution runs, and reconciliation reports are restored.
 36. Verify the graph view still loads data from `/api/graph`.
 37. Select a node to edit it in the sidebar.
-38. Create a new work item in the sidebar and confirm it appears in the graph.
-39. Create an edge between two nodes and confirm it appears in the graph and edge list.
-40. Delete an edge from the sidebar.
+38. Expand the collapsed **Create work item** section, create a new work item from the sidebar, and confirm it appears in the graph.
+39. Expand the collapsed **Edges** section, create an edge between two nodes, and confirm it appears in the graph and edge list.
+40. Collapse and re-expand the **Edges** section, then delete an edge from the sidebar.
 41. Change repo/state/track/phase filters and confirm the rendered graph updates.
 
 ## API smoke checks

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -429,6 +429,67 @@ a:hover {
   color: var(--text-secondary);
 }
 
+.sidebar-disclosure {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  overflow: clip;
+}
+
+.sidebar-disclosure summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.sidebar-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+.sidebar-disclosure summary::after {
+  content: "▸";
+  margin-left: auto;
+  color: var(--text-muted);
+  transform: rotate(0deg);
+  transition: transform 120ms ease;
+}
+
+.sidebar-disclosure[open] summary {
+  border-bottom: 1px solid var(--border);
+}
+
+.sidebar-disclosure[open] summary::after {
+  transform: rotate(90deg);
+}
+
+.sidebar-disclosure-meta {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--text-muted);
+}
+
+.sidebar-disclosure-body {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
 .stack {
   display: grid;
   gap: 6px;

--- a/web/src/components/Sidebar.svelte
+++ b/web/src/components/Sidebar.svelte
@@ -216,6 +216,11 @@
   $: connectedEdges = selectedItem
     ? graph.edges.filter((edge) => edge.from_id === selectedItem.id || edge.to_id === selectedItem.id)
     : [];
+  $: edgeSummary = connectedEdges.length > 0
+    ? `${connectedEdges.length} connected ${connectedEdges.length === 1 ? "edge" : "edges"}`
+    : selectedItem
+      ? "No connected edges"
+      : "Select a node to review connections";
 
   function submitEdit() {
     onSaveItem({
@@ -467,99 +472,111 @@
   </section>
 
   <section>
-    <h2>Create work item</h2>
-    <div class="stack">
-      <label>
-        ID
-        <input bind:value={createForm.id} placeholder="studio-2" />
-      </label>
-      <label>
-        Name
-        <input bind:value={createForm.name} placeholder="Graph frontend" />
-      </label>
-      <label>
-        Kind
-        <select bind:value={createForm.kind}>
-          <option value="issue">issue</option>
-          <option value="capability">capability</option>
-          <option value="phase">phase</option>
-          <option value="track">track</option>
-        </select>
-      </label>
-      <label>
-        State
-        <select bind:value={createForm.state}>
-          <option value="planned">planned</option>
-          <option value="drafting">drafting</option>
-          <option value="ready">ready</option>
-          <option value="in_progress">in_progress</option>
-          <option value="open_pr">open_pr</option>
-          <option value="merged_pr">merged_pr</option>
-          <option value="done">done</option>
-          <option value="deferred">deferred</option>
-          <option value="cancelled">cancelled</option>
-        </select>
-      </label>
-      <label>
-        Repo
-        <input bind:value={createForm.repo} placeholder="fusupo/escapement-studio" />
-      </label>
-      <label>
-        Scope hint
-        <textarea bind:value={createForm.scope_hint} rows="3"></textarea>
-      </label>
-      <button on:click={submitCreate} disabled={saving}>{saving ? "Saving..." : "Create work item"}</button>
-    </div>
+    <details class="sidebar-disclosure">
+      <summary>
+        <span>Create work item</span>
+        <span class="sidebar-disclosure-meta">New node</span>
+      </summary>
+      <div class="sidebar-disclosure-body stack">
+        <label>
+          ID
+          <input bind:value={createForm.id} placeholder="studio-2" />
+        </label>
+        <label>
+          Name
+          <input bind:value={createForm.name} placeholder="Graph frontend" />
+        </label>
+        <label>
+          Kind
+          <select bind:value={createForm.kind}>
+            <option value="issue">issue</option>
+            <option value="capability">capability</option>
+            <option value="phase">phase</option>
+            <option value="track">track</option>
+          </select>
+        </label>
+        <label>
+          State
+          <select bind:value={createForm.state}>
+            <option value="planned">planned</option>
+            <option value="drafting">drafting</option>
+            <option value="ready">ready</option>
+            <option value="in_progress">in_progress</option>
+            <option value="open_pr">open_pr</option>
+            <option value="merged_pr">merged_pr</option>
+            <option value="done">done</option>
+            <option value="deferred">deferred</option>
+            <option value="cancelled">cancelled</option>
+          </select>
+        </label>
+        <label>
+          Repo
+          <input bind:value={createForm.repo} placeholder="fusupo/escapement-studio" />
+        </label>
+        <label>
+          Scope hint
+          <textarea bind:value={createForm.scope_hint} rows="3"></textarea>
+        </label>
+        <button on:click={submitCreate} disabled={saving}>{saving ? "Saving..." : "Create work item"}</button>
+      </div>
+    </details>
   </section>
 
   <section>
-    <h2>Edges</h2>
-    <div class="stack">
-      <label>
-        From
-        <select bind:value={edgeForm.from_id}>
-          <option value="">Select source</option>
-          {#each graph.items as item}
-            <option value={item.id}>{item.name} ({item.id})</option>
-          {/each}
-        </select>
-      </label>
-      <label>
-        Relation
-        <select bind:value={edgeForm.rel}>
-          <option value="depends_on">depends_on</option>
-          <option value="is_part_of">is_part_of</option>
-          <option value="implemented_by">implemented_by</option>
-        </select>
-      </label>
-      <label>
-        To
-        <select bind:value={edgeForm.to_id}>
-          <option value="">Select target</option>
-          {#each graph.items as item}
-            <option value={item.id}>{item.name} ({item.id})</option>
-          {/each}
-        </select>
-      </label>
-      <button on:click={submitEdge} disabled={edgeSaving}>{edgeSaving ? "Creating..." : "Create edge"}</button>
-    </div>
+    <details class="sidebar-disclosure">
+      <summary>
+        <span>Edges</span>
+        <span class="sidebar-disclosure-meta">{edgeSummary}</span>
+      </summary>
+      <div class="sidebar-disclosure-body">
+        <div class="stack">
+          <label>
+            From
+            <select bind:value={edgeForm.from_id}>
+              <option value="">Select source</option>
+              {#each graph.items as item}
+                <option value={item.id}>{item.name} ({item.id})</option>
+              {/each}
+            </select>
+          </label>
+          <label>
+            Relation
+            <select bind:value={edgeForm.rel}>
+              <option value="depends_on">depends_on</option>
+              <option value="is_part_of">is_part_of</option>
+              <option value="implemented_by">implemented_by</option>
+            </select>
+          </label>
+          <label>
+            To
+            <select bind:value={edgeForm.to_id}>
+              <option value="">Select target</option>
+              {#each graph.items as item}
+                <option value={item.id}>{item.name} ({item.id})</option>
+              {/each}
+            </select>
+          </label>
+          <button on:click={submitEdge} disabled={edgeSaving}>{edgeSaving ? "Creating..." : "Create edge"}</button>
+        </div>
 
-    {#if connectedEdges.length > 0}
-      {#if canDeleteWorkItem}
-        <p class="muted">Deleting this work item will also remove these connected edges after explicit acknowledgement.</p>
-      {/if}
-      <ul class="edge-list">
-        {#each connectedEdges as edge}
-          <li>
-            <code>{edge.from_id}</code>
-            <span>{edge.rel}</span>
-            <code>{edge.to_id}</code>
-            <button class="danger small" on:click={() => onDeleteEdge(edge.id)} disabled={edgeSaving}>Delete</button>
-          </li>
-        {/each}
-      </ul>
-    {:else if selectedItem}
-      <p class="muted">No edges connected to the selected node.</p>
-    {/if}
+        {#if connectedEdges.length > 0}
+          {#if canDeleteWorkItem}
+            <p class="muted">Deleting this work item will also remove these connected edges after explicit acknowledgement.</p>
+          {/if}
+          <ul class="edge-list">
+            {#each connectedEdges as edge}
+              <li>
+                <code>{edge.from_id}</code>
+                <span>{edge.rel}</span>
+                <code>{edge.to_id}</code>
+                <button class="danger small" on:click={() => onDeleteEdge(edge.id)} disabled={edgeSaving}>Delete</button>
+              </li>
+            {/each}
+          </ul>
+        {:else if selectedItem}
+          <p class="muted">No edges connected to the selected node.</p>
+        {/if}
+      </div>
+    </details>
   </section>
 </aside>


### PR DESCRIPTION
## Summary
Sounds good — that matches the implementation:

- **Both sections collapse by default**
- **State is session-only** via native `<details>` behavior, with no persistence added

If you want, I can also do a quick follow-up tweak to auto-expand one of them after a successful create/edge action, but I left that out for now to stay within the approved scope.

actual_files synced: 0 file(s).

## Context
- Work item: studio-251
- Issue: https://github.com/fusupo/escapement-studio/issues/251
- Base branch: develop
- Head branch: studio-251-branch
- Artifact dir: /home/marc/escapement-studio-ctx/runs/exec_1776120684764
- Worktree: /home/marc/escapement-studio-ctx/worktrees/studio-251-branch
- Scope hint: Make the details-panel sidebar less dense by making the Edge and Create work item sections collapsible.

## Changed files
- (not recorded)