### PR TITLE
feat(events): Phase 5 event-driven cross-context calls (#225)

### DIFF
--- a/src/modules/execution/__tests__/disposition.test.ts
+++ b/src/modules/execution/__tests__/disposition.test.ts
@@ -57,8 +57,11 @@ interface HarnessService {
     invalidate: ReturnType<typeof vi.fn>;
     invalidateAll: ReturnType<typeof vi.fn>;
   };
-  plansService: {
-    deletePlanArtifacts: ReturnType<typeof vi.fn>;
+  // Phase 5 (#225): plans cleanup now runs via WorkItemDeletedEvent
+  // published through EventBus. RunDispositionService no longer
+  // injects PlansService directly.
+  eventBus: {
+    publish: ReturnType<typeof vi.fn>;
   };
 
   // Phase 4a: the run buffer lives on RunStore. RunDispositionService uses
@@ -166,7 +169,6 @@ function makeService(params: {
   githubDeleteIssue?: ReturnType<typeof vi.fn>;
   connectedEdges?: Array<{ id: number; from_id: string; rel: string; to_id: string }>;
   deleteWithConnectedEdges?: ReturnType<typeof vi.fn>;
-  deletePlanArtifacts?: ReturnType<typeof vi.fn>;
   updateImpl?: (id: string, patch: Partial<WorkItemRecord>) => WorkItemRecord;
   hsmDispatch?: ReturnType<typeof vi.fn>;
 }): HarnessService {
@@ -314,9 +316,7 @@ function makeService(params: {
     invalidate: vi.fn(),
     invalidateAll: vi.fn(),
   };
-  (service as unknown as { plansService: { deletePlanArtifacts: ReturnType<typeof vi.fn> } }).plansService = {
-    deletePlanArtifacts: params.deletePlanArtifacts ?? vi.fn(() => ({ removed: false, path: null })),
-  };
+  service.eventBus = { publish: vi.fn() };
 
   return service;
 }
@@ -393,15 +393,13 @@ describe("ADR 014 step 7: disposition flow", () => {
   });
 
   describe("deleteWorkItem", () => {
-    it("deletes an eligible issue-backed work item, cleans plan artifacts, and removes connected edges", async () => {
-      const deletePlanArtifacts = vi.fn(() => ({ removed: true, path: "/tmp/plans/studio-157" }));
+    it("deletes an eligible issue-backed work item, publishes WorkItemDeletedEvent, and removes connected edges", async () => {
       const service = makeService({
         artifactRoot: tmpRoot,
         workItem: makeWorkItem({ state: "drafting" }),
         connectedEdges: [
           { id: 11, from_id: "studio-157", rel: "depends_on", to_id: "studio-200" },
         ],
-        deletePlanArtifacts,
       });
 
       const result = await service.deleteWorkItem({
@@ -411,13 +409,17 @@ describe("ADR 014 step 7: disposition flow", () => {
       });
 
       expect(service.githubService.deleteIssue).toHaveBeenCalledWith("fusupo/escapement-studio", 157);
-      expect(deletePlanArtifacts).toHaveBeenCalledWith("studio-157");
       expect(service.workItemsService.deleteWithConnectedEdges).toHaveBeenCalledWith("studio-157", [11]);
+      // Phase 5 (#225): plans cleanup now runs via
+      // WorkItemDeletedEvent → WorkItemDeletedHandler in PlansModule.
+      // The disposition service no longer calls PlansService directly.
+      expect(service.eventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ workItemId: "studio-157" }),
+      );
       expect(result).toMatchObject({
         deleted: true,
         graph: { deleted: true, removed_edge_ids: [11] },
         github_issue: { attempted: true, deleted: true, fallback_used: false, message: null },
-        plan_cleanup: { removed: true, path: "/tmp/plans/studio-157" },
         warnings: [],
       } satisfies Partial<DeleteWorkItemResult>);
     });

--- a/src/modules/execution/__tests__/execution-github-refresh.test.ts
+++ b/src/modules/execution/__tests__/execution-github-refresh.test.ts
@@ -38,9 +38,9 @@ function makeRun(overrides: Partial<ExecutionRunRecord> = {}): ExecutionRunRecor
   };
 }
 
-describe("PullRequestService.refreshPullRequestTruth", () => {
+describe("PullRequestService.refreshRunsForPullRequest", () => {
   /**
-   * Phase 4e (#234): refreshPullRequestTruth lives on PullRequestService.
+   * Phase 4e (#234): refreshRunsForPullRequest lives on PullRequestService.
    * The harness targets `PullRequestService.prototype` and installs a
    * minimal `runStore` stub so the method body can reach
    * `this.runStore.listRecentRuns / updateRun / appendEvent / writeSummary`.
@@ -79,7 +79,7 @@ describe("PullRequestService.refreshPullRequestTruth", () => {
     (service as any).runStore = runStore;
     (service as any).now = () => "2026-04-09T00:02:00Z";
 
-    const result = service.refreshPullRequestTruth({
+    const result = service.refreshRunsForPullRequest({
       number: 70,
       url: "https://github.com/fusupo/escapement-studio/pull/70",
       title: "Refresh cached GitHub truth",
@@ -130,7 +130,7 @@ describe("PullRequestService.refreshPullRequestTruth", () => {
     (service as any).runStore = runStore;
     (service as any).now = () => "2026-04-09T00:02:00Z";
 
-    const result = service.refreshPullRequestTruth({
+    const result = service.refreshRunsForPullRequest({
       number: 70,
       url: "https://github.com/fusupo/escapement-studio/pull/70",
       title: "Refresh cached GitHub truth",

--- a/src/modules/execution/__tests__/github-cache-scheduler.test.ts
+++ b/src/modules/execution/__tests__/github-cache-scheduler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { GitHubCacheScheduler } from "../github-cache-scheduler.service.js";
+import { WorkItemMergedEvent } from "../events/work-item-merged.event.js";
 import type { WorkItemRecord } from "../../graph/types.js";
 
 function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
@@ -54,17 +55,21 @@ function makeService(stubs: {
       rejected: false,
     })),
   };
+  // Phase 5 (#225): the scheduler now injects EventBus and publishes
+  // WorkItemMergedEvent after a successful gh.pr_merged dispatch.
+  const eventBus = { publish: vi.fn() };
 
   const scheduler = Object.create(GitHubCacheScheduler.prototype) as GitHubCacheScheduler;
   (scheduler as unknown as { cache: typeof cache }).cache = cache;
   (scheduler as unknown as { workItemsService: typeof workItemsService }).workItemsService = workItemsService;
   (scheduler as unknown as { hsmService: typeof hsmService }).hsmService = hsmService;
+  (scheduler as unknown as { eventBus: typeof eventBus }).eventBus = eventBus;
   (scheduler as unknown as { logger: { log: () => void; warn: () => void } }).logger = {
     log: vi.fn(),
     warn: vi.fn(),
   };
 
-  return { scheduler, cache, workItemsService, hsmService };
+  return { scheduler, cache, workItemsService, hsmService, eventBus };
 }
 
 describe("GitHubCacheScheduler", () => {
@@ -99,7 +104,7 @@ describe("GitHubCacheScheduler", () => {
       title: "PR title",
       is_draft: false,
     }]]);
-    const { scheduler, hsmService } = makeService({
+    const { scheduler, hsmService, eventBus } = makeService({
       workItems: [makeWorkItem({ state: "open_pr" })],
       prMap,
     });
@@ -108,6 +113,16 @@ describe("GitHubCacheScheduler", () => {
       type: "gh.pr_merged",
     }));
     expect(results[0].dispatched).toBe(1);
+
+    // Phase 5 (#225): verify the WorkItemMergedEvent fired with the
+    // expected payload after the HSM dispatch committed.
+    expect(eventBus.publish).toHaveBeenCalledTimes(1);
+    const published = eventBus.publish.mock.calls[0]?.[0] as WorkItemMergedEvent;
+    expect(published).toBeInstanceOf(WorkItemMergedEvent);
+    expect(published.workItemId).toBe("studio-100");
+    expect(published.pullRequest.number).toBe(100);
+    expect(published.pullRequest.merged_at).toBe("2026-04-11T01:00:00.000Z");
+    expect(published.source).toBe("scheduler");
   });
 
   it("dispatches gh.issue_closed when merged_pr item has a closed issue", async () => {

--- a/src/modules/execution/events/pull-request-truth-refreshed.event.ts
+++ b/src/modules/execution/events/pull-request-truth-refreshed.event.ts
@@ -1,0 +1,21 @@
+import type { IEvent } from "@nestjs/cqrs";
+import type { GitHubPullRequestDetails } from "../../github/github.service.js";
+
+/**
+ * Phase 5 (#225): fires from `GitHubService.withPullRequestReconciliation`
+ * after the reconciler has walked the affected work items and
+ * updated them in the graph store. Replaces the bespoke
+ * `registerPullRequestTruthRefresher` callback handshake between
+ * `GitHubService` and `PullRequestService` with a proper event.
+ *
+ * The subscriber (`PullRequestTruthRefreshedHandler`) delegates to
+ * `PullRequestService.refreshRunsForPullRequest` so the execution
+ * run store learns about the PR truth update. Before Phase 5 that
+ * was a one-subscriber push via a private callback field.
+ */
+export class PullRequestTruthRefreshedEvent implements IEvent {
+  constructor(
+    public readonly pullRequest: GitHubPullRequestDetails,
+    public readonly workItemIds: string[],
+  ) {}
+}

--- a/src/modules/execution/events/pull-request-truth-refreshed.handler.ts
+++ b/src/modules/execution/events/pull-request-truth-refreshed.handler.ts
@@ -1,0 +1,30 @@
+import { Inject } from "@nestjs/common";
+import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
+import { PullRequestService } from "../pull-request.service.js";
+import { PullRequestTruthRefreshedEvent } from "./pull-request-truth-refreshed.event.js";
+
+/**
+ * Phase 5 (#225): subscriber for `PullRequestTruthRefreshedEvent`.
+ * Delegates to `PullRequestService.refreshRunsForPullRequest` so the
+ * run store gets updated with the latest PR truth.
+ *
+ * Lives in ExecutionModule (not GitHubModule) because the handler's
+ * target service is `PullRequestService`, which lives in
+ * ExecutionModule. Registering the handler in GitHubModule would
+ * force a GitHubModule → ExecutionModule import (circular). This
+ * arrangement keeps handlers co-located with their targets.
+ */
+@EventsHandler(PullRequestTruthRefreshedEvent)
+export class PullRequestTruthRefreshedHandler
+  implements IEventHandler<PullRequestTruthRefreshedEvent>
+{
+  constructor(
+    @Inject(PullRequestService) private readonly pullRequestService: PullRequestService,
+  ) {}
+
+  handle(event: PullRequestTruthRefreshedEvent): void {
+    this.pullRequestService.refreshRunsForPullRequest(event.pullRequest, {
+      work_item_ids: event.workItemIds,
+    });
+  }
+}

--- a/src/modules/execution/events/run-completed.event.ts
+++ b/src/modules/execution/events/run-completed.event.ts
@@ -1,0 +1,24 @@
+import type { IEvent } from "@nestjs/cqrs";
+import type { ExecutionPullRequestRecord } from "../types.js";
+
+/**
+ * Phase 5 (#225): fires after `ExecutionService.executeRun` writes
+ * its final `status: "completed"` update and emits the
+ * `execution_result` SSE envelope. Represents "a coding run just
+ * finished successfully" as a fact that future consumers can react
+ * to (e.g. auto-staging managed block syncs, the Phase 8 drift
+ * report, notifications).
+ *
+ * No subscribers land in Phase 5. `pullRequest` is optional because
+ * PR creation is a separate step that happens after the run
+ * completes — most freshly-completed runs do NOT have a PR yet.
+ */
+export class RunCompletedEvent implements IEvent {
+  constructor(
+    public readonly runId: string,
+    public readonly workItemId: string,
+    public readonly changedFiles: string[],
+    public readonly resultSummary: string,
+    public readonly pullRequest: ExecutionPullRequestRecord | null,
+  ) {}
+}

--- a/src/modules/execution/events/work-item-deleted.event.ts
+++ b/src/modules/execution/events/work-item-deleted.event.ts
@@ -1,0 +1,27 @@
+import type { IEvent } from "@nestjs/cqrs";
+
+/**
+ * Phase 5 (#225): fires after `RunDispositionService.deleteWorkItem`
+ * has finished the destructive removal of a work item from the
+ * graph store. The handler (`WorkItemDeletedHandler` in PlansModule)
+ * calls `PlansService.deletePlanArtifacts` to clean up the plan
+ * directory.
+ *
+ * **This event is load-bearing for the forwardRef removal.** Before
+ * Phase 5, `RunDispositionService` directly injected `PlansService`
+ * via `forwardRef(() => PlansService)` because `execution.module`
+ * imports `forwardRef(() => PlansModule)`. Routing the plan cleanup
+ * through an event handler removes that injection and lets the
+ * forwardRef count drop 8 → 7.
+ *
+ * EventBus is synchronous and swallows subscriber errors — but
+ * plan-directory cleanup is non-fatal (the artifact dir already has
+ * a missing-directory guard in `deletePlanArtifacts`), so a silent
+ * failure here just means the plan dir sticks around on disk and
+ * a future reconcile pass can sweep it. Acceptable.
+ */
+export class WorkItemDeletedEvent implements IEvent {
+  constructor(
+    public readonly workItemId: string,
+  ) {}
+}

--- a/src/modules/execution/events/work-item-merged.event.ts
+++ b/src/modules/execution/events/work-item-merged.event.ts
@@ -1,0 +1,34 @@
+import type { IEvent } from "@nestjs/cqrs";
+
+/**
+ * Phase 5 (#225): fires after a work item successfully transitions into
+ * `merged_pr` — i.e. the HSM dispatched `gh.pr_merged` and
+ * `mutation_applied` came back `true`. Dispatched from two sites:
+ *
+ *   1. `GitHubCacheScheduler.sweepRepo` — the background reconciler
+ *      that polls GitHub and drives state transitions.
+ *   2. `PullRequestService.syncMergedPullRequest` — the `POST
+ *      /api/execution/post-merge-sync` HTTP entry point.
+ *
+ * No subscribers land in Phase 5. The event exists so future
+ * consumers (drift reports, notifications, the Phase 8 reconciliation
+ * pass) can subscribe without adding a new cross-module import.
+ *
+ * EventBus is synchronous in-process and swallows subscriber errors,
+ * so every dispatcher must `eventBus.publish` only **after** the
+ * primary action (HSM dispatch + work-item update) has fully
+ * committed. Subscriber failures don't roll anything back.
+ */
+export class WorkItemMergedEvent implements IEvent {
+  constructor(
+    public readonly workItemId: string,
+    public readonly pullRequest: {
+      number: number;
+      url: string;
+      title: string;
+      merged_at: string;
+      merge_commit_sha: string | null;
+    },
+    public readonly source: "scheduler" | "sync_merged_api",
+  ) {}
+}

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,7 +1,6 @@
 import { forwardRef, Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
-import { PlansModule } from "../plans/plans.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
 import { ArchiveAndCloseMergedPullRequestHandler } from "./application/commands/archive-and-close-merged-pull-request.handler.js";
 import { CancelWorkItemHandler } from "./application/commands/cancel-work-item.handler.js";
@@ -26,7 +25,7 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => PlansModule), forwardRef(() => SettingsModule)],
+  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => SettingsModule)],
   controllers: [ExecutionController, GitHubCacheController, WorkItemReconcilerController],
   providers: [
     ExecutionService,

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -9,6 +9,7 @@ import { CloseMergedPullRequestHandler } from "./application/commands/close-merg
 import { DeleteWorkItemHandler } from "./application/commands/delete-work-item.handler.js";
 import { TransitionInProgressToDraftingHandler } from "./application/commands/transition-in-progress-to-drafting.handler.js";
 import { TransitionInProgressToReadyHandler } from "./application/commands/transition-in-progress-to-ready.handler.js";
+import { PullRequestTruthRefreshedHandler } from "./events/pull-request-truth-refreshed.handler.js";
 import { ExecutionController } from "./execution.controller.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { GitHubCacheController } from "./github-cache.controller.js";
@@ -45,6 +46,7 @@ import { WorktreeService } from "./worktree.service.js";
     TransitionInProgressToDraftingHandler,
     CloseMergedPullRequestHandler,
     ArchiveAndCloseMergedPullRequestHandler,
+    PullRequestTruthRefreshedHandler,
   ],
   exports: [
     ExecutionService,

--- a/src/modules/execution/execution.service.ts
+++ b/src/modules/execution/execution.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Inject, Injectable, Logger, NotFoundException, OnModuleInit } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { getConfig } from "../../config.js";
@@ -10,6 +11,7 @@ import {
 import { fetchIssueBody } from "../../lib/github-cli.js";
 import { getDefaultWorkingBranch, listDefaultWorkingBranches } from "./default-working-branches.js";
 import { listArchivedRunBundles, readArchivedRunBundle } from "./archive-reader.js";
+import { RunCompletedEvent } from "./events/run-completed.event.js";
 import { PullRequestService } from "./pull-request.service.js";
 import { RunInteractionService } from "./run-interaction.service.js";
 import { RunStore } from "./run-store.service.js";
@@ -60,6 +62,7 @@ export class ExecutionService implements OnModuleInit {
     @Inject(PullRequestService) private readonly pullRequestService: PullRequestService,
     @Inject(ScratchpadService) private readonly scratchpadService: ScratchpadService,
     @Inject(WorktreeService) private readonly worktreeService: WorktreeService,
+    @Inject(EventBus) private readonly eventBus: EventBus,
   ) {
     // Phase 4e (#234): the truth refresher callback is registered by
     // PullRequestService in its own constructor. ExecutionService no
@@ -422,6 +425,21 @@ export class ExecutionService implements OnModuleInit {
     this.runStore.writeSummary(run, node);
     this.runStore.appendEvent(run, { type: "run_completed", changed_files: changedFiles, actual_files_sync: actualFilesSync });
     this.runStore.emitRun("execution_result", run);
+
+    // Phase 5 (#225): publish RunCompletedEvent so future consumers
+    // (drift reports, notifications, etc.) can react without editing
+    // executeRun. No subscribers land in Phase 5. `pullRequest` is
+    // null at this point because PR creation is a separate later
+    // step — most freshly-completed runs don't have a PR yet.
+    this.eventBus.publish(
+      new RunCompletedEvent(
+        run.run_id,
+        run.work_item_id,
+        changedFiles,
+        assistantText,
+        run.pull_request ?? null,
+      ),
+    );
   }
 
   getRunActivityLog(runId: string): ActivityLogEntry[] {

--- a/src/modules/execution/github-cache-scheduler.service.ts
+++ b/src/modules/execution/github-cache-scheduler.service.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { WorkItemRecord, WorkItemState } from "../graph/types.js";
+import { WorkItemMergedEvent } from "./events/work-item-merged.event.js";
 import { GitHubBatchCache, type CachedPullRequest, type CachedIssue } from "./github-batch-cache.service.js";
 
 /**
@@ -24,6 +26,7 @@ export class GitHubCacheScheduler {
     @Inject(GitHubBatchCache) private readonly cache: GitHubBatchCache,
     @Inject(WorkItemsService) private readonly workItemsService: WorkItemsService,
     @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
+    @Inject(EventBus) private readonly eventBus: EventBus,
   ) {}
 
   @Cron(CronExpression.EVERY_MINUTE)
@@ -93,6 +96,33 @@ export class GitHubCacheScheduler {
             this.logger.log(
               `Sweep dispatched ${event.type} for ${workItem.id}: ${result.prev_state} → ${result.next_state}`,
             );
+
+            // Phase 5 (#225): publish WorkItemMergedEvent when the
+            // sweep successfully transitions a work item into
+            // merged_pr. Fired after the HSM dispatch commits so
+            // subscribers see the post-transition state.
+            if (event.type === "gh.pr_merged") {
+              const pr = event.pull_request as Record<string, unknown> | undefined;
+              const prNumber = typeof pr?.number === "number" ? pr.number : null;
+              const prUrl = typeof pr?.url === "string" ? pr.url : null;
+              const prTitle = typeof pr?.title === "string" ? pr.title : null;
+              const mergedAt = typeof pr?.merged_at === "string" ? pr.merged_at : null;
+              if (prNumber != null && prUrl && prTitle && mergedAt) {
+                this.eventBus.publish(
+                  new WorkItemMergedEvent(
+                    workItem.id,
+                    {
+                      number: prNumber,
+                      url: prUrl,
+                      title: prTitle,
+                      merged_at: mergedAt,
+                      merge_commit_sha: null,
+                    },
+                    "scheduler",
+                  ),
+                );
+              }
+            }
           }
         } catch (error) {
           this.logger.warn(

--- a/src/modules/execution/pull-request.service.ts
+++ b/src/modules/execution/pull-request.service.ts
@@ -1,7 +1,9 @@
 import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getDefaultWorkingBranch } from "./default-working-branches.js";
+import { WorkItemMergedEvent } from "./events/work-item-merged.event.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { RunStore } from "./run-store.service.js";
 import { ScratchpadService } from "./scratchpad.service.js";
@@ -62,6 +64,7 @@ export class PullRequestService {
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
     @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
+    @Inject(EventBus) private readonly eventBus: EventBus,
   ) {
     // Phase 5 (#225): the bespoke `registerPullRequestTruthRefresher`
     // callback handshake is gone. `GitHubService.withPullRequestReconciliation`
@@ -338,6 +341,23 @@ export class PullRequestService {
       archive_path: nextArchivePath,
       meta: nextMeta,
     });
+
+    // Phase 5 (#225): publish WorkItemMergedEvent after the HSM
+    // dispatch + work-item update have both committed. No subscribers
+    // land in this phase; the event exists for future consumers.
+    this.eventBus.publish(
+      new WorkItemMergedEvent(
+        workItem.id,
+        {
+          number: pullRequest.number,
+          url: pullRequest.url,
+          title: pullRequest.title,
+          merged_at: pullRequest.merged_at!,
+          merge_commit_sha: pullRequest.merge_commit_sha ?? null,
+        },
+        "sync_merged_api",
+      ),
+    );
 
     const updatedWorkItem = this.workItemsService.get(workItem.id);
     const managedBlockSync = input.stage_github_sync ? await this.safeStageManagedBlockSync(updatedWorkItem.id) : undefined;

--- a/src/modules/execution/pull-request.service.ts
+++ b/src/modules/execution/pull-request.service.ts
@@ -31,7 +31,7 @@ import type {
  * wrappers on `ExecutionService` — matching the Phase 4b/4c/4d
  * cleanupWorktree / getRunChecklist / sendFollowUp passthrough pattern.
  *
- * `refreshPullRequestTruth` is registered with `GitHubService` at
+ * `refreshRunsForPullRequest` is registered with `GitHubService` at
  * construction time. After Phase 4e, `ExecutionService` does not touch
  * `registerPullRequestTruthRefresher` at all.
  *
@@ -68,13 +68,13 @@ export class PullRequestService {
     // the refresh logic owns the registration. Atomic swap with the
     // ExecutionService rewire commit.
     this.githubService.registerPullRequestTruthRefresher(
-      (pullRequest, options) => this.refreshPullRequestTruth(pullRequest, options),
+      (pullRequest, options) => this.refreshRunsForPullRequest(pullRequest, options),
     );
   }
 
   // ─── PR truth refresh (GitHubService callback) ───────────────────
 
-  refreshPullRequestTruth(
+  refreshRunsForPullRequest(
     pullRequest: {
       number: number;
       url: string;

--- a/src/modules/execution/pull-request.service.ts
+++ b/src/modules/execution/pull-request.service.ts
@@ -63,13 +63,12 @@ export class PullRequestService {
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
     @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
   ) {
-    // Phase 4e (#234): take ownership of the PR truth refresher callback.
-    // ExecutionService no longer registers this — the service that owns
-    // the refresh logic owns the registration. Atomic swap with the
-    // ExecutionService rewire commit.
-    this.githubService.registerPullRequestTruthRefresher(
-      (pullRequest, options) => this.refreshRunsForPullRequest(pullRequest, options),
-    );
+    // Phase 5 (#225): the bespoke `registerPullRequestTruthRefresher`
+    // callback handshake is gone. `GitHubService.withPullRequestReconciliation`
+    // now publishes a `PullRequestTruthRefreshedEvent`, and the
+    // `PullRequestTruthRefreshedHandler` (registered in ExecutionModule)
+    // delegates to `this.refreshRunsForPullRequest` via standard CQRS
+    // event dispatch.
   }
 
   // ─── PR truth refresh (GitHubService callback) ───────────────────

--- a/src/modules/execution/run-disposition.service.ts
+++ b/src/modules/execution/run-disposition.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Inject, Injectable, Logger, forwardRef } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import { existsSync, mkdirSync, renameSync } from "node:fs";
 import { resolve } from "node:path";
 import { getConfig } from "../../config.js";
@@ -11,7 +12,7 @@ import type {
 } from "../graph/types.js";
 import { WorkItemHsmService } from "../graph/work-item-hsm.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
-import { PlansService } from "../plans/plans.service.js";
+import { WorkItemDeletedEvent } from "./events/work-item-deleted.event.js";
 import { ExecutionService } from "./execution.service.js";
 import { GitHubBatchCache } from "./github-batch-cache.service.js";
 import { RunStore } from "./run-store.service.js";
@@ -67,7 +68,6 @@ export class RunDispositionService {
     @Inject(WorkItemHsmService) private readonly hsmService: WorkItemHsmService,
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(GitHubBatchCache) private readonly githubBatchCache: GitHubBatchCache,
-    @Inject(forwardRef(() => PlansService)) private readonly plansService: PlansService,
     // Phase 4a (#230): forwardRef(ExecutionService) survives ONLY for
     // `getPreview` used in the close/archive response envelopes. The
     // buffer/stream/seam half of the Phase 3 dependency is now served
@@ -75,6 +75,12 @@ export class RunDispositionService {
     // this residual can be unwrapped.
     @Inject(forwardRef(() => ExecutionService)) private readonly executionService: ExecutionService,
     @Inject(RunStore) private readonly runStore: RunStore,
+    // Phase 5 (#225): plan artifact cleanup now runs via
+    // WorkItemDeletedEvent → WorkItemDeletedHandler (in PlansModule).
+    // `PlansService` is no longer injected directly — that removes
+    // the `forwardRef(() => PlansService)` that required
+    // `execution.module.ts` to import `PlansModule`.
+    @Inject(EventBus) private readonly eventBus: EventBus,
   ) {}
 
   async closeMergedPullRequest(workItemId: string): Promise<CloseMergedPullRequestResult> {
@@ -292,8 +298,17 @@ export class RunDispositionService {
       warnings.push(`GitHub issue was not deleted: ${message}`);
     }
 
-    const planCleanup = this.plansService.deletePlanArtifacts(workItemId);
     const graphResult = this.workItemsService.deleteWithConnectedEdges(workItemId, connectedEdges.map((edge) => edge.id));
+
+    // Phase 5 (#225): publish WorkItemDeletedEvent AFTER the graph
+    // delete commits. Subscriber (WorkItemDeletedHandler in
+    // PlansModule) cleans up plan artifacts via PlansService.
+    // Fires post-graph-delete because the handler's PlansService
+    // call internally re-reads the work item to resolve the plan dir;
+    // if the graph delete came first the handler tolerates the
+    // missing-workitem lookup error and warns. Either ordering is
+    // acceptable — the plan dir cleanup is defensive and idempotent.
+    this.eventBus.publish(new WorkItemDeletedEvent(workItemId));
 
     return {
       deleted: true,
@@ -307,7 +322,6 @@ export class RunDispositionService {
       },
       graph: graphResult,
       github_issue: githubIssue,
-      plan_cleanup: planCleanup,
       warnings,
     };
   }

--- a/src/modules/execution/types.ts
+++ b/src/modules/execution/types.ts
@@ -332,10 +332,10 @@ export interface DeleteWorkItemResult {
     fallback_used: boolean;
     message: string | null;
   };
-  plan_cleanup: {
-    removed: boolean;
-    path: string | null;
-  };
+  // Phase 5 (#225): plan-artifact cleanup now runs via
+  // WorkItemDeletedEvent → WorkItemDeletedHandler (in PlansModule),
+  // not via a direct synchronous call. The `plan_cleanup` return
+  // field was test-only and is dropped from the envelope.
   warnings: string[];
 }
 

--- a/src/modules/github/__tests__/github.service.test.ts
+++ b/src/modules/github/__tests__/github.service.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 import { GitHubService } from "../github.service.js";
+import { PullRequestTruthRefreshedEvent } from "../../execution/events/pull-request-truth-refreshed.event.js";
 import type { WorkItemRecord } from "../../graph/types.js";
+
+/**
+ * Phase 5 (#225): GitHubService now injects an EventBus and publishes
+ * PullRequestTruthRefreshedEvent instead of invoking the bespoke
+ * `registerPullRequestTruthRefresher` callback. Every test that
+ * constructs GitHubService needs to pass in an EventBus stub as the
+ * third constructor arg.
+ */
+function makeEventBusStub() {
+  const publish = vi.fn();
+  return { publish } as unknown as import("@nestjs/cqrs").EventBus & {
+    publish: ReturnType<typeof vi.fn>;
+  };
+}
 
 function makeWorkItem(overrides: Partial<WorkItemRecord> = {}): WorkItemRecord {
   return {
@@ -53,7 +68,7 @@ describe("GitHubService reconciliation", () => {
     const service = new GitHubService({ getDb: () => ({}) } as any, {
       listByRepoIssueNumber: vi.fn(() => [workItem]),
       update,
-    } as any);
+    } as any, makeEventBusStub());
 
     (service as any).runGhJson = vi.fn().mockResolvedValue({
       number: 91,
@@ -106,13 +121,12 @@ describe("GitHubService reconciliation", () => {
       return applyPatch(workItem, patch);
     });
 
+    const eventBus = makeEventBusStub();
     const service = new GitHubService({ getDb: () => ({}) } as any, {
       listByRepoPullRequestNumber: vi.fn(() => []),
       listByRepoBranch: vi.fn(() => [workItem]),
       update,
-    } as any);
-
-    service.registerPullRequestTruthRefresher(() => ({ updated_run_ids: ["exec_123"] }));
+    } as any, eventBus);
 
     (service as any).runGhJson = vi.fn().mockResolvedValue({
       number: 70,
@@ -142,9 +156,17 @@ describe("GitHubService reconciliation", () => {
     });
     expect(result.reconciliation).toEqual({
       updated_work_item_ids: ["studio-91"],
-      updated_run_ids: ["exec_123"],
       work_items: [expect.objectContaining({ id: "studio-91", state: "merged_pr" })],
     });
+    // Phase 5 (#225): truth refresh is now event-driven; verify the
+    // event was published with the expected payload. Subscribers run
+    // synchronously via CqrsModule's in-process EventBus.
+    expect(eventBus.publish).toHaveBeenCalledWith(
+      expect.any(PullRequestTruthRefreshedEvent),
+    );
+    const publishedEvent = eventBus.publish.mock.calls[0]?.[0] as PullRequestTruthRefreshedEvent;
+    expect(publishedEvent.workItemIds).toEqual(["studio-91"]);
+    expect(publishedEvent.pullRequest.number).toBe(70);
   });
 
   describe("merged PR state advancement", () => {
@@ -172,13 +194,13 @@ describe("GitHubService reconciliation", () => {
         expect(id).toBe(workItem.id);
         return applyPatch(workItem, patch);
       });
+      const eventBus = makeEventBusStub();
       const service = new GitHubService({ getDb: () => ({}) } as any, {
         listByRepoPullRequestNumber: vi.fn(() => []),
         listByRepoBranch: vi.fn(() => [workItem]),
         update,
-      } as any);
-      service.registerPullRequestTruthRefresher(() => ({ updated_run_ids: [] }));
-      return { service, update };
+      } as any, eventBus);
+      return { service, update, eventBus };
     }
 
     function mockMergedPr(service: GitHubService, mergedAt: string | null) {
@@ -274,7 +296,7 @@ describe("GitHubService reconciliation", () => {
 
 describe("GitHubService issue closing", () => {
   it("closes an issue without posting a comment by default", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGh = vi.fn().mockReturnValue("");
     const readIssueResult = {
       repo: "fusupo/escapement-studio",
@@ -305,7 +327,7 @@ describe("GitHubService issue closing", () => {
   });
 
   it("posts a comment before closing when one is provided", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGh = vi.fn().mockReturnValue("");
     const readIssueResult = {
       repo: "fusupo/escapement-studio",
@@ -342,14 +364,14 @@ describe("GitHubService issue closing", () => {
   });
 
   it("rejects closeIssue when repo or issue_number are invalid", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
 
     await expect(service.closeIssue("", 136)).rejects.toThrow("repo is required");
     await expect(service.closeIssue("fusupo/escapement-studio", 0)).rejects.toThrow("issue_number must be a positive integer");
   });
 
   it("stops before close when posting the comment fails", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGh = vi.fn(() => {
       throw new Error("gh command failed: comment nope");
     });
@@ -360,7 +382,7 @@ describe("GitHubService issue closing", () => {
   });
 
   it("propagates close failures after posting the comment", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGh = vi.fn()
       .mockReturnValueOnce("")
       .mockImplementationOnce(() => {
@@ -375,7 +397,7 @@ describe("GitHubService issue closing", () => {
 
 describe("GitHubService issue deletion", () => {
   it("deletes an issue with gh issue delete --yes", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGh = vi.fn().mockReturnValue("");
     (service as any).runGh = runGh;
 
@@ -395,14 +417,14 @@ describe("GitHubService issue deletion", () => {
   });
 
   it("rejects deleteIssue when repo or issue_number are invalid", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
 
     await expect(service.deleteIssue("", 137)).rejects.toThrow("repo is required");
     await expect(service.deleteIssue("fusupo/escapement-studio", 0)).rejects.toThrow("issue_number must be a positive integer");
   });
 
   it("propagates gh delete failures", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     (service as any).runGh = vi.fn(() => {
       throw new Error("gh command failed: nope");
     });
@@ -413,7 +435,7 @@ describe("GitHubService issue deletion", () => {
 
 describe("GitHubService batch list methods", () => {
   it("lists pull requests with normalized fields and commands", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGhJson = vi.fn().mockResolvedValue([
       {
         number: 194,
@@ -458,7 +480,7 @@ describe("GitHubService batch list methods", () => {
   });
 
   it("lists issues with normalized closed_at fields and empty responses", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const runGhJson = vi.fn()
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -498,7 +520,7 @@ describe("GitHubService batch list methods", () => {
   });
 
   it("warns when batch list results hit the hard limits", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     const logger = { warn: vi.fn() };
     (service as any).logger = logger;
     (service as any).runGhJson = vi.fn()
@@ -527,7 +549,7 @@ describe("GitHubService batch list methods", () => {
   });
 
   it("propagates batch list failures", async () => {
-    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any);
+    const service = new GitHubService({ getDb: () => ({}) } as any, {} as any, makeEventBusStub());
     (service as any).runGhJson = vi.fn().mockRejectedValue(new Error("gh failed"));
 
     await expect(service.listPullRequests("fusupo/escapement-studio")).rejects.toThrow("gh failed");

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -1,7 +1,9 @@
 import { BadRequestException, Inject, Injectable, Logger } from "@nestjs/common";
+import { EventBus } from "@nestjs/cqrs";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import type { Database as DatabaseType } from "better-sqlite3";
+import { PullRequestTruthRefreshedEvent } from "../execution/events/pull-request-truth-refreshed.event.js";
 import { SQLiteService } from "../graph/sqlite.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { UpdateWorkItemDto, WorkItemRecord } from "../graph/types.js";
@@ -101,30 +103,19 @@ export interface GitHubPullRequestDetails {
   merge_commit_sha: string | null;
   reconciliation?: {
     updated_work_item_ids: string[];
-    updated_run_ids: string[];
     work_items: WorkItemRecord[];
   };
-}
-
-interface PullRequestTruthRefreshResult {
-  updated_run_ids: string[];
 }
 
 @Injectable()
 export class GitHubService {
   private readonly logger = new Logger(GitHubService.name);
-  private pullRequestTruthRefresher?: (pullRequest: GitHubPullRequestDetails, options?: { work_item_ids?: string[] }) => PullRequestTruthRefreshResult;
 
   constructor(
     @Inject(SQLiteService) private readonly sqlite: SQLiteService,
     @Inject(WorkItemsService) private readonly workItems: WorkItemsService,
+    @Inject(EventBus) private readonly eventBus: EventBus,
   ) {}
-
-  registerPullRequestTruthRefresher(
-    refresher: (pullRequest: GitHubPullRequestDetails, options?: { work_item_ids?: string[] }) => PullRequestTruthRefreshResult,
-  ) {
-    this.pullRequestTruthRefresher = refresher;
-  }
 
   private get db(): DatabaseType {
     return this.sqlite.getDb();
@@ -565,15 +556,24 @@ export class GitHubService {
       return this.workItems.update(workItem.id, updatePatch);
     });
 
-    const refreshResult = this.pullRequestTruthRefresher?.(pullRequest, {
-      work_item_ids: nextWorkItems.map((workItem) => workItem.id),
-    }) ?? { updated_run_ids: [] };
+    // Phase 5 (#225): publish a PullRequestTruthRefreshedEvent so
+    // PullRequestService (via PullRequestTruthRefreshedHandler) can
+    // update the run store. Replaces the previous
+    // `registerPullRequestTruthRefresher` callback handshake.
+    // EventBus is synchronous in-process, so the handler runs before
+    // `publish` returns — the semantics match the old direct callback
+    // from this caller's point of view.
+    this.eventBus.publish(
+      new PullRequestTruthRefreshedEvent(
+        pullRequest,
+        nextWorkItems.map((workItem) => workItem.id),
+      ),
+    );
 
     return {
       ...pullRequest,
       reconciliation: {
         updated_work_item_ids: updatedWorkItemIds,
-        updated_run_ids: refreshResult.updated_run_ids,
         work_items: nextWorkItems,
       },
     };

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -7,6 +7,7 @@ import { ReopenPlanHandler } from "./application/commands/reopen-plan.handler.js
 import { PlanDrafterService } from "./plan-drafter.service.js";
 import { PlansController } from "./plans.controller.js";
 import { PlansService } from "./plans.service.js";
+import { WorkItemDeletedHandler } from "./work-item-deleted.handler.js";
 
 /**
  * ADR 014 step 4 — plan preparation module.
@@ -18,7 +19,13 @@ import { PlansService } from "./plans.service.js";
 @Module({
   imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => SettingsModule)],
   controllers: [PlansController],
-  providers: [PlansService, PlanDrafterService, PreparePlanHandler, ReopenPlanHandler],
+  providers: [
+    PlansService,
+    PlanDrafterService,
+    PreparePlanHandler,
+    ReopenPlanHandler,
+    WorkItemDeletedHandler,
+  ],
   exports: [PlansService, PlanDrafterService],
 })
 export class PlansModule {}

--- a/src/modules/plans/plans.service.ts
+++ b/src/modules/plans/plans.service.ts
@@ -208,9 +208,15 @@ export class PlansService {
     };
   }
 
+  /**
+   * Phase 5 (#225): safely idempotent. Callers are now the
+   * `WorkItemDeletedHandler` event subscriber (post-graph-delete),
+   * plus any legacy direct caller that may still need synchronous
+   * cleanup. Since the event handler fires AFTER the graph delete
+   * commits, the work item lookup guard was removed — the path
+   * computation + existence check stand on their own.
+   */
   deletePlanArtifacts(workItemId: string): { removed: boolean; path: string | null } {
-    this.workItemsService.get(workItemId);
-
     const target = planDir(this.artifactRoot, workItemId);
     if (!existsSync(target)) {
       return { removed: false, path: null };

--- a/src/modules/plans/work-item-deleted.handler.ts
+++ b/src/modules/plans/work-item-deleted.handler.ts
@@ -1,0 +1,49 @@
+import { Inject, Logger } from "@nestjs/common";
+import { EventsHandler, type IEventHandler } from "@nestjs/cqrs";
+import { WorkItemDeletedEvent } from "../execution/events/work-item-deleted.event.js";
+import { PlansService } from "./plans.service.js";
+
+/**
+ * Phase 5 (#225): subscriber for `WorkItemDeletedEvent`. Cleans up
+ * the plan artifact directory for the deleted work item.
+ *
+ * Before Phase 5, `RunDispositionService.deleteWorkItem` called
+ * `PlansService.deletePlanArtifacts` directly via a
+ * `forwardRef(() => PlansService)` injection. Routing the cleanup
+ * through an event handler lets RunDispositionService drop the
+ * direct dependency and the ExecutionModule's
+ * `forwardRef(() => PlansModule)` goes away, dropping the
+ * project-wide forwardRef count 8 → 7.
+ *
+ * Lives in PlansModule because its target service (`PlansService`)
+ * lives there. This handler is the ONE subscriber that actually
+ * needs to run — the plan directory on disk is a side effect that
+ * can't be recovered without an explicit reconcile pass. That said,
+ * `deletePlanArtifacts` is defensive (missing dir = no-op), so a
+ * silent handler failure is degraded-but-not-broken behavior.
+ */
+@EventsHandler(WorkItemDeletedEvent)
+export class WorkItemDeletedHandler implements IEventHandler<WorkItemDeletedEvent> {
+  private readonly logger = new Logger(WorkItemDeletedHandler.name);
+
+  constructor(
+    @Inject(PlansService) private readonly plansService: PlansService,
+  ) {}
+
+  handle(event: WorkItemDeletedEvent): void {
+    try {
+      this.plansService.deletePlanArtifacts(event.workItemId);
+    } catch (error) {
+      // PlansService.deletePlanArtifacts currently looks up the
+      // work item via WorkItemsService.get first, which throws if
+      // the work item has already been removed from the graph.
+      // That's the normal case in the post-delete handler — the
+      // delete already finished. Swallow the lookup error; a
+      // future reconcile pass can sweep any orphaned plan dirs.
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(
+        `Failed to delete plan artifacts for ${event.workItemId}: ${message}`,
+      );
+    }
+  }
+}

--- a/src/modules/plans/work-item-deleted.handler.ts
+++ b/src/modules/plans/work-item-deleted.handler.ts
@@ -11,16 +11,13 @@ import { PlansService } from "./plans.service.js";
  * `PlansService.deletePlanArtifacts` directly via a
  * `forwardRef(() => PlansService)` injection. Routing the cleanup
  * through an event handler lets RunDispositionService drop the
- * direct dependency and the ExecutionModule's
- * `forwardRef(() => PlansModule)` goes away, dropping the
- * project-wide forwardRef count 8 → 7.
+ * direct dependency and the `ExecutionModule → forwardRef(PlansModule)`
+ * edge goes away, dropping the project-wide forwardRef count 8 → 7.
  *
  * Lives in PlansModule because its target service (`PlansService`)
- * lives there. This handler is the ONE subscriber that actually
- * needs to run — the plan directory on disk is a side effect that
- * can't be recovered without an explicit reconcile pass. That said,
- * `deletePlanArtifacts` is defensive (missing dir = no-op), so a
- * silent handler failure is degraded-but-not-broken behavior.
+ * lives there. `deletePlanArtifacts` is idempotent and defensive
+ * (missing dir = no-op) after Phase 5 — the caller doesn't need to
+ * verify the work item still exists before dispatching the event.
  */
 @EventsHandler(WorkItemDeletedEvent)
 export class WorkItemDeletedHandler implements IEventHandler<WorkItemDeletedEvent> {
@@ -34,12 +31,10 @@ export class WorkItemDeletedHandler implements IEventHandler<WorkItemDeletedEven
     try {
       this.plansService.deletePlanArtifacts(event.workItemId);
     } catch (error) {
-      // PlansService.deletePlanArtifacts currently looks up the
-      // work item via WorkItemsService.get first, which throws if
-      // the work item has already been removed from the graph.
-      // That's the normal case in the post-delete handler — the
-      // delete already finished. Swallow the lookup error; a
-      // future reconcile pass can sweep any orphaned plan dirs.
+      // EventBus swallows handler errors, but logging here gives
+      // an explicit warning if plan-dir removal fails (e.g. fs
+      // permissions). A future reconcile pass can sweep orphaned
+      // plan dirs.
       const message = error instanceof Error ? error.message : String(error);
       this.logger.warn(
         `Failed to delete plan artifacts for ${event.workItemId}: ${message}`,


### PR DESCRIPTION
## Summary

Phase 5 of the CQRS refactor (#225) — introduces 4 events where fire-and-forget broadcast semantics actually fit, and takes the architectural win of dropping one forwardRef via the plan-cleanup event path.

**Not a blanket sweep.** Load-bearing cross-module calls stay direct. Events are picked per case: each dispatch site is structured as "publish after the primary action committed successfully" so subscriber failures don't roll anything back (`@nestjs/cqrs` EventBus is synchronous in-process and swallows subscriber errors).

## Events + handlers

| Event | Dispatched from | Subscribers |
|---|---|---|
| \`PullRequestTruthRefreshedEvent\` | \`GitHubService.withPullRequestReconciliation\` | \`PullRequestTruthRefreshedHandler\` → \`PullRequestService.refreshRunsForPullRequest\` |
| \`WorkItemMergedEvent\` | \`GitHubCacheScheduler.sweepRepo\` (source: "scheduler") + \`PullRequestService.syncMergedPullRequest\` (source: "sync_merged_api") | **none yet** — future consumers subscribe |
| \`RunCompletedEvent\` | \`ExecutionService.executeRun\` completion | **none yet** |
| \`WorkItemDeletedEvent\` | \`RunDispositionService.deleteWorkItem\` | \`WorkItemDeletedHandler\` → \`PlansService.deletePlanArtifacts\` |

5 dispatch sites, 2 handlers, 4 event classes.

## The architectural win: forwardRef 8 → 7

Before Phase 5, \`RunDispositionService.deleteWorkItem\` called \`PlansService.deletePlanArtifacts\` directly via \`@Inject(forwardRef(() => PlansService))\`, which required \`ExecutionModule\` to import \`forwardRef(() => PlansModule)\`. Routing the cleanup through \`WorkItemDeletedEvent\` → \`WorkItemDeletedHandler\` (in PlansModule) removes the direct dependency and drops the forwardRef entirely.

**forwardRef audit after Phase 5:**
\`\`\`
execution.module.ts:   3 (GraphModule, GitHubModule, SettingsModule)
plans.module.ts:       3 (GraphModule, GitHubModule, SettingsModule)
settings.module.ts:    1 (GraphModule)
                       ─────
                       7 total (was 8)
\`\`\`

## Callback API deletion

\`GitHubService.registerPullRequestTruthRefresher\` is deleted entirely — method, private field, and the bespoke callback shape. This was a one-subscriber hand-rolled push pattern from before \`CqrsModule\` landed. The equivalent event dispatch is 3 lines + a typed event class.

\`grep -r 'registerPullRequestTruthRefresher' src/\` returns only comments + docstrings after this PR.

## Method rename

\`PullRequestService.refreshPullRequestTruth\` → \`refreshRunsForPullRequest\`. The new name reflects what the method actually does (updates run store records for a PR, not "refreshing PR truth" — that's GitHubService's job). Suggested by the Phase 5 proposal doc at line 175–177.

## Dead state dropped from HTTP envelopes

Two fields deleted because they were test-only and had no frontend consumer. Both becomes stale the moment their producing logic moves to async event handlers that can't plumb results back:

1. **\`GitHubPullRequestDetails.reconciliation.updated_run_ids\`** — populated from the deleted callback's return value. Not read in production; test assertions rewritten to check \`eventBus.publish\` fires with the expected payload instead.
2. **\`DeleteWorkItemResult.plan_cleanup\`** — populated from the synchronous \`PlansService.deletePlanArtifacts\` return. Post-Phase 5 the cleanup runs via event handler so the caller can't observe the result. Not read in production; test assertions rewritten to check \`eventBus.publish\` fires with a \`WorkItemDeletedEvent\`.

## Changes

- \`70c54c9\` feat(events): add Phase 5 event classes + CQRS handlers
- \`2aa794f\` refactor(github): replace PR truth refresher callback with event
- \`d1a097d\` feat(events): dispatch WorkItemMergedEvent + RunCompletedEvent
- \`c244565\` refactor(execution): route plan cleanup through WorkItemDeletedEvent

## Test plan

- [x] \`npm run check\` clean (tsc --noEmit)
- [x] \`npx vitest run --no-file-parallelism\` — 561 / 561 tests pass
- [x] \`npm run build:web\` clean
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\` → **7** (down from 8)
- [x] \`grep -r 'registerPullRequestTruthRefresher' src/\` → only comments
- [ ] Manual smoke test: create PR → sync merged PR → delete work item (verify plan artifacts cleaned up via event handler)

## Test harness updates

- **\`github.service.test.ts\`** — adds \`makeEventBusStub\` helper, passes it as 3rd constructor arg to 14 \`new GitHubService(...)\` call sites, rewires the merged-PR reconciliation test to assert \`eventBus.publish\` fires with \`PullRequestTruthRefreshedEvent\`.
- **\`github-cache-scheduler.test.ts\`** — harness installs an \`eventBus\` stub alongside the cache/workItems/hsm stubs; the existing \`gh.pr_merged\` dispatch test gains an assertion that \`WorkItemMergedEvent\` fires with the expected workItemId, pullRequest.number, merged_at, and source="scheduler".
- **\`disposition.test.ts\`** — drops the \`plansService\` harness field + \`deletePlanArtifacts\` makeService param, adds an \`eventBus\` stub; rewires the deleteWorkItem test to assert \`eventBus.publish\` fires with a \`WorkItemDeletedEvent\` instead of asserting on \`plansService.deletePlanArtifacts\` + \`plan_cleanup\`.
- **\`execution-github-refresh.test.ts\`** — method rename only (\`refreshPullRequestTruth\` → \`refreshRunsForPullRequest\`); describe block label updated.

## Known remaining drift

- \`@nestjs/cqrs\`'s \`EventBus\` is synchronous in-process and swallows subscriber errors. Every dispatch site in this PR is structured as "publish after the primary action committed successfully." If a future subscriber becomes load-bearing, the right fix is a durable outbox pattern, not retrofitting these events. Documented in each event class docstring.
- \`ExecutionService\` still injects the \`RunInteractionService\` / \`PullRequestService\` / \`ScratchpadService\` / \`WorktreeService\` / \`RunStore\` siblings for direct calls. That's intentional — those are internal-to-a-module, not cross-context.
- Residual \`forwardRef(() => ExecutionService)\` in \`RunDispositionService\` for \`getPreview\`. Phase 9a audit target, not Phase 5's job.

## Follow-ups

- **Phase 6 (#226):** Move \`SQLiteService\` to a new \`PlatformModule\`, move \`GitHubBatchCache\` + \`GitHubCacheScheduler\` into GitHubModule. Expected −3 forwardRefs, down to 4.
- **Phase 9a:** Unwrap residual \`forwardRef(ExecutionService)\` in \`RunDispositionService\`.

Closes #225.