### PR TITLE
refactor(platform): move SQLiteService to global PlatformModule (Phase 6a #235)

### DIFF
--- a/src/__tests__/state-machine-allowlist.test.ts
+++ b/src/__tests__/state-machine-allowlist.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { initManifest } from "../lib/manifest-core.js";
-import { SQLiteService } from "../modules/graph/sqlite.service.js";
+import { SQLiteService } from "../platform/sqlite.service.js";
 import type { WorkItemState } from "../modules/graph/types.js";
 
 /**

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -25,7 +25,7 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => SettingsModule)],
+  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), SettingsModule],
   controllers: [ExecutionController, GitHubCacheController, WorkItemReconcilerController],
   providers: [
     ExecutionService,

--- a/src/modules/github/github.service.ts
+++ b/src/modules/github/github.service.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { PullRequestTruthRefreshedEvent } from "../execution/events/pull-request-truth-refreshed.event.js";
-import { SQLiteService } from "../graph/sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { UpdateWorkItemDto, WorkItemRecord } from "../graph/types.js";
 import type {

--- a/src/modules/graph/__tests__/graph-writer.service.test.ts
+++ b/src/modules/graph/__tests__/graph-writer.service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { initManifest } from "../../../lib/manifest-core.js";
 import { GraphWriterService } from "../graph-writer.service.js";
-import { SQLiteService } from "../sqlite.service.js";
+import { SQLiteService } from "../../../platform/sqlite.service.js";
 import type {
   ApplyGraphMutationsDto,
   GraphMutation,

--- a/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
+++ b/src/modules/graph/__tests__/migrate-done-to-archived.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { initManifest } from "../../../lib/manifest-core.js";
 import { archiveDir } from "../../../lib/context-layout.js";
-import { SQLiteService } from "../sqlite.service.js";
+import { SQLiteService } from "../../../platform/sqlite.service.js";
 import { migrateDoneToArchived } from "../../../../scripts/migrate-done-to-archived.js";
 
 const tempRoots: string[] = [];

--- a/src/modules/graph/__tests__/work-item-state-persistence.test.ts
+++ b/src/modules/graph/__tests__/work-item-state-persistence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { initManifest } from "../../../lib/manifest-core.js";
 import { GraphService } from "../graph.service.js";
 import { GraphWriterService } from "../graph-writer.service.js";
-import { SQLiteService } from "../sqlite.service.js";
+import { SQLiteService } from "../../../platform/sqlite.service.js";
 import type { WorkItemState } from "../types.js";
 import { WorkItemsService } from "../work-items.service.js";
 

--- a/src/modules/graph/edges.service.ts
+++ b/src/modules/graph/edges.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
 import { GraphWriterService } from "./graph-writer.service.js";
-import { SQLiteService } from "./sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import type { CreateEdgeDto, EdgeRecord, UpdateEdgeDto } from "./types.js";
 
 interface RawEdgeRecord {

--- a/src/modules/graph/graph-writer.service.ts
+++ b/src/modules/graph/graph-writer.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
-import { SQLiteService } from "./sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import {
   checkIdAlignment,
   type ApplyGraphMutationsDto,

--- a/src/modules/graph/graph.module.ts
+++ b/src/modules/graph/graph.module.ts
@@ -5,16 +5,21 @@ import { GraphController } from "./graph.controller.js";
 import { GraphEventsService } from "./graph-events.service.js";
 import { GraphService } from "./graph.service.js";
 import { GraphWriterService } from "./graph-writer.service.js";
-import { SQLiteService } from "./sqlite.service.js";
 import { WorkItemHsmService } from "./work-item-hsm.service.js";
 import { WorkItemsController } from "./work-items.controller.js";
 import { WorkItemsService } from "./work-items.service.js";
 
+/**
+ * Phase 6a (#235): `SQLiteService` moved to `@Global PlatformModule`
+ * (src/platform/). GraphModule no longer provides or exports it.
+ * Graph's own services still inject `SQLiteService` directly — it's
+ * available via the global platform without an explicit module
+ * import.
+ */
 @Module({
   imports: [],
   controllers: [WorkItemsController, EdgesController, GraphController],
   providers: [
-    SQLiteService,
     WorkItemsService,
     EdgesService,
     GraphService,
@@ -23,7 +28,6 @@ import { WorkItemsService } from "./work-items.service.js";
     WorkItemHsmService,
   ],
   exports: [
-    SQLiteService,
     WorkItemsService,
     EdgesService,
     GraphService,

--- a/src/modules/graph/graph.service.ts
+++ b/src/modules/graph/graph.service.ts
@@ -11,7 +11,7 @@ import {
   queryOverlaps,
 } from "../../lib/manifest-core.js";
 import type { Assessment, DispatchPlan, FrontierItem } from "../../lib/manifest-core.js";
-import { SQLiteService } from "./sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import type { GraphFilters, WorkItemRecord } from "./types.js";
 import { WorkItemsService } from "./work-items.service.js";
 

--- a/src/modules/graph/work-items.service.ts
+++ b/src/modules/graph/work-items.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Inject, Injectable, Logger, NotFoundException } fr
 import type { Database as DatabaseType } from "better-sqlite3";
 import { parseJsonArray } from "../../lib/manifest-core.js";
 import { GraphWriterService } from "./graph-writer.service.js";
-import { SQLiteService } from "./sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import { deriveIssueWorkItemId, type CreateWorkItemDto, type EdgeRecord, type MisalignedWorkItem, type UpdateWorkItemDto, type WorkItemRecord, type WorkItemState } from "./types.js";
 
 interface RawWorkItemRecord {

--- a/src/modules/health/health.module.ts
+++ b/src/modules/health/health.module.ts
@@ -1,10 +1,16 @@
 import { Module } from "@nestjs/common";
-import { GraphModule } from "../graph/graph.module.js";
 import { HealthController } from "./health.controller.js";
 import { HealthService } from "./health.service.js";
 
+/**
+ * Phase 6a (#235): dropped the `GraphModule` import. `HealthService`
+ * only injected `SQLiteService` from the graph side, and SQLite
+ * now lives in the @Global PlatformModule. Health has no domain
+ * dependencies — it just hosts the `/health` endpoint that probes
+ * the DB.
+ */
 @Module({
-  imports: [GraphModule],
+  imports: [],
   controllers: [HealthController],
   providers: [HealthService],
 })

--- a/src/modules/health/health.service.ts
+++ b/src/modules/health/health.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { SQLiteService } from "../graph/sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 
 @Injectable()
 export class HealthService {

--- a/src/modules/planning/context.service.ts
+++ b/src/modules/planning/context.service.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { queryBlocked, queryFrontier } from "../../lib/manifest-core.js";
 import { EdgesService } from "../graph/edges.service.js";
-import { SQLiteService } from "../graph/sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import { WorkItemsService } from "../graph/work-items.service.js";
 import type { EdgeRecord, WorkItemRecord } from "../graph/types.js";
 import { MemoryService } from "./memory.service.js";

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -17,7 +17,7 @@ import { WorkItemDeletedHandler } from "./work-item-deleted.handler.js";
  * PlansModule, so no forwardRef cycles.
  */
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), forwardRef(() => SettingsModule)],
+  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), SettingsModule],
   controllers: [PlansController],
   providers: [
     PlansService,

--- a/src/modules/settings/settings.module.ts
+++ b/src/modules/settings/settings.module.ts
@@ -1,11 +1,20 @@
-import { forwardRef, Module } from "@nestjs/common";
-import { GraphModule } from "../graph/graph.module.js";
+import { Module } from "@nestjs/common";
 import { ModelRegistryService } from "./model-registry.service.js";
 import { SettingsController } from "./settings.controller.js";
 import { SettingsService } from "./settings.service.js";
 
+/**
+ * Phase 6a (#235): `SettingsModule` no longer imports `GraphModule`.
+ * `SettingsService` only injected `SQLiteService` from the graph side,
+ * and after Phase 6a that comes from the @Global PlatformModule
+ * (src/platform/) so Settings has zero domain-module dependencies.
+ * Dropping the forward-referenced Graph import here is the first leg
+ * of the −3 forwardRef cleanup — it unblocks the follow-up unwraps
+ * on ExecutionModule and PlansModule where the forward-referenced
+ * Settings import defended cycles that went through Settings → Graph.
+ */
 @Module({
-  imports: [forwardRef(() => GraphModule)],
+  imports: [],
   controllers: [SettingsController],
   providers: [SettingsService, ModelRegistryService],
   exports: [SettingsService, ModelRegistryService],

--- a/src/modules/settings/settings.service.ts
+++ b/src/modules/settings/settings.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 import type { Api, Model } from "@mariozechner/pi-ai";
-import { SQLiteService } from "../graph/sqlite.service.js";
+import { SQLiteService } from "../../platform/sqlite.service.js";
 import { getConfig } from "../../config.js";
 import { ModelRegistryService } from "./model-registry.service.js";
 

--- a/src/platform/platform.module.ts
+++ b/src/platform/platform.module.ts
@@ -1,11 +1,12 @@
 import { Global, Module } from "@nestjs/common";
 import { CqrsModule } from "@nestjs/cqrs";
+import { SQLiteService } from "./sqlite.service.js";
 
 /**
  * Global platform infrastructure. Every feature module gets access to
- * CommandBus, EventBus, and QueryBus (from @nestjs/cqrs) without having
- * to import PlatformModule explicitly — the @Global() decorator makes
- * its exports available to every module.
+ * CommandBus, EventBus, QueryBus (from @nestjs/cqrs) and SQLiteService
+ * without having to import PlatformModule explicitly — the @Global()
+ * decorator makes its exports available to every module.
  *
  * Feature modules MUST NOT import other feature modules directly.
  * Cross-context communication routes through:
@@ -15,12 +16,20 @@ import { CqrsModule } from "@nestjs/cqrs";
  *   - EventBus.publish(new SomethingHappenedEvent(...))  — when N
  *     subscribers react to a domain fact, fire-and-forget
  *
- * See docs/proposals/phase-0-platform-bus.md for the conventions the bus
- * imposes and the rationale for the module star-shape.
+ * Phase 6a (#235) adds `SQLiteService` here. It used to live in
+ * `GraphModule` but `SQLiteService` is infrastructure, not domain —
+ * placing it in the global platform removes the transitive
+ * `Settings → Graph`, `Execution → Settings`, `Plans → Settings`
+ * forwardRef cycles that depended on Graph being the DB host.
+ *
+ * See docs/proposals/phase-0-platform-bus.md for the CQRS bus
+ * conventions and docs/proposals/phase-6-platform-module.md for
+ * the SQLite relocation rationale.
  */
 @Global()
 @Module({
   imports: [CqrsModule],
-  exports: [CqrsModule],
+  providers: [SQLiteService],
+  exports: [CqrsModule, SQLiteService],
 })
 export class PlatformModule {}

--- a/src/platform/sqlite.service.ts
+++ b/src/platform/sqlite.service.ts
@@ -1,8 +1,17 @@
 import { Injectable } from "@nestjs/common";
 import type { Database as DatabaseType } from "better-sqlite3";
-import { getConfig } from "../../config.js";
-import { hasSchema, initManifest, isHealthy } from "../../lib/manifest-core.js";
+import { getConfig } from "../config.js";
+import { hasSchema, initManifest, isHealthy } from "../lib/manifest-core.js";
 
+/**
+ * Phase 6a (#235): moved from `src/modules/graph/sqlite.service.ts`
+ * to `src/platform/sqlite.service.ts`. `SQLiteService` is
+ * infrastructure — a 135-line wrapper around `better-sqlite3` +
+ * startup schema migration — not a graph concern. Placing it in the
+ * `@Global()` PlatformModule removes the last transitive dependency
+ * that required `Settings → Graph`, `Execution → Settings`, and
+ * `Plans → Settings` forwardRefs. See `docs/proposals/phase-6-platform-module.md`.
+ */
 @Injectable()
 export class SQLiteService {
   private readonly manifestPath = getConfig().manifestPath;


### PR DESCRIPTION
## Summary

Phase 6a of the CQRS refactor (#235) — moves \`SQLiteService\` out of \`GraphModule\` and into the already-\`@Global\` \`PlatformModule\` (the CqrsModule host created in Phase 0). \`SQLiteService\` is infrastructure — a 135-line \`better-sqlite3\` wrapper plus a startup schema migration — not a graph concern. Placing it in the global platform breaks three transitive forwardRef cycles that depended on Graph being the DB host.

**forwardRef count: 7 → 4** — the Phase 6a architectural win.

## Key deviation from the proposal doc

The Phase 6 proposal doc suggested creating a new non-\`@Global\` module at \`src/modules/platform/platform.module.ts\` and adding explicit \`imports: [PlatformModule]\` entries to every consumer module (5 of them). The actual \`PlatformModule\` from Phase 0 is \`@Global\` and lives at \`src/platform/platform.module.ts\`.

This PR takes the simpler path: add \`SQLiteService\` to the existing \`@Global\` module. Consumer modules don't need any new \`imports: [PlatformModule]\` boilerplate — \`@Global\` exports are available everywhere automatically. Fewer edits, same architectural outcome.

## Changes

- \`915054a\` refactor(platform): move SQLiteService into global PlatformModule
- \`2b9db90\` refactor(modules): break 3 transitive forwardRef cycles (7 → 4)

### Commit 1: File move + import updates (architecturally neutral)

- **File move:** \`src/modules/graph/sqlite.service.ts\` → \`src/platform/sqlite.service.ts\`. Body unchanged; only the relative paths to \`config.js\` and \`manifest-core.js\` updated.
- **PlatformModule update:** now provides + exports \`SQLiteService\` alongside \`CqrsModule\`.
- **GraphModule shrink:** drops \`SQLiteService\` from providers + exports. Graph's own services still inject it — they get it via the global platform without any module-level import.
- **8 consumer source files:** import path updates only.
  - 4 graph siblings: \`./sqlite.service.js\` → \`../../platform/sqlite.service.js\`
  - 4 cross-module: \`../graph/sqlite.service.js\` → \`../../platform/sqlite.service.js\`
- **4 test files:** same path updates. All use \`Object.create(SQLiteService.prototype)\` harnesses so the change is path-only.

### Commit 2: ForwardRef cleanup (the architectural win)

- **SettingsModule** drops the \`forwardRef(() => GraphModule)\` import entry entirely. \`SettingsService\` only injected \`SQLiteService\` from the graph side; after Phase 6a that comes from \`@Global PlatformModule\` so Settings has zero domain-module dependencies.
- **HealthModule** drops the direct \`GraphModule\` import entirely. \`HealthService\` only injected \`SQLiteService\`; same reasoning. Health is now a zero-dep module.
- **ExecutionModule:** \`forwardRef(() => SettingsModule)\` → direct \`SettingsModule\`. The cycle \`Execution → Settings → Graph → Execution\` is gone because Settings → Graph no longer exists.
- **PlansModule:** same unwrap.

## forwardRef audit

**Before:** 7
\`\`\`
execution.module.ts:   3 (GraphModule, GitHubModule, SettingsModule)
plans.module.ts:       3 (GraphModule, GitHubModule, SettingsModule)
settings.module.ts:    1 (GraphModule)
\`\`\`

**After:** 4
\`\`\`
execution.module.ts:   2 (GraphModule, GitHubModule)
plans.module.ts:       2 (GraphModule, GitHubModule)
\`\`\`

The 4 remaining forwardRefs defend real cycles (Execution ↔ Graph, Execution ↔ GitHub, Plans ↔ Graph, Plans ↔ GitHub). They're Phase 9 audit targets. Phase 6b (#236) will relocate \`GitHubBatchCache\` / \`GitHubCacheScheduler\` into \`GitHubModule\`, which doesn't remove any forwardRefs on its own — that's purely organizational.

## Test plan

- [x] \`npm run check\` clean (tsc --noEmit)
- [x] \`npx vitest run --no-file-parallelism\` — 561 / 561 tests pass
- [x] \`npm run build:web\` clean
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\` → **4** (down from 7)
- [x] \`grep -rn 'from.*graph/sqlite' src/\` → only the docstring reference in \`src/platform/sqlite.service.ts\`
- [ ] Manual smoke test: server boots, \`curl /health\` returns a healthy envelope, startup schema migration runs without errors (verify via dev server tail)

## Affected files

- \`src/platform/platform.module.ts\` — adds SQLiteService provider + export
- \`src/platform/sqlite.service.ts\` — new (moved from graph)
- \`src/modules/graph/sqlite.service.ts\` — deleted
- \`src/modules/graph/graph.module.ts\` — drops SQLiteService
- 4 graph siblings + 4 cross-module consumers — import path updates
- 4 test files — import path updates
- \`src/modules/settings/settings.module.ts\` — drops GraphModule
- \`src/modules/health/health.module.ts\` — drops GraphModule
- \`src/modules/execution/execution.module.ts\` — unwraps Settings forwardRef
- \`src/modules/plans/plans.module.ts\` — unwraps Settings forwardRef

## Follow-ups

- **Phase 6b (#236):** relocate \`GitHubBatchCache\` + \`GitHubCacheScheduler\` from ExecutionModule to GitHubModule. No forwardRef delta — purely organizational.
- **Phase 9 audit:** unwrap the 4 remaining forwardRefs in \`ExecutionModule\` and \`PlansModule\` once Phase 6b + Phase 8 land and the remaining cycles can be walked.

Closes #235.