### PR TITLE
refactor(planning): extract planner tools into a registry (Phase 7) (#227)

### DIFF
--- a/src/modules/planning/__tests__/planning.service.test.ts
+++ b/src/modules/planning/__tests__/planning.service.test.ts
@@ -31,6 +31,8 @@ vi.mock("../../reconciliation/reconciliation.service.js", () => ({
 import { checkIdAlignment } from "../../graph/types.js";
 import { PlanningService } from "../planning.service.js";
 import { ProposalStateService } from "../proposal-state.service.js";
+import { createGitHubCreateIssueTool } from "../tools/github-create-issue.tool.js";
+import type { PlanningToolDeps } from "../tools/types.js";
 import type { PlanningMutationProposal } from "../types.js";
 
 type CreatedIssue = {
@@ -69,10 +71,26 @@ function makePlanningService(createdIssues: CreatedIssue[]) {
 
   (service as any).currentTurnId = "turn_0001";
 
+  // Phase 7 (#227): the github_create_issue tool is now a pure factory
+  // that takes a typed deps bag instead of a method on PlanningService.
+  // Build the bag with the same mocks the service got so the existing
+  // proposal-staging assertions exercise the real tool body.
+  const deps: PlanningToolDeps = {
+    graphService,
+    memoryService,
+    subAgentService: {} as never,
+    githubService,
+    reconciliationService: {} as never,
+    proposalState,
+    emitStudioEvent: () => {},
+    buildProposalDefaults: () => ({ currentTurnId: "turn_0001", sessionId: "planning-root" }),
+    getCurrentTurnId: () => "turn_0001",
+  };
+
   return {
     service,
     createIssue,
-    tool: (service as any).createGitHubCreateIssueTool(),
+    tool: createGitHubCreateIssueTool(deps),
   };
 }
 

--- a/src/modules/planning/__tests__/planning.service.test.ts
+++ b/src/modules/planning/__tests__/planning.service.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../reconciliation/reconciliation.service.js", () => ({
 
 import { checkIdAlignment } from "../../graph/types.js";
 import { PlanningService } from "../planning.service.js";
+import { ProposalStateService } from "../proposal-state.service.js";
 import type { PlanningMutationProposal } from "../types.js";
 
 type CreatedIssue = {
@@ -45,15 +46,25 @@ function makePlanningService(createdIssues: CreatedIssue[]) {
     createIssue.mockResolvedValueOnce(issue);
   }
 
+  const graphService = { getGraph: () => ({ graph_version: "7" }) } as never;
+  const githubService = { createIssue } as never;
+  const memoryService = {} as never;
+  // Phase 7 (#227): proposalState owns the staging/alias state that
+  // PlanningService used to manage inline. Construct a real instance
+  // with the same mocks so the existing assertions about issue-id
+  // alias resolution and grouped staging keep working.
+  const proposalState = new ProposalStateService(graphService, githubService, memoryService);
+
   const service = new PlanningService(
     {} as never,
-    { getGraph: () => ({ graph_version: "7" }) } as never,
+    graphService,
+    {} as never,
+    memoryService,
+    {} as never,
+    githubService,
     {} as never,
     {} as never,
-    {} as never,
-    { createIssue } as never,
-    {} as never,
-    {} as never,
+    proposalState,
   );
 
   (service as any).currentTurnId = "turn_0001";

--- a/src/modules/planning/planning.module.ts
+++ b/src/modules/planning/planning.module.ts
@@ -6,13 +6,14 @@ import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
 import { PlanningController } from "./planning.controller.js";
 import { PlanningService } from "./planning.service.js";
+import { ProposalStateService } from "./proposal-state.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 import { ReconciliationModule } from "../reconciliation/reconciliation.module.js";
 
 @Module({
   imports: [GraphModule, GitHubModule, ReconciliationModule, SettingsModule],
   controllers: [PlanningController],
-  providers: [PlanningService, ContextService, MemoryService, SubAgentService],
-  exports: [PlanningService, ContextService, MemoryService, SubAgentService],
+  providers: [PlanningService, ContextService, MemoryService, ProposalStateService, SubAgentService],
+  exports: [PlanningService, ContextService, MemoryService, ProposalStateService, SubAgentService],
 })
 export class PlanningModule {}

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -20,6 +20,7 @@ import {
 } from "../graph/types.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
+import { ProposalStateService } from "./proposal-state.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 import { ReconciliationService } from "../reconciliation/reconciliation.service.js";
 import { SettingsService } from "../settings/settings.service.js";
@@ -59,10 +60,6 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private readonly streamId = "planning-root";
   private readonly eventSubject = new Subject<MessageEvent>();
   private readonly sessionDir = resolve(process.cwd(), getConfig().planningSessionDir);
-  private readonly proposals = new Map<string, PlanningMutationProposal>();
-  private readonly memoryChanges = new Map<string, PlanningMemoryChange>();
-  private readonly githubSyncs = new Map<string, GitHubSyncProposal>();
-  private readonly issueIdAliases = new Map<string, string>();
 
   private session?: AgentSession;
   private sessionPromise?: Promise<AgentSession>;
@@ -70,13 +67,6 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private eventCounter = 0;
   private turnCounter = 0;
   private currentTurnId: string | null = null;
-  private activeProposalId: string | null = null;
-  private proposalCounter = 0;
-  private lastCommitResult: PlanningGraphCommitResult | null = null;
-  private activeMemoryChangeId: string | null = null;
-  private lastMemoryWriteResult: PlanningMemoryWriteResult | null = null;
-  private activeGitHubSyncId: string | null = null;
-  private lastGitHubSyncResult: GitHubSyncResult | null = null;
 
   constructor(
     @Inject(ContextService) private readonly contextService: ContextService,
@@ -87,6 +77,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     @Inject(GitHubService) private readonly githubService: GitHubService,
     @Inject(ReconciliationService) private readonly reconciliationService: ReconciliationService,
     @Inject(SettingsService) private readonly settingsService: SettingsService,
+    @Inject(ProposalStateService) private readonly proposalState: ProposalStateService,
   ) {}
 
   async onModuleInit() {
@@ -116,12 +107,12 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       session_file: session.sessionFile,
       is_streaming: session.isStreaming,
       messages: this.projectSessionEntries(session.sessionManager.getEntries()),
-      active_proposal: this.getActiveProposal(),
-      last_commit_result: this.lastCommitResult,
-      active_memory_change: this.getActiveMemoryChange(),
-      last_memory_write_result: this.lastMemoryWriteResult,
-      active_github_sync: this.getActiveGitHubSync(),
-      last_github_sync_result: this.lastGitHubSyncResult,
+      active_proposal: this.proposalState.getActiveProposal(),
+      last_commit_result: this.proposalState.getLastCommitResult(),
+      active_memory_change: this.proposalState.getActiveMemoryChange(),
+      last_memory_write_result: this.proposalState.getLastMemoryWriteResult(),
+      active_github_sync: this.proposalState.getActiveGitHubSync(),
+      last_github_sync_result: this.proposalState.getLastGitHubSyncResult(),
       memory: this.memoryService.read(),
       recent_subagent_runs: this.subAgentService.listRecentRuns(),
     };
@@ -172,13 +163,13 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       throw new BadRequestException("approved_mutation_ids must contain at least one mutation id");
     }
 
-    const proposal = this.proposals.get(proposalId);
+    const proposal = this.proposalState.getProposal(proposalId);
     if (!proposal) {
       throw new BadRequestException(`Unknown proposal: ${proposalId}`);
     }
 
     const selectedMutations = approvedIds.map((id) => {
-      const mutation = proposal.mutations.find((candidate) => candidate.id === id);
+      const mutation = proposal.mutations.find((candidate: PlanningMutationProposalMutation) => candidate.id === id);
       if (!mutation) {
         throw new BadRequestException(`Unknown mutation id for proposal ${proposalId}: ${id}`);
       }
@@ -192,8 +183,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     });
 
     const activeProposal = result.status === "applied"
-      ? this.updateActiveProposalAfterApply(proposal, approvedIds)
-      : this.getActiveProposal();
+      ? this.proposalState.updateActiveProposalAfterApply(proposal, approvedIds)
+      : this.proposalState.getActiveProposal();
 
     const commitResult: PlanningGraphCommitResult = {
       proposal_id: proposal.proposal_id,
@@ -202,7 +193,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       active_proposal: activeProposal,
     };
 
-    this.lastCommitResult = commitResult;
+    this.proposalState.setLastCommitResult(commitResult);
     this.emitStudioEvent("graph_commit_result", commitResult);
 
     return commitResult;
@@ -219,15 +210,15 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       throw new BadRequestException("approved_edit_ids must contain at least one edit id");
     }
 
-    const change = this.memoryChanges.get(changeId);
+    const change = this.proposalState.getMemoryChange(changeId);
     if (!change) {
       throw new BadRequestException(`Unknown memory change: ${changeId}`);
     }
 
     const { result, memory } = this.memoryService.applyChange(change, approvedEditIds);
     const activeMemoryChange = result.status === "applied"
-      ? this.updateActiveMemoryChangeAfterApply(change, approvedEditIds)
-      : this.getActiveMemoryChange();
+      ? this.proposalState.updateActiveMemoryChangeAfterApply(change, approvedEditIds)
+      : this.proposalState.getActiveMemoryChange();
 
     const writeResult: PlanningMemoryWriteResult = {
       change_id: change.change_id,
@@ -237,7 +228,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       memory,
     };
 
-    this.lastMemoryWriteResult = writeResult;
+    this.proposalState.setLastMemoryWriteResult(writeResult);
     this.emitStudioEvent("memory_write_result", writeResult);
     return writeResult;
   }
@@ -253,15 +244,15 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       throw new BadRequestException("approved_operation_ids must contain at least one operation id");
     }
 
-    const proposal = this.githubSyncs.get(syncId);
+    const proposal = this.proposalState.getGitHubSync(syncId);
     if (!proposal) {
       throw new BadRequestException(`Unknown GitHub sync proposal: ${syncId}`);
     }
 
     const { result, issue } = await this.githubService.applySyncProposal(proposal, approvedOperationIds);
     const activeGitHubSync = result.status === "applied"
-      ? this.updateActiveGitHubSyncAfterApply(proposal, approvedOperationIds)
-      : this.getActiveGitHubSync();
+      ? this.proposalState.updateActiveGitHubSyncAfterApply(proposal, approvedOperationIds)
+      : this.proposalState.getActiveGitHubSync();
 
     const syncResult: GitHubSyncResult = {
       sync_id: proposal.sync_id,
@@ -271,7 +262,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       issue,
     };
 
-    this.lastGitHubSyncResult = syncResult;
+    this.proposalState.setLastGitHubSyncResult(syncResult);
     this.emitStudioEvent("github_sync_result", syncResult);
     return syncResult;
   }
@@ -328,7 +319,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
   private handleSessionEvent(event: AgentSessionEvent) {
     if (event.type === "turn_start") {
       this.currentTurnId = `turn_${String(++this.turnCounter).padStart(4, "0")}`;
-      this.issueIdAliases.clear();
+      this.proposalState.resetTurnState();
     }
 
     if (!this.isStreamableEvent(event.type)) {
@@ -353,7 +344,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
 
     if (event.type === "turn_end") {
       this.currentTurnId = null;
-      this.issueIdAliases.clear();
+      this.proposalState.resetTurnState();
     }
   }
 
@@ -436,10 +427,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         })),
       }),
       execute: async (_toolCallId, params: ProposeMutationsToolInput) => {
-        const proposal = this.normalizeProposal(params);
-        this.proposals.set(proposal.proposal_id, proposal);
-        this.activeProposalId = proposal.proposal_id;
-        this.lastCommitResult = null;
+        const proposal = this.proposalState.normalizeProposal(params, this.buildProposalDefaults());
+        this.proposalState.setActiveProposal(proposal);
         this.emitStudioEvent("mutation_proposal", { proposal });
 
         return {
@@ -533,10 +522,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         })),
       }),
       execute: async (_toolCallId, params: ProposeMemoryWriteToolInput) => {
-        const change = this.normalizeMemoryChange(params);
-        this.memoryChanges.set(change.change_id, change);
-        this.activeMemoryChangeId = change.change_id;
-        this.lastMemoryWriteResult = null;
+        const change = this.proposalState.normalizeMemoryChange(params, this.buildProposalDefaults());
+        this.proposalState.setActiveMemoryChange(change);
         this.emitStudioEvent("memory_change_proposal", { change });
 
         return {
@@ -640,16 +627,16 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
           labels: params.labels,
         });
 
-        const existingProposal = this.getActiveProposalForAccumulation();
-        const stagedWorkItemIds = this.getStagedWorkItemIds(existingProposal);
+        const existingProposal = this.proposalState.getActiveProposalForAccumulation(this.currentTurnId);
+        const stagedWorkItemIds = this.proposalState.getStagedWorkItemIds(existingProposal);
         const requestedWorkItemId = params.work_item_id?.trim();
         const workItemId = deriveIssueWorkItemId(created.number);
-        this.rememberIssueIdAlias(requestedWorkItemId, workItemId, stagedWorkItemIds);
+        this.proposalState.rememberIssueIdAlias(requestedWorkItemId, workItemId, stagedWorkItemIds);
 
         const groupId = `issue-${created.number}`;
-        const parentId = this.resolveIssueIdAlias(params.parent_id, stagedWorkItemIds);
+        const parentId = this.proposalState.resolveIssueIdAlias(params.parent_id, stagedWorkItemIds);
         const dependsOnIds = params.depends_on_ids
-          ?.map((depId) => this.resolveIssueIdAlias(depId, stagedWorkItemIds))
+          ?.map((depId) => this.proposalState.resolveIssueIdAlias(depId, stagedWorkItemIds))
           .filter((depId): depId is string => Boolean(depId));
 
         const mutations: ProposeMutationsToolInput["mutations"] = [
@@ -705,23 +692,21 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         let proposal: PlanningMutationProposal;
 
         if (existingProposal) {
-          proposal = this.accumulateMutations(
+          proposal = this.proposalState.accumulateMutations(
             existingProposal,
             mutations,
             `+ GitHub issue #${created.number}: ${created.title}`,
           );
         } else {
-          proposal = this.normalizeProposal({
+          proposal = this.proposalState.normalizeProposal({
             summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
             mutations,
-          });
+          }, this.buildProposalDefaults());
         }
 
-        proposal = this.rewriteProposalIssueAliases(proposal);
+        proposal = this.proposalState.rewriteProposalIssueAliases(proposal);
 
-        this.proposals.set(proposal.proposal_id, proposal);
-        this.activeProposalId = proposal.proposal_id;
-        this.lastCommitResult = null;
+        this.proposalState.setActiveProposal(proposal);
         this.emitStudioEvent("mutation_proposal", { proposal });
 
         const summary = `Created GitHub issue #${created.number} (${created.url}) and staged graph proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s) for browser approval.`;
@@ -760,10 +745,8 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         work_item_id: Type.String(),
       }),
       execute: async (_toolCallId, params: GitHubSyncToolInput) => {
-        const sync = await this.normalizeGitHubSync(params);
-        this.githubSyncs.set(sync.sync_id, sync);
-        this.activeGitHubSyncId = sync.sync_id;
-        this.lastGitHubSyncResult = null;
+        const sync = await this.proposalState.normalizeGitHubSync(params, this.buildProposalDefaults());
+        this.proposalState.setActiveGitHubSync(sync);
         this.emitStudioEvent("github_sync_proposal", { sync });
 
         return {
@@ -798,108 +781,6 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
         };
       },
     });
-  }
-
-  private normalizeProposal(input: ProposeMutationsToolInput): PlanningMutationProposal {
-    const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
-    const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}_${++this.proposalCounter}`;
-    const createdAt = input.created_at?.trim() || this.now();
-
-    return {
-      proposal_id: proposalId,
-      created_at: createdAt,
-      source: {
-        agent: input.source?.agent?.trim() || "root-planner",
-        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
-        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
-      },
-      context: {
-        ...input.context,
-        based_on_graph_version: graphVersion,
-      },
-      summary: input.summary.trim(),
-      mutations: input.mutations.map((mutation, index) => this.normalizeProposalMutation(mutation, index)),
-    };
-  }
-
-  private normalizeProposalMutation(
-    mutation: ProposeMutationsToolInput["mutations"][number],
-    index: number,
-  ): PlanningMutationProposalMutation {
-    const payload = mutation.payload && typeof mutation.payload === "object"
-      ? { ...(mutation.payload as Record<string, unknown>) }
-      : undefined;
-
-    const entityId = mutation.entity_id
-      ?? (typeof payload?.id === "string" ? payload.id : undefined)
-      ?? (mutation.type === "create_edge" && payload
-        ? `${String(payload.from_id ?? "")}:${String(payload.rel ?? "")}:${String(payload.to_id ?? "")}`
-        : undefined);
-
-    return {
-      id: mutation.id?.trim() || `m${index + 1}`,
-      type: mutation.type,
-      entity_id: entityId,
-      payload,
-      rationale: mutation.rationale.trim(),
-      validation: mutation.validation,
-      group_id: mutation.group_id,
-      depends_on_mutation_ids: mutation.depends_on_mutation_ids,
-    };
-  }
-
-  private normalizeMemoryChange(input: ProposeMemoryWriteToolInput): PlanningMemoryChange {
-    const memory = this.memoryService.read();
-    const changeId = input.change_id?.trim() || `mem_${Date.now()}`;
-    const createdAt = input.created_at?.trim() || this.now();
-
-    return {
-      change_id: changeId,
-      created_at: createdAt,
-      source: {
-        agent: input.source?.agent?.trim() || "root-planner",
-        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
-        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
-      },
-      summary: input.summary.trim(),
-      based_on_content_hash: memory.content_hash,
-      edits: input.edits.map((edit, index) => this.normalizeMemoryEdit(edit, index)),
-    };
-  }
-
-  private async normalizeGitHubSync(input: GitHubSyncToolInput): Promise<GitHubSyncProposal> {
-    const staged = await this.githubService.stageManagedBlockSync(input.work_item_id);
-    return {
-      sync_id: input.sync_id?.trim() || `ghsync_${Date.now()}`,
-      created_at: input.created_at?.trim() || this.now(),
-      source: {
-        agent: input.source?.agent?.trim() || "root-planner",
-        turn_id: input.source?.turn_id?.trim() || this.currentTurnId,
-        session_id: input.source?.session_id?.trim() || this.session?.sessionId || "planning-root",
-      },
-      summary: input.summary.trim(),
-      issue: {
-        repo: staged.issue.repo,
-        issue_number: staged.issue.number,
-        issue_url: staged.issue.url,
-        title: staged.issue.title,
-      },
-      work_item_id: staged.work_item_id,
-      based_on_body_hash: staged.based_on_body_hash,
-      operations: staged.operations,
-    };
-  }
-
-  private normalizeMemoryEdit(edit: ProposeMemoryWriteToolInput["edits"][number], index: number): PlanningMemoryEdit {
-    return {
-      id: edit.id?.trim() || `e${index + 1}`,
-      kind: edit.kind,
-      summary: edit.summary.trim(),
-      rationale: edit.rationale.trim(),
-      old_text: edit.old_text,
-      new_text: edit.new_text,
-      target_heading: edit.target_heading,
-    };
   }
 
   private toGraphMutation(mutation: PlanningMutationProposalMutation): GraphMutation {
@@ -989,268 +870,25 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private updateActiveProposalAfterApply(
-    proposal: PlanningMutationProposal,
-    approvedIds: string[],
-  ): PlanningMutationProposal | null {
-    const remainingMutations = proposal.mutations.filter((mutation) => !approvedIds.includes(mutation.id));
-
-    if (remainingMutations.length === 0) {
-      this.proposals.delete(proposal.proposal_id);
-      if (this.activeProposalId === proposal.proposal_id) {
-        this.activeProposalId = null;
-      }
-      return null;
-    }
-
-    const nextProposal: PlanningMutationProposal = {
-      ...proposal,
-      summary: `${proposal.summary} (${remainingMutations.length} mutation(s) remaining)`,
-      mutations: remainingMutations,
-    };
-    this.proposals.set(nextProposal.proposal_id, nextProposal);
-    this.activeProposalId = nextProposal.proposal_id;
-    return nextProposal;
-  }
-
-  private updateActiveMemoryChangeAfterApply(
-    change: PlanningMemoryChange,
-    approvedEditIds: string[],
-  ): PlanningMemoryChange | null {
-    const remainingEdits = change.edits.filter((edit) => !approvedEditIds.includes(edit.id));
-
-    if (remainingEdits.length === 0) {
-      this.memoryChanges.delete(change.change_id);
-      if (this.activeMemoryChangeId === change.change_id) {
-        this.activeMemoryChangeId = null;
-      }
-      return null;
-    }
-
-    const nextChange: PlanningMemoryChange = {
-      ...change,
-      summary: `${change.summary} (${remainingEdits.length} edit(s) remaining)`,
-      edits: remainingEdits,
-      based_on_content_hash: this.memoryService.read().content_hash,
-    };
-    this.memoryChanges.set(nextChange.change_id, nextChange);
-    this.activeMemoryChangeId = nextChange.change_id;
-    return nextChange;
-  }
-
-  private updateActiveGitHubSyncAfterApply(
-    proposal: GitHubSyncProposal,
-    approvedOperationIds: string[],
-  ): GitHubSyncProposal | null {
-    const remainingOperations = proposal.operations.filter((operation) => !approvedOperationIds.includes(operation.id));
-
-    if (remainingOperations.length === 0) {
-      this.githubSyncs.delete(proposal.sync_id);
-      if (this.activeGitHubSyncId === proposal.sync_id) {
-        this.activeGitHubSyncId = null;
-      }
-      return null;
-    }
-
-    const nextProposal: GitHubSyncProposal = {
-      ...proposal,
-      summary: `${proposal.summary} (${remainingOperations.length} operation(s) remaining)`,
-      operations: remainingOperations,
-    };
-    this.githubSyncs.set(nextProposal.sync_id, nextProposal);
-    this.activeGitHubSyncId = nextProposal.sync_id;
-    return nextProposal;
-  }
-
   dismissAllProposals(): { dismissed_proposal_ids: string[]; dismissed_memory_change_ids: string[]; dismissed_github_sync_ids: string[] } {
-    const dismissedProposalIds = this.activeProposalId ? [this.activeProposalId] : [];
-    const dismissedMemoryChangeIds = this.activeMemoryChangeId ? [this.activeMemoryChangeId] : [];
-    const dismissedGitHubSyncIds = this.activeGitHubSyncId ? [this.activeGitHubSyncId] : [];
-
-    this.activeProposalId = null;
-    this.lastCommitResult = null;
-    this.activeMemoryChangeId = null;
-    this.lastMemoryWriteResult = null;
-    this.activeGitHubSyncId = null;
-    this.lastGitHubSyncResult = null;
-
-    this.logger.log(`Dismissed proposals: ${dismissedProposalIds.length} mutation, ${dismissedMemoryChangeIds.length} memory, ${dismissedGitHubSyncIds.length} GitHub sync`);
-
-    return {
-      dismissed_proposal_ids: dismissedProposalIds,
-      dismissed_memory_change_ids: dismissedMemoryChangeIds,
-      dismissed_github_sync_ids: dismissedGitHubSyncIds,
-    };
-  }
-
-  private getActiveProposal(): PlanningMutationProposal | null {
-    return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
-  }
-
-  /**
-   * Return the active proposal only if it was created in the current turn
-   * and has not yet been committed — suitable for accumulating additional
-   * mutations from a second github_create_issue call in the same flow.
-   */
-  private getActiveProposalForAccumulation(): PlanningMutationProposal | null {
-    const proposal = this.getActiveProposal();
-    if (!proposal || !this.currentTurnId) {
-      return null;
-    }
-    // Only accumulate when the existing proposal belongs to this turn
-    if (proposal.source.turn_id !== this.currentTurnId) {
-      return null;
-    }
-    return proposal;
-  }
-
-  /**
-   * Append new mutations to an existing proposal, re-numbering their IDs
-   * to avoid collisions. Returns the updated (same-ID) proposal.
-   */
-  private accumulateMutations(
-    existing: PlanningMutationProposal,
-    newMutations: ProposeMutationsToolInput["mutations"],
-    summaryAppendix: string,
-  ): PlanningMutationProposal {
-    // Find the highest existing numeric suffix to avoid ID collisions
-    const maxExistingIndex = existing.mutations.reduce((max, mutation) => {
-      const match = mutation.id.match(/^m(\d+)$/);
-      return match ? Math.max(max, Number(match[1])) : max;
-    }, 0);
-
-    let nextIndex = maxExistingIndex + 1;
-    const normalized = newMutations.map((mutation) =>
-      this.normalizeProposalMutation(
-        { ...mutation, id: `m${nextIndex++}` },
-        0, // index param unused when id is pre-set
-      ),
+    const result = this.proposalState.dismissAll();
+    this.logger.log(
+      `Dismissed proposals: ${result.dismissed_proposal_ids.length} mutation, ${result.dismissed_memory_change_ids.length} memory, ${result.dismissed_github_sync_ids.length} GitHub sync`,
     );
+    return result;
+  }
 
+  /**
+   * Phase 7 (#227): passes the current turn + session context into
+   * ProposalStateService's normalize* helpers so they can stamp the
+   * `source` envelope on new proposals. Grouped in one helper so tool
+   * bodies don't need to know the shape.
+   */
+  private buildProposalDefaults(): { currentTurnId: string | null; sessionId: string } {
     return {
-      ...existing,
-      summary: `${existing.summary} ${summaryAppendix}`,
-      mutations: [...existing.mutations, ...normalized],
+      currentTurnId: this.currentTurnId,
+      sessionId: this.session?.sessionId ?? "planning-root",
     };
-  }
-
-  private rememberIssueIdAlias(
-    requestedId: string | null | undefined,
-    finalId: string,
-    stagedWorkItemIds: ReadonlySet<string> = new Set(),
-  ) {
-    const placeholderId = requestedId?.trim();
-    if (!placeholderId || placeholderId === finalId) {
-      return;
-    }
-    // If the requested ID is already staged as a canonical work item from an
-    // earlier create, or already resolves to one, treat that existing staged ID
-    // as authoritative and do not overwrite the alias chain with a later guess.
-    if (stagedWorkItemIds.has(placeholderId)) {
-      return;
-    }
-    const existingResolvedId = this.resolveIssueIdAlias(placeholderId, stagedWorkItemIds);
-    if (existingResolvedId !== placeholderId && stagedWorkItemIds.has(existingResolvedId)) {
-      return;
-    }
-    this.issueIdAliases.set(placeholderId, finalId);
-  }
-
-  private resolveIssueIdAlias(id: string | null | undefined, stopIds: ReadonlySet<string> = new Set()): string {
-    const trimmed = id?.trim();
-    if (!trimmed) {
-      return "";
-    }
-    if (stopIds.has(trimmed)) {
-      return trimmed;
-    }
-
-    let resolved = trimmed;
-    const seen = new Set<string>();
-
-    while (this.issueIdAliases.has(resolved) && !seen.has(resolved)) {
-      seen.add(resolved);
-      const next = this.issueIdAliases.get(resolved) ?? resolved;
-      resolved = next;
-      if (stopIds.has(resolved)) {
-        break;
-      }
-    }
-
-    return resolved;
-  }
-
-  private getStagedWorkItemIds(proposal: PlanningMutationProposal | null | undefined): Set<string> {
-    const ids = new Set<string>();
-    if (!proposal) {
-      return ids;
-    }
-
-    for (const mutation of proposal.mutations) {
-      if (mutation.type !== "create_work_item") {
-        continue;
-      }
-      if (mutation.entity_id) {
-        ids.add(mutation.entity_id);
-      }
-      if (typeof mutation.payload?.id === "string") {
-        ids.add(mutation.payload.id);
-      }
-    }
-
-    return ids;
-  }
-
-  private rewriteProposalIssueAliases(proposal: PlanningMutationProposal): PlanningMutationProposal {
-    const stagedWorkItemIds = this.getStagedWorkItemIds(proposal);
-    return {
-      ...proposal,
-      mutations: proposal.mutations.map((mutation) => this.rewriteProposalMutationIssueAliases(mutation, stagedWorkItemIds)),
-    };
-  }
-
-  private rewriteProposalMutationIssueAliases(
-    mutation: PlanningMutationProposalMutation,
-    stagedWorkItemIds: ReadonlySet<string>,
-  ): PlanningMutationProposalMutation {
-    const payload = mutation.payload && typeof mutation.payload === "object"
-      ? { ...mutation.payload }
-      : undefined;
-
-    const entityId = mutation.entity_id ? this.resolveIssueIdAlias(mutation.entity_id, stagedWorkItemIds) : mutation.entity_id;
-
-    if (mutation.type === "create_work_item" || mutation.type === "update_work_item") {
-      if (typeof payload?.id === "string") {
-        payload.id = this.resolveIssueIdAlias(payload.id, stagedWorkItemIds);
-      }
-    }
-
-    if (mutation.type === "create_edge") {
-      if (typeof payload?.from_id === "string") {
-        payload.from_id = this.resolveIssueIdAlias(payload.from_id, stagedWorkItemIds);
-      }
-      if (typeof payload?.to_id === "string") {
-        payload.to_id = this.resolveIssueIdAlias(payload.to_id, stagedWorkItemIds);
-      }
-    }
-
-    const rewrittenEntityId = mutation.type === "create_edge" && payload?.from_id && payload?.rel && payload?.to_id
-      ? `${String(payload.from_id)}:${String(payload.rel)}:${String(payload.to_id)}`
-      : entityId;
-
-    return {
-      ...mutation,
-      entity_id: rewrittenEntityId,
-      payload,
-    };
-  }
-
-  private getActiveMemoryChange(): PlanningMemoryChange | null {
-    return this.activeMemoryChangeId ? this.memoryChanges.get(this.activeMemoryChangeId) ?? null : null;
-  }
-
-  private getActiveGitHubSync(): GitHubSyncProposal | null {
-    return this.activeGitHubSyncId ? this.githubSyncs.get(this.activeGitHubSyncId) ?? null : null;
   }
 
   private emitStudioEvent(eventType: string, payload: unknown) {

--- a/src/modules/planning/planning.service.ts
+++ b/src/modules/planning/planning.service.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Inject, Injectable, Logger, MessageEvent, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
-import { Type } from "@sinclair/typebox";
-import { createAgentSession, defineTool, SessionManager, type AgentSession, type AgentSessionEvent, type SessionEntry } from "@mariozechner/pi-coding-agent";
+import { createAgentSession, SessionManager, type AgentSession, type AgentSessionEvent, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { Observable, Subject } from "rxjs";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
@@ -8,15 +7,14 @@ import { getConfig } from "../../config.js";
 import { GitHubService } from "../github/github.service.js";
 import { GraphService } from "../graph/graph.service.js";
 import { GraphWriterService } from "../graph/graph-writer.service.js";
-import {
-  deriveIssueWorkItemId,
-  type CreateEdgeDto,
-  type CreateWorkItemDto,
-  type DeleteEdgeMutation,
-  type DeleteWorkItemMutation,
-  type EdgeRel,
-  type GraphMutation,
-  type UpdateWorkItemDto,
+import type {
+  CreateEdgeDto,
+  CreateWorkItemDto,
+  DeleteEdgeMutation,
+  DeleteWorkItemMutation,
+  EdgeRel,
+  GraphMutation,
+  UpdateWorkItemDto,
 } from "../graph/types.js";
 import { ContextService } from "./context.service.js";
 import { MemoryService } from "./memory.service.js";
@@ -24,34 +22,24 @@ import { ProposalStateService } from "./proposal-state.service.js";
 import { SubAgentService } from "./sub-agent.service.js";
 import { ReconciliationService } from "../reconciliation/reconciliation.service.js";
 import { SettingsService } from "../settings/settings.service.js";
+import { createPlanningTools } from "./tools/tool-registry.js";
+import type { PlanningToolDeps } from "./tools/types.js";
 import type {
   ApproveGitHubSyncDto,
   ApproveMutationProposalDto,
   ApprovePlanningMemoryChangeDto,
   CreateEdgePayload,
   CreateWorkItemPayload,
-  DelegateSubAgentToolInput,
-  GitHubReadToolInput,
-  GitHubSyncProposal,
   GitHubSyncResult,
-  GitHubSyncToolInput,
-  GraphQueryToolInput,
   PlanningGraphCommitResult,
-  PlanningMemoryChange,
-  PlanningMemoryEdit,
   PlanningMemoryWriteResult,
-  PlanningMutationProposal,
   PlanningMutationProposalMutation,
   PlanningSessionSnapshot,
   PlanningSessionTranscriptEntry,
-  ProposeMemoryWriteToolInput,
-  ProposeMutationsToolInput,
   SendAgentMessageDto,
   SendAgentMessageResult,
   StudioSseEnvelope,
   UpdateWorkItemPayload,
-  ReconciliationQueryToolInput,
-  GitHubCreateIssueToolInput,
 } from "./types.js";
 
 @Injectable()
@@ -290,18 +278,7 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
       cwd: process.cwd(),
       sessionManager: SessionManager.continueRecent(process.cwd(), this.sessionDir),
       model: this.settingsService.getSelectedModel(),
-      customTools: [
-        this.createGraphQueryTool(),
-        this.createProposeMutationsTool(),
-        this.createGraphMutateTool(),
-        this.createMemoryReadTool(),
-        this.createMemoryWriteTool(),
-        this.createDelegateSubAgentTool(),
-        this.createGitHubReadTool(),
-        this.createGitHubCreateIssueTool(),
-        this.createGitHubSyncTool(),
-        this.createReconciliationQueryTool(),
-      ],
+      customTools: createPlanningTools(this.buildToolDeps()),
     });
 
     if (modelFallbackMessage) {
@@ -348,439 +325,23 @@ export class PlanningService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  private createGraphQueryTool() {
-    return defineTool({
-      name: "graph_query",
-      label: "Graph Query",
-      description: "Query the Studio planning graph, frontier, or dispatch plan.",
-      promptSnippet: "graph_query: inspect graph, frontier, or dispatch plan data before proposing structural changes.",
-      promptGuidelines: [
-        "Use graph_query to inspect the current graph/frontier/plan before proposing structural graph changes.",
-      ],
-      parameters: Type.Object({
-        query: Type.Union([Type.Literal("graph"), Type.Literal("frontier"), Type.Literal("plan")]),
-        repo: Type.Optional(Type.String()),
-        state: Type.Optional(Type.String()),
-        track: Type.Optional(Type.String()),
-        phase: Type.Optional(Type.String()),
-      }),
-      execute: async (_toolCallId, params: GraphQueryToolInput) => {
-        const result = params.query === "graph"
-          ? this.graphService.getGraph({
-              repo: params.repo,
-              state: params.state,
-              track: params.track,
-              phase: params.phase,
-            })
-          : params.query === "frontier"
-            ? this.graphService.getFrontier(params.repo)
-            : this.graphService.getPlan(params.repo);
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-          details: result,
-        };
-      },
-    });
-  }
-
-  private createProposeMutationsTool() {
-    return defineTool({
-      name: "propose_mutations",
-      label: "Propose Mutations",
-      description: "Stage a structured graph mutation proposal for browser review and approval.",
-      promptSnippet: "propose_mutations: emit a structured mutation proposal envelope for browser approval instead of only describing changes in prose.",
-      promptGuidelines: [
-        "When recommending graph changes, call propose_mutations with a structured proposal envelope that matches the browser approval contract.",
-        "Include a concise summary plus rationale for each mutation so the browser can render reviewable cards.",
-        "Set based_on_graph_version from graph_query results when available.",
-      ],
-      parameters: Type.Object({
-        proposal_id: Type.Optional(Type.String()),
-        created_at: Type.Optional(Type.String()),
-        source: Type.Optional(Type.Object({
-          agent: Type.Optional(Type.String()),
-          turn_id: Type.Optional(Type.String()),
-          session_id: Type.Optional(Type.String()),
-        })),
-        context: Type.Optional(Type.Object({
-          scope: Type.Optional(Type.String()),
-          mode: Type.Optional(Type.Union([Type.Literal("default"), Type.Literal("focused"), Type.Literal("full")])) ,
-          based_on_graph_version: Type.Optional(Type.String()),
-        })),
-        summary: Type.String(),
-        mutations: Type.Array(Type.Object({
-          id: Type.Optional(Type.String()),
-          type: Type.Union([
-            Type.Literal("create_work_item"),
-            Type.Literal("update_work_item"),
-            Type.Literal("create_edge"),
-            Type.Literal("delete_edge"),
-            Type.Literal("delete_work_item"),
-          ]),
-          entity_id: Type.Optional(Type.String()),
-          payload: Type.Optional(Type.Any()),
-          rationale: Type.String(),
-          validation: Type.Optional(Type.Any()),
-          group_id: Type.Optional(Type.String()),
-          depends_on_mutation_ids: Type.Optional(Type.Array(Type.String())),
-        })),
-      }),
-      execute: async (_toolCallId, params: ProposeMutationsToolInput) => {
-        const proposal = this.proposalState.normalizeProposal(params, this.buildProposalDefaults());
-        this.proposalState.setActiveProposal(proposal);
-        this.emitStudioEvent("mutation_proposal", { proposal });
-
-        return {
-          content: [{ type: "text", text: `Staged proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s).` }],
-          details: { proposal },
-        };
-      },
-    });
-  }
-
-  private createGraphMutateTool() {
-    return defineTool({
-      name: "graph_mutate",
-      label: "Graph Mutate",
-      description: "Reserved graph commit tool. In V1, actual commits must go through browser approval.",
-      promptSnippet: "graph_mutate: reserved for approval-backed graph commits; do not call directly in V1.",
-      promptGuidelines: [
-        "Do not call graph_mutate directly in V1. Human approval in the browser is required; use propose_mutations instead.",
-      ],
-      parameters: Type.Object({
-        proposal_id: Type.String(),
-        approved_mutation_ids: Type.Array(Type.String()),
-      }),
-      execute: async (_toolCallId, params: ApproveMutationProposalDto) => ({
-        content: [{
-          type: "text",
-          text: `Direct graph_mutate execution is disabled in V1. Proposal ${params.proposal_id} must be committed from the browser approval UI.`,
-        }],
-        details: {
-          blocked: true,
-          reason: "browser_approval_required",
-          proposal_id: params.proposal_id,
-          approved_mutation_ids: params.approved_mutation_ids,
-        },
-      }),
-    });
-  }
-
-  private createMemoryReadTool() {
-    return defineTool({
-      name: "memory_read",
-      label: "Planning Memory Read",
-      description: "Read the curated durable planning memory file.",
-      promptSnippet: "memory_read: inspect the curated planning memory before proposing durable memory changes.",
-      promptGuidelines: [
-        "Use memory_read before suggesting durable planning-memory edits so you can update the existing curated structure intentionally.",
-      ],
-      parameters: Type.Object({}),
-      execute: async () => {
-        const memory = this.memoryService.read();
-        return {
-          content: [{ type: "text", text: memory.content }],
-          details: memory,
-        };
-      },
-    });
-  }
-
-  private createMemoryWriteTool() {
-    return defineTool({
-      name: "memory_write",
-      label: "Planning Memory Write",
-      description: "Stage targeted planning memory edits for browser approval.",
-      promptSnippet: "memory_write: stage targeted edits to PLANNING_MEMORY.md for browser approval instead of writing directly.",
-      promptGuidelines: [
-        "Use memory_write only for durable, curated planning-memory updates.",
-        "Prefer targeted replacements or section-specific inserts over append-only growth.",
-        "Do not include transcript residue, raw tool output, or broad dumps.",
-      ],
-      parameters: Type.Object({
-        change_id: Type.Optional(Type.String()),
-        created_at: Type.Optional(Type.String()),
-        source: Type.Optional(Type.Object({
-          agent: Type.Optional(Type.String()),
-          turn_id: Type.Optional(Type.String()),
-          session_id: Type.Optional(Type.String()),
-        })),
-        summary: Type.String(),
-        edits: Type.Array(Type.Object({
-          id: Type.Optional(Type.String()),
-          kind: Type.Union([
-            Type.Literal("replace_text"),
-            Type.Literal("insert_after_heading"),
-            Type.Literal("delete_text"),
-          ]),
-          summary: Type.String(),
-          rationale: Type.String(),
-          old_text: Type.Optional(Type.String()),
-          new_text: Type.Optional(Type.String()),
-          target_heading: Type.Optional(Type.String()),
-        })),
-      }),
-      execute: async (_toolCallId, params: ProposeMemoryWriteToolInput) => {
-        const change = this.proposalState.normalizeMemoryChange(params, this.buildProposalDefaults());
-        this.proposalState.setActiveMemoryChange(change);
-        this.emitStudioEvent("memory_change_proposal", { change });
-
-        return {
-          content: [{ type: "text", text: `Staged planning memory change ${change.change_id} with ${change.edits.length} edit(s).` }],
-          details: { change },
-        };
-      },
-    });
-  }
-
-  private createDelegateSubAgentTool() {
-    return defineTool({
-      name: "delegate_subagent",
-      label: "Delegate Sub-agent",
-      description: "Launch a bounded specialist run for repo research and return a structured result.",
-      promptSnippet: "delegate_subagent: delegate bounded code research to a structured specialist when the planner needs grounded repo evidence.",
-      promptGuidelines: [
-        "Use delegate_subagent when you need grounded repository evidence beyond quick direct reasoning.",
-        "Pick code-crawler for concrete implementation tracing and scope-predictor for bounded impact prediction.",
-        "Keep the delegated task narrow and include focus paths or work item ids when useful.",
-      ],
-      parameters: Type.Object({
-        agent_type: Type.Union([Type.Literal("code-crawler"), Type.Literal("scope-predictor"), Type.Literal("reconciliation-analyst")]),
-        task: Type.String(),
-        repo: Type.Optional(Type.String()),
-        focus_paths: Type.Optional(Type.Array(Type.String())),
-        work_item_ids: Type.Optional(Type.Array(Type.String())),
-        notes: Type.Optional(Type.String()),
-      }),
-      execute: async (_toolCallId, params: DelegateSubAgentToolInput) => {
-        const run = await this.subAgentService.runDelegation(params, {
-          onStatus: (nextRun) => this.emitStudioEvent("subagent_status", { run: nextRun }),
-          onResult: (nextRun) => this.emitStudioEvent("subagent_result", { run: nextRun }),
-        });
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(run.result ?? run, null, 2) }],
-          details: { run },
-        };
-      },
-    });
-  }
-
-  private createGitHubReadTool() {
-    return defineTool({
-      name: "github_read",
-      label: "GitHub Read",
-      description: "Read GitHub issue details for an issue-backed work item or repo issue.",
-      promptSnippet: "github_read: inspect GitHub issue details before making GitHub sync recommendations.",
-      promptGuidelines: [
-        "Use github_read when you need grounded issue details from GitHub rather than relying only on graph metadata.",
-        "Prefer the work item's repo + issue_number when available.",
-      ],
-      parameters: Type.Object({
-        repo: Type.String(),
-        issue_number: Type.Number(),
-      }),
-      execute: async (_toolCallId, params: GitHubReadToolInput) => {
-        const issue = await this.githubService.readIssue(params.repo, params.issue_number);
-        return {
-          content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
-          details: issue,
-        };
-      },
-    });
-  }
-
-  private createGitHubCreateIssueTool() {
-    return defineTool({
-      name: "github_create_issue",
-      label: "GitHub Create Issue",
-      description: "Create a GitHub issue with a polished body and automatically stage a graph work item proposal for browser approval.",
-      promptSnippet: "github_create_issue: draft a rich GitHub issue body and auto-stage the corresponding graph work item proposal in one step.",
-      promptGuidelines: [
-        "Use github_create_issue when the user asks to create a new issue — it handles both GitHub issue creation and graph proposal staging.",
-        "Prefer richer issue bodies by default. Unless the user explicitly wants a quick capture, include background or motivation, the current problem, proposed behavior or expected vs actual behavior, scope or impact, and acceptance criteria.",
-        "For under-specified requests, draft the proposed title/body in chat and confirm before calling the tool.",
-        "Use lightweight repo context when it will materially improve the issue body — for example relevant docs, nearby module/file names, and any canonical Escapement Studio issue drafting template included in prompt context.",
-        "Keep issue text grounded in the user's request and repo evidence; do not invent repro steps, implementation details, or acceptance criteria.",
-        "The graph mutation proposal is staged automatically for browser approval; no separate propose_mutations call is needed.",
-        "Provide a work_item_id that follows the project's naming convention (e.g. 'studio-57').",
-        "Include scope_hint and predicted_files when available to enrich the graph node.",
-        "Use parent_id and depends_on_ids to wire the new item into the graph hierarchy.",
-      ],
-      parameters: Type.Object({
-        repo: Type.String(),
-        title: Type.String(),
-        body: Type.Optional(Type.String()),
-        labels: Type.Optional(Type.Array(Type.String())),
-        work_item_id: Type.Optional(Type.String()),
-        scope_hint: Type.Optional(Type.String()),
-        predicted_files: Type.Optional(Type.Array(Type.String())),
-        parent_id: Type.Optional(Type.String()),
-        depends_on_ids: Type.Optional(Type.Array(Type.String())),
-      }),
-      execute: async (_toolCallId, params: GitHubCreateIssueToolInput) => {
-        const created = await this.githubService.createIssue({
-          repo: params.repo,
-          title: params.title,
-          body: params.body,
-          labels: params.labels,
-        });
-
-        const existingProposal = this.proposalState.getActiveProposalForAccumulation(this.currentTurnId);
-        const stagedWorkItemIds = this.proposalState.getStagedWorkItemIds(existingProposal);
-        const requestedWorkItemId = params.work_item_id?.trim();
-        const workItemId = deriveIssueWorkItemId(created.number);
-        this.proposalState.rememberIssueIdAlias(requestedWorkItemId, workItemId, stagedWorkItemIds);
-
-        const groupId = `issue-${created.number}`;
-        const parentId = this.proposalState.resolveIssueIdAlias(params.parent_id, stagedWorkItemIds);
-        const dependsOnIds = params.depends_on_ids
-          ?.map((depId) => this.proposalState.resolveIssueIdAlias(depId, stagedWorkItemIds))
-          .filter((depId): depId is string => Boolean(depId));
-
-        const mutations: ProposeMutationsToolInput["mutations"] = [
-          {
-            type: "create_work_item",
-            entity_id: workItemId,
-            group_id: groupId,
-            payload: {
-              id: workItemId,
-              name: created.title,
-              kind: "issue",
-              state: "planned",
-              repo: params.repo,
-              issue_number: created.number,
-              issue_url: created.url,
-              scope_hint: params.scope_hint ?? null,
-              predicted_files: params.predicted_files ?? [],
-            },
-            rationale: `Graph representation for newly created GitHub issue #${created.number}.`,
-          },
-        ];
-
-        if (parentId) {
-          mutations.push({
-            type: "create_edge",
-            group_id: groupId,
-            payload: {
-              from_id: workItemId,
-              rel: "is_part_of",
-              to_id: parentId,
-            },
-            rationale: `Attach ${workItemId} under parent ${parentId}.`,
-          });
-        }
-
-        if (dependsOnIds) {
-          for (const depId of dependsOnIds) {
-            mutations.push({
-              type: "create_edge",
-              group_id: groupId,
-              payload: {
-                from_id: workItemId,
-                rel: "depends_on",
-                to_id: depId,
-              },
-              rationale: `${workItemId} depends on ${depId}.`,
-            });
-          }
-        }
-
-        // Accumulate into existing active proposal from the same turn,
-        // so multi-issue creation produces one reviewable proposal.
-        let proposal: PlanningMutationProposal;
-
-        if (existingProposal) {
-          proposal = this.proposalState.accumulateMutations(
-            existingProposal,
-            mutations,
-            `+ GitHub issue #${created.number}: ${created.title}`,
-          );
-        } else {
-          proposal = this.proposalState.normalizeProposal({
-            summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
-            mutations,
-          }, this.buildProposalDefaults());
-        }
-
-        proposal = this.proposalState.rewriteProposalIssueAliases(proposal);
-
-        this.proposalState.setActiveProposal(proposal);
-        this.emitStudioEvent("mutation_proposal", { proposal });
-
-        const summary = `Created GitHub issue #${created.number} (${created.url}) and staged graph proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s) for browser approval.`;
-
-        return {
-          content: [{ type: "text", text: summary }],
-          details: {
-            issue: created,
-            proposal,
-          },
-        };
-      },
-    });
-  }
-
-  private createGitHubSyncTool() {
-    return defineTool({
-      name: "github_sync",
-      label: "GitHub Sync",
-      description: "Stage an approval-gated GitHub sync proposal for a GitHub-backed work item.",
-      promptSnippet: "github_sync: stage a structured GitHub sync proposal for browser approval instead of mutating GitHub directly.",
-      promptGuidelines: [
-        "Use github_sync only for narrow, non-destructive GitHub updates.",
-        "V1 sync supports only the machine-managed issue body block bounded by studio-sync markers.",
-        "Do not attempt direct GitHub mutation outside the approval flow.",
-      ],
-      parameters: Type.Object({
-        sync_id: Type.Optional(Type.String()),
-        created_at: Type.Optional(Type.String()),
-        source: Type.Optional(Type.Object({
-          agent: Type.Optional(Type.String()),
-          turn_id: Type.Optional(Type.String()),
-          session_id: Type.Optional(Type.String()),
-        })),
-        summary: Type.String(),
-        work_item_id: Type.String(),
-      }),
-      execute: async (_toolCallId, params: GitHubSyncToolInput) => {
-        const sync = await this.proposalState.normalizeGitHubSync(params, this.buildProposalDefaults());
-        this.proposalState.setActiveGitHubSync(sync);
-        this.emitStudioEvent("github_sync_proposal", { sync });
-
-        return {
-          content: [{ type: "text", text: `Staged GitHub sync ${sync.sync_id} with ${sync.operations.length} operation(s).` }],
-          details: { sync },
-        };
-      },
-    });
-  }
-
-  private createReconciliationQueryTool() {
-    return defineTool({
-      name: "reconciliation_query",
-      label: "Reconciliation Query",
-      description: "Read deterministic predicted-vs-actual reconciliation reports for recent or specific work items.",
-      promptSnippet: "reconciliation_query: inspect reconciliation reports before explaining drift or proposing planning memory learnings.",
-      promptGuidelines: [
-        "Use reconciliation_query when you need deterministic predicted-vs-actual comparison data.",
-        "Prefer a specific work_item_id when discussing one execution run or one work item's drift.",
-      ],
-      parameters: Type.Object({
-        work_item_id: Type.Optional(Type.String()),
-      }),
-      execute: async (_toolCallId, params: ReconciliationQueryToolInput) => {
-        const result = params.work_item_id
-          ? this.reconciliationService.getReport(params.work_item_id)
-          : this.reconciliationService.listReports();
-
-        return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-          details: result,
-        };
-      },
-    });
+  /**
+   * Phase 7 (#227): build the typed dependency bag the tool registry
+   * factories receive. Bound to `this` so the SSE emitter / turn id /
+   * session id callbacks stay private to PlanningService.
+   */
+  private buildToolDeps(): PlanningToolDeps {
+    return {
+      graphService: this.graphService,
+      memoryService: this.memoryService,
+      subAgentService: this.subAgentService,
+      githubService: this.githubService,
+      reconciliationService: this.reconciliationService,
+      proposalState: this.proposalState,
+      emitStudioEvent: (eventType, payload) => this.emitStudioEvent(eventType, payload),
+      buildProposalDefaults: () => this.buildProposalDefaults(),
+      getCurrentTurnId: () => this.currentTurnId,
+    };
   }
 
   private toGraphMutation(mutation: PlanningMutationProposalMutation): GraphMutation {

--- a/src/modules/planning/proposal-state.service.ts
+++ b/src/modules/planning/proposal-state.service.ts
@@ -1,0 +1,514 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { GraphService } from "../graph/graph.service.js";
+import { GitHubService } from "../github/github.service.js";
+import { MemoryService } from "./memory.service.js";
+import type {
+  GitHubSyncProposal,
+  GitHubSyncToolInput,
+  PlanningGraphCommitResult,
+  PlanningMemoryChange,
+  PlanningMemoryEdit,
+  PlanningMemoryWriteResult,
+  PlanningMutationProposal,
+  PlanningMutationProposalMutation,
+  ProposeMemoryWriteToolInput,
+  ProposeMutationsToolInput,
+  GitHubSyncResult,
+} from "./types.js";
+
+/**
+ * Phase 7 of the cqrs refactor (#227): owns the staging state that
+ * the planner's custom tools accumulate (mutation proposals, memory
+ * changes, GitHub syncs) plus the helper methods that normalize,
+ * accumulate, and alias-resolve those proposals.
+ *
+ * Extracted from `PlanningService` to get 11 state fields + 17 helper
+ * methods out of the 1378-line god class. `PlanningService` now
+ * delegates every state read/write to this service, and the planner
+ * tool files (Phase 7 Task 2) will inject `ProposalStateService`
+ * directly via their dependency bag.
+ *
+ * Injects:
+ *   - `GraphService` — for `graph_version` in `normalizeProposal`
+ *   - `GitHubService` — for `stageManagedBlockSync` in `normalizeGitHubSync`
+ *   - `MemoryService` — for `content_hash` in `normalizeMemoryChange`
+ *     + the refreshed hash in `updateActiveMemoryChangeAfterApply`
+ *
+ * Does NOT inject anything new at the module level — all three
+ * siblings are already available to `PlanningModule`.
+ */
+@Injectable()
+export class ProposalStateService {
+  private readonly proposals = new Map<string, PlanningMutationProposal>();
+  private readonly memoryChanges = new Map<string, PlanningMemoryChange>();
+  private readonly githubSyncs = new Map<string, GitHubSyncProposal>();
+  private readonly issueIdAliases = new Map<string, string>();
+
+  private activeProposalId: string | null = null;
+  private proposalCounter = 0;
+  private lastCommitResult: PlanningGraphCommitResult | null = null;
+  private activeMemoryChangeId: string | null = null;
+  private lastMemoryWriteResult: PlanningMemoryWriteResult | null = null;
+  private activeGitHubSyncId: string | null = null;
+  private lastGitHubSyncResult: GitHubSyncResult | null = null;
+
+  constructor(
+    @Inject(GraphService) private readonly graphService: GraphService,
+    @Inject(GitHubService) private readonly githubService: GitHubService,
+    @Inject(MemoryService) private readonly memoryService: MemoryService,
+  ) {}
+
+  // ─── Proposal staging ────────────────────────────────────────────
+
+  setActiveProposal(proposal: PlanningMutationProposal): void {
+    this.proposals.set(proposal.proposal_id, proposal);
+    this.activeProposalId = proposal.proposal_id;
+    this.lastCommitResult = null;
+  }
+
+  getActiveProposal(): PlanningMutationProposal | null {
+    return this.activeProposalId ? this.proposals.get(this.activeProposalId) ?? null : null;
+  }
+
+  getProposal(proposalId: string): PlanningMutationProposal | null {
+    return this.proposals.get(proposalId) ?? null;
+  }
+
+  /**
+   * Return the active proposal only if it was created in the current
+   * turn and has not yet been committed — suitable for accumulating
+   * additional mutations from a second `github_create_issue` call in
+   * the same turn.
+   */
+  getActiveProposalForAccumulation(currentTurnId: string | null): PlanningMutationProposal | null {
+    const proposal = this.getActiveProposal();
+    if (!proposal || !currentTurnId) {
+      return null;
+    }
+    if (proposal.source.turn_id !== currentTurnId) {
+      return null;
+    }
+    return proposal;
+  }
+
+  setLastCommitResult(result: PlanningGraphCommitResult | null): void {
+    this.lastCommitResult = result;
+  }
+
+  getLastCommitResult(): PlanningGraphCommitResult | null {
+    return this.lastCommitResult;
+  }
+
+  updateActiveProposalAfterApply(
+    proposal: PlanningMutationProposal,
+    approvedIds: string[],
+  ): PlanningMutationProposal | null {
+    const remainingMutations = proposal.mutations.filter((mutation) => !approvedIds.includes(mutation.id));
+
+    if (remainingMutations.length === 0) {
+      this.proposals.delete(proposal.proposal_id);
+      if (this.activeProposalId === proposal.proposal_id) {
+        this.activeProposalId = null;
+      }
+      return null;
+    }
+
+    const nextProposal: PlanningMutationProposal = {
+      ...proposal,
+      summary: `${proposal.summary} (${remainingMutations.length} mutation(s) remaining)`,
+      mutations: remainingMutations,
+    };
+    this.proposals.set(nextProposal.proposal_id, nextProposal);
+    this.activeProposalId = nextProposal.proposal_id;
+    return nextProposal;
+  }
+
+  normalizeProposal(
+    input: ProposeMutationsToolInput,
+    defaults: { currentTurnId: string | null; sessionId: string },
+  ): PlanningMutationProposal {
+    const graphVersion = input.context?.based_on_graph_version ?? this.graphService.getGraph().graph_version;
+    const proposalId = input.proposal_id?.trim() || `prop_${Date.now()}_${++this.proposalCounter}`;
+    const createdAt = input.created_at?.trim() || this.now();
+
+    return {
+      proposal_id: proposalId,
+      created_at: createdAt,
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || defaults.currentTurnId,
+        session_id: input.source?.session_id?.trim() || defaults.sessionId,
+      },
+      context: {
+        ...input.context,
+        based_on_graph_version: graphVersion,
+      },
+      summary: input.summary.trim(),
+      mutations: input.mutations.map((mutation, index) => this.normalizeProposalMutation(mutation, index)),
+    };
+  }
+
+  private normalizeProposalMutation(
+    mutation: ProposeMutationsToolInput["mutations"][number],
+    index: number,
+  ): PlanningMutationProposalMutation {
+    const payload = mutation.payload && typeof mutation.payload === "object"
+      ? { ...(mutation.payload as Record<string, unknown>) }
+      : undefined;
+
+    const entityId = mutation.entity_id
+      ?? (typeof payload?.id === "string" ? payload.id : undefined)
+      ?? (mutation.type === "create_edge" && payload
+        ? `${String(payload.from_id ?? "")}:${String(payload.rel ?? "")}:${String(payload.to_id ?? "")}`
+        : undefined);
+
+    return {
+      id: mutation.id?.trim() || `m${index + 1}`,
+      type: mutation.type,
+      entity_id: entityId,
+      payload,
+      rationale: mutation.rationale.trim(),
+      validation: mutation.validation,
+      group_id: mutation.group_id,
+      depends_on_mutation_ids: mutation.depends_on_mutation_ids,
+    };
+  }
+
+  /**
+   * Append new mutations to an existing proposal, re-numbering their
+   * IDs to avoid collisions. Returns the updated (same-ID) proposal.
+   */
+  accumulateMutations(
+    existing: PlanningMutationProposal,
+    newMutations: ProposeMutationsToolInput["mutations"],
+    summaryAppendix: string,
+  ): PlanningMutationProposal {
+    const maxExistingIndex = existing.mutations.reduce((max, mutation) => {
+      const match = mutation.id.match(/^m(\d+)$/);
+      return match ? Math.max(max, Number(match[1])) : max;
+    }, 0);
+
+    let nextIndex = maxExistingIndex + 1;
+    const normalized = newMutations.map((mutation) =>
+      this.normalizeProposalMutation(
+        { ...mutation, id: `m${nextIndex++}` },
+        0, // index param unused when id is pre-set
+      ),
+    );
+
+    return {
+      ...existing,
+      summary: `${existing.summary} ${summaryAppendix}`,
+      mutations: [...existing.mutations, ...normalized],
+    };
+  }
+
+  rememberIssueIdAlias(
+    requestedId: string | null | undefined,
+    finalId: string,
+    stagedWorkItemIds: ReadonlySet<string> = new Set(),
+  ): void {
+    const placeholderId = requestedId?.trim();
+    if (!placeholderId || placeholderId === finalId) {
+      return;
+    }
+    // If the requested ID is already staged as a canonical work item from an
+    // earlier create, or already resolves to one, treat that existing staged ID
+    // as authoritative and do not overwrite the alias chain with a later guess.
+    if (stagedWorkItemIds.has(placeholderId)) {
+      return;
+    }
+    const existingResolvedId = this.resolveIssueIdAlias(placeholderId, stagedWorkItemIds);
+    if (existingResolvedId !== placeholderId && stagedWorkItemIds.has(existingResolvedId)) {
+      return;
+    }
+    this.issueIdAliases.set(placeholderId, finalId);
+  }
+
+  resolveIssueIdAlias(id: string | null | undefined, stopIds: ReadonlySet<string> = new Set()): string {
+    const trimmed = id?.trim();
+    if (!trimmed) {
+      return "";
+    }
+    if (stopIds.has(trimmed)) {
+      return trimmed;
+    }
+
+    let resolved = trimmed;
+    const seen = new Set<string>();
+
+    while (this.issueIdAliases.has(resolved) && !seen.has(resolved)) {
+      seen.add(resolved);
+      const next = this.issueIdAliases.get(resolved) ?? resolved;
+      resolved = next;
+      if (stopIds.has(resolved)) {
+        break;
+      }
+    }
+
+    return resolved;
+  }
+
+  getStagedWorkItemIds(proposal: PlanningMutationProposal | null | undefined): Set<string> {
+    const ids = new Set<string>();
+    if (!proposal) {
+      return ids;
+    }
+
+    for (const mutation of proposal.mutations) {
+      if (mutation.type !== "create_work_item") {
+        continue;
+      }
+      if (mutation.entity_id) {
+        ids.add(mutation.entity_id);
+      }
+      if (typeof mutation.payload?.id === "string") {
+        ids.add(mutation.payload.id);
+      }
+    }
+
+    return ids;
+  }
+
+  rewriteProposalIssueAliases(proposal: PlanningMutationProposal): PlanningMutationProposal {
+    const stagedWorkItemIds = this.getStagedWorkItemIds(proposal);
+    return {
+      ...proposal,
+      mutations: proposal.mutations.map((mutation) => this.rewriteProposalMutationIssueAliases(mutation, stagedWorkItemIds)),
+    };
+  }
+
+  private rewriteProposalMutationIssueAliases(
+    mutation: PlanningMutationProposalMutation,
+    stagedWorkItemIds: ReadonlySet<string>,
+  ): PlanningMutationProposalMutation {
+    const payload = mutation.payload && typeof mutation.payload === "object"
+      ? { ...mutation.payload }
+      : undefined;
+
+    const entityId = mutation.entity_id ? this.resolveIssueIdAlias(mutation.entity_id, stagedWorkItemIds) : mutation.entity_id;
+
+    if (mutation.type === "create_work_item" || mutation.type === "update_work_item") {
+      if (typeof payload?.id === "string") {
+        payload.id = this.resolveIssueIdAlias(payload.id, stagedWorkItemIds);
+      }
+    }
+
+    if (mutation.type === "create_edge") {
+      if (typeof payload?.from_id === "string") {
+        payload.from_id = this.resolveIssueIdAlias(payload.from_id, stagedWorkItemIds);
+      }
+      if (typeof payload?.to_id === "string") {
+        payload.to_id = this.resolveIssueIdAlias(payload.to_id, stagedWorkItemIds);
+      }
+    }
+
+    const rewrittenEntityId = mutation.type === "create_edge" && payload?.from_id && payload?.rel && payload?.to_id
+      ? `${String(payload.from_id)}:${String(payload.rel)}:${String(payload.to_id)}`
+      : entityId;
+
+    return {
+      ...mutation,
+      entity_id: rewrittenEntityId,
+      payload,
+    };
+  }
+
+  // ─── Memory change staging ───────────────────────────────────────
+
+  setActiveMemoryChange(change: PlanningMemoryChange): void {
+    this.memoryChanges.set(change.change_id, change);
+    this.activeMemoryChangeId = change.change_id;
+    this.lastMemoryWriteResult = null;
+  }
+
+  getActiveMemoryChange(): PlanningMemoryChange | null {
+    return this.activeMemoryChangeId ? this.memoryChanges.get(this.activeMemoryChangeId) ?? null : null;
+  }
+
+  getMemoryChange(changeId: string): PlanningMemoryChange | null {
+    return this.memoryChanges.get(changeId) ?? null;
+  }
+
+  setLastMemoryWriteResult(result: PlanningMemoryWriteResult | null): void {
+    this.lastMemoryWriteResult = result;
+  }
+
+  getLastMemoryWriteResult(): PlanningMemoryWriteResult | null {
+    return this.lastMemoryWriteResult;
+  }
+
+  updateActiveMemoryChangeAfterApply(
+    change: PlanningMemoryChange,
+    approvedEditIds: string[],
+  ): PlanningMemoryChange | null {
+    const remainingEdits = change.edits.filter((edit) => !approvedEditIds.includes(edit.id));
+
+    if (remainingEdits.length === 0) {
+      this.memoryChanges.delete(change.change_id);
+      if (this.activeMemoryChangeId === change.change_id) {
+        this.activeMemoryChangeId = null;
+      }
+      return null;
+    }
+
+    const nextChange: PlanningMemoryChange = {
+      ...change,
+      summary: `${change.summary} (${remainingEdits.length} edit(s) remaining)`,
+      edits: remainingEdits,
+      based_on_content_hash: this.memoryService.read().content_hash,
+    };
+    this.memoryChanges.set(nextChange.change_id, nextChange);
+    this.activeMemoryChangeId = nextChange.change_id;
+    return nextChange;
+  }
+
+  normalizeMemoryChange(
+    input: ProposeMemoryWriteToolInput,
+    defaults: { currentTurnId: string | null; sessionId: string },
+  ): PlanningMemoryChange {
+    const memory = this.memoryService.read();
+    const changeId = input.change_id?.trim() || `mem_${Date.now()}`;
+    const createdAt = input.created_at?.trim() || this.now();
+
+    return {
+      change_id: changeId,
+      created_at: createdAt,
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || defaults.currentTurnId,
+        session_id: input.source?.session_id?.trim() || defaults.sessionId,
+      },
+      summary: input.summary.trim(),
+      based_on_content_hash: memory.content_hash,
+      edits: input.edits.map((edit, index) => this.normalizeMemoryEdit(edit, index)),
+    };
+  }
+
+  private normalizeMemoryEdit(edit: ProposeMemoryWriteToolInput["edits"][number], index: number): PlanningMemoryEdit {
+    return {
+      id: edit.id?.trim() || `e${index + 1}`,
+      kind: edit.kind,
+      summary: edit.summary.trim(),
+      rationale: edit.rationale.trim(),
+      old_text: edit.old_text,
+      new_text: edit.new_text,
+      target_heading: edit.target_heading,
+    };
+  }
+
+  // ─── GitHub sync staging ─────────────────────────────────────────
+
+  setActiveGitHubSync(sync: GitHubSyncProposal): void {
+    this.githubSyncs.set(sync.sync_id, sync);
+    this.activeGitHubSyncId = sync.sync_id;
+    this.lastGitHubSyncResult = null;
+  }
+
+  getActiveGitHubSync(): GitHubSyncProposal | null {
+    return this.activeGitHubSyncId ? this.githubSyncs.get(this.activeGitHubSyncId) ?? null : null;
+  }
+
+  getGitHubSync(syncId: string): GitHubSyncProposal | null {
+    return this.githubSyncs.get(syncId) ?? null;
+  }
+
+  setLastGitHubSyncResult(result: GitHubSyncResult | null): void {
+    this.lastGitHubSyncResult = result;
+  }
+
+  getLastGitHubSyncResult(): GitHubSyncResult | null {
+    return this.lastGitHubSyncResult;
+  }
+
+  updateActiveGitHubSyncAfterApply(
+    proposal: GitHubSyncProposal,
+    approvedOperationIds: string[],
+  ): GitHubSyncProposal | null {
+    const remainingOperations = proposal.operations.filter((operation) => !approvedOperationIds.includes(operation.id));
+
+    if (remainingOperations.length === 0) {
+      this.githubSyncs.delete(proposal.sync_id);
+      if (this.activeGitHubSyncId === proposal.sync_id) {
+        this.activeGitHubSyncId = null;
+      }
+      return null;
+    }
+
+    const nextProposal: GitHubSyncProposal = {
+      ...proposal,
+      summary: `${proposal.summary} (${remainingOperations.length} operation(s) remaining)`,
+      operations: remainingOperations,
+    };
+    this.githubSyncs.set(nextProposal.sync_id, nextProposal);
+    this.activeGitHubSyncId = nextProposal.sync_id;
+    return nextProposal;
+  }
+
+  async normalizeGitHubSync(
+    input: GitHubSyncToolInput,
+    defaults: { currentTurnId: string | null; sessionId: string },
+  ): Promise<GitHubSyncProposal> {
+    const staged = await this.githubService.stageManagedBlockSync(input.work_item_id);
+    return {
+      sync_id: input.sync_id?.trim() || `ghsync_${Date.now()}`,
+      created_at: input.created_at?.trim() || this.now(),
+      source: {
+        agent: input.source?.agent?.trim() || "root-planner",
+        turn_id: input.source?.turn_id?.trim() || defaults.currentTurnId,
+        session_id: input.source?.session_id?.trim() || defaults.sessionId,
+      },
+      summary: input.summary.trim(),
+      issue: {
+        repo: staged.issue.repo,
+        issue_number: staged.issue.number,
+        issue_url: staged.issue.url,
+        title: staged.issue.title,
+      },
+      work_item_id: staged.work_item_id,
+      based_on_body_hash: staged.based_on_body_hash,
+      operations: staged.operations,
+    };
+  }
+
+  // ─── Turn lifecycle + dismiss ────────────────────────────────────
+
+  /**
+   * Clear issue ID aliases between turn boundaries. Called by
+   * `PlanningService.handleSessionEvent` at `turn_start` and
+   * `turn_end` so aliases from a previous turn don't leak into the
+   * next one.
+   */
+  resetTurnState(): void {
+    this.issueIdAliases.clear();
+  }
+
+  dismissAll(): {
+    dismissed_proposal_ids: string[];
+    dismissed_memory_change_ids: string[];
+    dismissed_github_sync_ids: string[];
+  } {
+    const dismissedProposalIds = this.activeProposalId ? [this.activeProposalId] : [];
+    const dismissedMemoryChangeIds = this.activeMemoryChangeId ? [this.activeMemoryChangeId] : [];
+    const dismissedGitHubSyncIds = this.activeGitHubSyncId ? [this.activeGitHubSyncId] : [];
+
+    this.activeProposalId = null;
+    this.lastCommitResult = null;
+    this.activeMemoryChangeId = null;
+    this.lastMemoryWriteResult = null;
+    this.activeGitHubSyncId = null;
+    this.lastGitHubSyncResult = null;
+
+    return {
+      dismissed_proposal_ids: dismissedProposalIds,
+      dismissed_memory_change_ids: dismissedMemoryChangeIds,
+      dismissed_github_sync_ids: dismissedGitHubSyncIds,
+    };
+  }
+
+  // ─── Trivial helpers ─────────────────────────────────────────────
+
+  private now(): string {
+    return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  }
+}

--- a/src/modules/planning/tools/delegate-subagent.tool.ts
+++ b/src/modules/planning/tools/delegate-subagent.tool.ts
@@ -1,0 +1,37 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { DelegateSubAgentToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createDelegateSubAgentTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "delegate_subagent",
+    label: "Delegate Sub-agent",
+    description: "Launch a bounded specialist run for repo research and return a structured result.",
+    promptSnippet: "delegate_subagent: delegate bounded code research to a structured specialist when the planner needs grounded repo evidence.",
+    promptGuidelines: [
+      "Use delegate_subagent when you need grounded repository evidence beyond quick direct reasoning.",
+      "Pick code-crawler for concrete implementation tracing and scope-predictor for bounded impact prediction.",
+      "Keep the delegated task narrow and include focus paths or work item ids when useful.",
+    ],
+    parameters: Type.Object({
+      agent_type: Type.Union([Type.Literal("code-crawler"), Type.Literal("scope-predictor"), Type.Literal("reconciliation-analyst")]),
+      task: Type.String(),
+      repo: Type.Optional(Type.String()),
+      focus_paths: Type.Optional(Type.Array(Type.String())),
+      work_item_ids: Type.Optional(Type.Array(Type.String())),
+      notes: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, params: DelegateSubAgentToolInput) => {
+      const run = await deps.subAgentService.runDelegation(params, {
+        onStatus: (nextRun) => deps.emitStudioEvent("subagent_status", { run: nextRun }),
+        onResult: (nextRun) => deps.emitStudioEvent("subagent_result", { run: nextRun }),
+      });
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(run.result ?? run, null, 2) }],
+        details: { run },
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/github-create-issue.tool.ts
+++ b/src/modules/planning/tools/github-create-issue.tool.ts
@@ -1,0 +1,144 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import {
+  deriveIssueWorkItemId,
+  type CreateEdgeDto,
+  type CreateWorkItemDto,
+} from "../../graph/types.js";
+import type {
+  GitHubCreateIssueToolInput,
+  PlanningMutationProposal,
+  ProposeMutationsToolInput,
+} from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createGitHubCreateIssueTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "github_create_issue",
+    label: "GitHub Create Issue",
+    description: "Create a GitHub issue with a polished body and automatically stage a graph work item proposal for browser approval.",
+    promptSnippet: "github_create_issue: draft a rich GitHub issue body and auto-stage the corresponding graph work item proposal in one step.",
+    promptGuidelines: [
+      "Use github_create_issue when the user asks to create a new issue — it handles both GitHub issue creation and graph proposal staging.",
+      "Prefer richer issue bodies by default. Unless the user explicitly wants a quick capture, include background or motivation, the current problem, proposed behavior or expected vs actual behavior, scope or impact, and acceptance criteria.",
+      "For under-specified requests, draft the proposed title/body in chat and confirm before calling the tool.",
+      "Use lightweight repo context when it will materially improve the issue body — for example relevant docs, nearby module/file names, and any canonical Escapement Studio issue drafting template included in prompt context.",
+      "Keep issue text grounded in the user's request and repo evidence; do not invent repro steps, implementation details, or acceptance criteria.",
+      "The graph mutation proposal is staged automatically for browser approval; no separate propose_mutations call is needed.",
+      "Provide a work_item_id that follows the project's naming convention (e.g. 'studio-57').",
+      "Include scope_hint and predicted_files when available to enrich the graph node.",
+      "Use parent_id and depends_on_ids to wire the new item into the graph hierarchy.",
+    ],
+    parameters: Type.Object({
+      repo: Type.String(),
+      title: Type.String(),
+      body: Type.Optional(Type.String()),
+      labels: Type.Optional(Type.Array(Type.String())),
+      work_item_id: Type.Optional(Type.String()),
+      scope_hint: Type.Optional(Type.String()),
+      predicted_files: Type.Optional(Type.Array(Type.String())),
+      parent_id: Type.Optional(Type.String()),
+      depends_on_ids: Type.Optional(Type.Array(Type.String())),
+    }),
+    execute: async (_toolCallId, params: GitHubCreateIssueToolInput) => {
+      const created = await deps.githubService.createIssue({
+        repo: params.repo,
+        title: params.title,
+        body: params.body,
+        labels: params.labels,
+      });
+
+      const existingProposal = deps.proposalState.getActiveProposalForAccumulation(deps.getCurrentTurnId());
+      const stagedWorkItemIds = deps.proposalState.getStagedWorkItemIds(existingProposal);
+      const requestedWorkItemId = params.work_item_id?.trim();
+      const workItemId = deriveIssueWorkItemId(created.number);
+      deps.proposalState.rememberIssueIdAlias(requestedWorkItemId, workItemId, stagedWorkItemIds);
+
+      const groupId = `issue-${created.number}`;
+      const parentId = deps.proposalState.resolveIssueIdAlias(params.parent_id, stagedWorkItemIds);
+      const dependsOnIds = params.depends_on_ids
+        ?.map((depId) => deps.proposalState.resolveIssueIdAlias(depId, stagedWorkItemIds))
+        .filter((depId): depId is string => Boolean(depId));
+
+      const mutations: ProposeMutationsToolInput["mutations"] = [
+        {
+          type: "create_work_item",
+          entity_id: workItemId,
+          group_id: groupId,
+          payload: {
+            id: workItemId,
+            name: created.title,
+            kind: "issue",
+            state: "planned",
+            repo: params.repo,
+            issue_number: created.number,
+            issue_url: created.url,
+            scope_hint: params.scope_hint ?? null,
+            predicted_files: params.predicted_files ?? [],
+          } satisfies CreateWorkItemDto,
+          rationale: `Graph representation for newly created GitHub issue #${created.number}.`,
+        },
+      ];
+
+      if (parentId) {
+        mutations.push({
+          type: "create_edge",
+          group_id: groupId,
+          payload: {
+            from_id: workItemId,
+            rel: "is_part_of",
+            to_id: parentId,
+          } satisfies CreateEdgeDto,
+          rationale: `Attach ${workItemId} under parent ${parentId}.`,
+        });
+      }
+
+      if (dependsOnIds) {
+        for (const depId of dependsOnIds) {
+          mutations.push({
+            type: "create_edge",
+            group_id: groupId,
+            payload: {
+              from_id: workItemId,
+              rel: "depends_on",
+              to_id: depId,
+            } satisfies CreateEdgeDto,
+            rationale: `${workItemId} depends on ${depId}.`,
+          });
+        }
+      }
+
+      // Accumulate into existing active proposal from the same turn,
+      // so multi-issue creation produces one reviewable proposal.
+      let proposal: PlanningMutationProposal;
+
+      if (existingProposal) {
+        proposal = deps.proposalState.accumulateMutations(
+          existingProposal,
+          mutations,
+          `+ GitHub issue #${created.number}: ${created.title}`,
+        );
+      } else {
+        proposal = deps.proposalState.normalizeProposal({
+          summary: `Graph work item for GitHub issue #${created.number}: ${created.title}`,
+          mutations,
+        }, deps.buildProposalDefaults());
+      }
+
+      proposal = deps.proposalState.rewriteProposalIssueAliases(proposal);
+
+      deps.proposalState.setActiveProposal(proposal);
+      deps.emitStudioEvent("mutation_proposal", { proposal });
+
+      const summary = `Created GitHub issue #${created.number} (${created.url}) and staged graph proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s) for browser approval.`;
+
+      return {
+        content: [{ type: "text", text: summary }],
+        details: {
+          issue: created,
+          proposal,
+        },
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/github-read.tool.ts
+++ b/src/modules/planning/tools/github-read.tool.ts
@@ -1,0 +1,28 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { GitHubReadToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createGitHubReadTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "github_read",
+    label: "GitHub Read",
+    description: "Read GitHub issue details for an issue-backed work item or repo issue.",
+    promptSnippet: "github_read: inspect GitHub issue details before making GitHub sync recommendations.",
+    promptGuidelines: [
+      "Use github_read when you need grounded issue details from GitHub rather than relying only on graph metadata.",
+      "Prefer the work item's repo + issue_number when available.",
+    ],
+    parameters: Type.Object({
+      repo: Type.String(),
+      issue_number: Type.Number(),
+    }),
+    execute: async (_toolCallId, params: GitHubReadToolInput) => {
+      const issue = await deps.githubService.readIssue(params.repo, params.issue_number);
+      return {
+        content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        details: issue,
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/github-sync.tool.ts
+++ b/src/modules/planning/tools/github-sync.tool.ts
@@ -1,0 +1,39 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { GitHubSyncToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createGitHubSyncTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "github_sync",
+    label: "GitHub Sync",
+    description: "Stage an approval-gated GitHub sync proposal for a GitHub-backed work item.",
+    promptSnippet: "github_sync: stage a structured GitHub sync proposal for browser approval instead of mutating GitHub directly.",
+    promptGuidelines: [
+      "Use github_sync only for narrow, non-destructive GitHub updates.",
+      "V1 sync supports only the machine-managed issue body block bounded by studio-sync markers.",
+      "Do not attempt direct GitHub mutation outside the approval flow.",
+    ],
+    parameters: Type.Object({
+      sync_id: Type.Optional(Type.String()),
+      created_at: Type.Optional(Type.String()),
+      source: Type.Optional(Type.Object({
+        agent: Type.Optional(Type.String()),
+        turn_id: Type.Optional(Type.String()),
+        session_id: Type.Optional(Type.String()),
+      })),
+      summary: Type.String(),
+      work_item_id: Type.String(),
+    }),
+    execute: async (_toolCallId, params: GitHubSyncToolInput) => {
+      const sync = await deps.proposalState.normalizeGitHubSync(params, deps.buildProposalDefaults());
+      deps.proposalState.setActiveGitHubSync(sync);
+      deps.emitStudioEvent("github_sync_proposal", { sync });
+
+      return {
+        content: [{ type: "text", text: `Staged GitHub sync ${sync.sync_id} with ${sync.operations.length} operation(s).` }],
+        details: { sync },
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/graph-mutate.tool.ts
+++ b/src/modules/planning/tools/graph-mutate.tool.ts
@@ -1,0 +1,38 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { ApproveMutationProposalDto } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+/**
+ * V1: direct graph_mutate execution is disabled. Browser approval is
+ * required for every commit. The tool exists only as a no-op
+ * placeholder so the LLM can still reason about graph commits in its
+ * response — it never actually mutates anything.
+ */
+export function createGraphMutateTool(_deps: PlanningToolDeps) {
+  return defineTool({
+    name: "graph_mutate",
+    label: "Graph Mutate",
+    description: "Reserved graph commit tool. In V1, actual commits must go through browser approval.",
+    promptSnippet: "graph_mutate: reserved for approval-backed graph commits; do not call directly in V1.",
+    promptGuidelines: [
+      "Do not call graph_mutate directly in V1. Human approval in the browser is required; use propose_mutations instead.",
+    ],
+    parameters: Type.Object({
+      proposal_id: Type.String(),
+      approved_mutation_ids: Type.Array(Type.String()),
+    }),
+    execute: async (_toolCallId, params: ApproveMutationProposalDto) => ({
+      content: [{
+        type: "text",
+        text: `Direct graph_mutate execution is disabled in V1. Proposal ${params.proposal_id} must be committed from the browser approval UI.`,
+      }],
+      details: {
+        blocked: true,
+        reason: "browser_approval_required",
+        proposal_id: params.proposal_id,
+        approved_mutation_ids: params.approved_mutation_ids,
+      },
+    }),
+  });
+}

--- a/src/modules/planning/tools/graph-query.tool.ts
+++ b/src/modules/planning/tools/graph-query.tool.ts
@@ -1,0 +1,40 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { GraphQueryToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createGraphQueryTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "graph_query",
+    label: "Graph Query",
+    description: "Query the Studio planning graph, frontier, or dispatch plan.",
+    promptSnippet: "graph_query: inspect graph, frontier, or dispatch plan data before proposing structural changes.",
+    promptGuidelines: [
+      "Use graph_query to inspect the current graph/frontier/plan before proposing structural graph changes.",
+    ],
+    parameters: Type.Object({
+      query: Type.Union([Type.Literal("graph"), Type.Literal("frontier"), Type.Literal("plan")]),
+      repo: Type.Optional(Type.String()),
+      state: Type.Optional(Type.String()),
+      track: Type.Optional(Type.String()),
+      phase: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, params: GraphQueryToolInput) => {
+      const result = params.query === "graph"
+        ? deps.graphService.getGraph({
+            repo: params.repo,
+            state: params.state,
+            track: params.track,
+            phase: params.phase,
+          })
+        : params.query === "frontier"
+          ? deps.graphService.getFrontier(params.repo)
+          : deps.graphService.getPlan(params.repo);
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        details: result,
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/memory-read.tool.ts
+++ b/src/modules/planning/tools/memory-read.tool.ts
@@ -1,0 +1,23 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createMemoryReadTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "memory_read",
+    label: "Planning Memory Read",
+    description: "Read the curated durable planning memory file.",
+    promptSnippet: "memory_read: inspect the curated planning memory before proposing durable memory changes.",
+    promptGuidelines: [
+      "Use memory_read before suggesting durable planning-memory edits so you can update the existing curated structure intentionally.",
+    ],
+    parameters: Type.Object({}),
+    execute: async () => {
+      const memory = deps.memoryService.read();
+      return {
+        content: [{ type: "text", text: memory.content }],
+        details: memory,
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/memory-write.tool.ts
+++ b/src/modules/planning/tools/memory-write.tool.ts
@@ -1,0 +1,51 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { ProposeMemoryWriteToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createMemoryWriteTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "memory_write",
+    label: "Planning Memory Write",
+    description: "Stage targeted planning memory edits for browser approval.",
+    promptSnippet: "memory_write: stage targeted edits to PLANNING_MEMORY.md for browser approval instead of writing directly.",
+    promptGuidelines: [
+      "Use memory_write only for durable, curated planning-memory updates.",
+      "Prefer targeted replacements or section-specific inserts over append-only growth.",
+      "Do not include transcript residue, raw tool output, or broad dumps.",
+    ],
+    parameters: Type.Object({
+      change_id: Type.Optional(Type.String()),
+      created_at: Type.Optional(Type.String()),
+      source: Type.Optional(Type.Object({
+        agent: Type.Optional(Type.String()),
+        turn_id: Type.Optional(Type.String()),
+        session_id: Type.Optional(Type.String()),
+      })),
+      summary: Type.String(),
+      edits: Type.Array(Type.Object({
+        id: Type.Optional(Type.String()),
+        kind: Type.Union([
+          Type.Literal("replace_text"),
+          Type.Literal("insert_after_heading"),
+          Type.Literal("delete_text"),
+        ]),
+        summary: Type.String(),
+        rationale: Type.String(),
+        old_text: Type.Optional(Type.String()),
+        new_text: Type.Optional(Type.String()),
+        target_heading: Type.Optional(Type.String()),
+      })),
+    }),
+    execute: async (_toolCallId, params: ProposeMemoryWriteToolInput) => {
+      const change = deps.proposalState.normalizeMemoryChange(params, deps.buildProposalDefaults());
+      deps.proposalState.setActiveMemoryChange(change);
+      deps.emitStudioEvent("memory_change_proposal", { change });
+
+      return {
+        content: [{ type: "text", text: `Staged planning memory change ${change.change_id} with ${change.edits.length} edit(s).` }],
+        details: { change },
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/propose-mutations.tool.ts
+++ b/src/modules/planning/tools/propose-mutations.tool.ts
@@ -1,0 +1,59 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { ProposeMutationsToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createProposeMutationsTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "propose_mutations",
+    label: "Propose Mutations",
+    description: "Stage a structured graph mutation proposal for browser review and approval.",
+    promptSnippet: "propose_mutations: emit a structured mutation proposal envelope for browser approval instead of only describing changes in prose.",
+    promptGuidelines: [
+      "When recommending graph changes, call propose_mutations with a structured proposal envelope that matches the browser approval contract.",
+      "Include a concise summary plus rationale for each mutation so the browser can render reviewable cards.",
+      "Set based_on_graph_version from graph_query results when available.",
+    ],
+    parameters: Type.Object({
+      proposal_id: Type.Optional(Type.String()),
+      created_at: Type.Optional(Type.String()),
+      source: Type.Optional(Type.Object({
+        agent: Type.Optional(Type.String()),
+        turn_id: Type.Optional(Type.String()),
+        session_id: Type.Optional(Type.String()),
+      })),
+      context: Type.Optional(Type.Object({
+        scope: Type.Optional(Type.String()),
+        mode: Type.Optional(Type.Union([Type.Literal("default"), Type.Literal("focused"), Type.Literal("full")])) ,
+        based_on_graph_version: Type.Optional(Type.String()),
+      })),
+      summary: Type.String(),
+      mutations: Type.Array(Type.Object({
+        id: Type.Optional(Type.String()),
+        type: Type.Union([
+          Type.Literal("create_work_item"),
+          Type.Literal("update_work_item"),
+          Type.Literal("create_edge"),
+          Type.Literal("delete_edge"),
+          Type.Literal("delete_work_item"),
+        ]),
+        entity_id: Type.Optional(Type.String()),
+        payload: Type.Optional(Type.Any()),
+        rationale: Type.String(),
+        validation: Type.Optional(Type.Any()),
+        group_id: Type.Optional(Type.String()),
+        depends_on_mutation_ids: Type.Optional(Type.Array(Type.String())),
+      })),
+    }),
+    execute: async (_toolCallId, params: ProposeMutationsToolInput) => {
+      const proposal = deps.proposalState.normalizeProposal(params, deps.buildProposalDefaults());
+      deps.proposalState.setActiveProposal(proposal);
+      deps.emitStudioEvent("mutation_proposal", { proposal });
+
+      return {
+        content: [{ type: "text", text: `Staged proposal ${proposal.proposal_id} with ${proposal.mutations.length} mutation(s).` }],
+        details: { proposal },
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/reconciliation-query.tool.ts
+++ b/src/modules/planning/tools/reconciliation-query.tool.ts
@@ -1,0 +1,30 @@
+import { Type } from "@sinclair/typebox";
+import { defineTool } from "@mariozechner/pi-coding-agent";
+import type { ReconciliationQueryToolInput } from "../types.js";
+import type { PlanningToolDeps } from "./types.js";
+
+export function createReconciliationQueryTool(deps: PlanningToolDeps) {
+  return defineTool({
+    name: "reconciliation_query",
+    label: "Reconciliation Query",
+    description: "Read deterministic predicted-vs-actual reconciliation reports for recent or specific work items.",
+    promptSnippet: "reconciliation_query: inspect reconciliation reports before explaining drift or proposing planning memory learnings.",
+    promptGuidelines: [
+      "Use reconciliation_query when you need deterministic predicted-vs-actual comparison data.",
+      "Prefer a specific work_item_id when discussing one execution run or one work item's drift.",
+    ],
+    parameters: Type.Object({
+      work_item_id: Type.Optional(Type.String()),
+    }),
+    execute: async (_toolCallId, params: ReconciliationQueryToolInput) => {
+      const result = params.work_item_id
+        ? deps.reconciliationService.getReport(params.work_item_id)
+        : deps.reconciliationService.listReports();
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        details: result,
+      };
+    },
+  });
+}

--- a/src/modules/planning/tools/tool-registry.ts
+++ b/src/modules/planning/tools/tool-registry.ts
@@ -1,0 +1,32 @@
+import { createDelegateSubAgentTool } from "./delegate-subagent.tool.js";
+import { createGitHubCreateIssueTool } from "./github-create-issue.tool.js";
+import { createGitHubReadTool } from "./github-read.tool.js";
+import { createGitHubSyncTool } from "./github-sync.tool.js";
+import { createGraphMutateTool } from "./graph-mutate.tool.js";
+import { createGraphQueryTool } from "./graph-query.tool.js";
+import { createMemoryReadTool } from "./memory-read.tool.js";
+import { createMemoryWriteTool } from "./memory-write.tool.js";
+import { createProposeMutationsTool } from "./propose-mutations.tool.js";
+import { createReconciliationQueryTool } from "./reconciliation-query.tool.js";
+import type { PlanningToolDeps } from "./types.js";
+
+/**
+ * Phase 7 (#227): central registry returning all 10 root-planner
+ * custom tools in their original registration order. Tool names are
+ * a hard contract — preserved exactly so the LLM's memorised tool
+ * set keeps working.
+ */
+export function createPlanningTools(deps: PlanningToolDeps) {
+  return [
+    createGraphQueryTool(deps),
+    createProposeMutationsTool(deps),
+    createGraphMutateTool(deps),
+    createMemoryReadTool(deps),
+    createMemoryWriteTool(deps),
+    createDelegateSubAgentTool(deps),
+    createGitHubReadTool(deps),
+    createGitHubCreateIssueTool(deps),
+    createGitHubSyncTool(deps),
+    createReconciliationQueryTool(deps),
+  ];
+}

--- a/src/modules/planning/tools/types.ts
+++ b/src/modules/planning/tools/types.ts
@@ -1,0 +1,31 @@
+import type { GitHubService } from "../../github/github.service.js";
+import type { GraphService } from "../../graph/graph.service.js";
+import type { MemoryService } from "../memory.service.js";
+import type { ProposalStateService } from "../proposal-state.service.js";
+import type { ReconciliationService } from "../../reconciliation/reconciliation.service.js";
+import type { SubAgentService } from "../sub-agent.service.js";
+
+/**
+ * Phase 7 (#227): the static dependency surface every planner tool
+ * file is allowed to touch. Adding a new dep means updating this
+ * interface AND `PlanningService.buildToolDeps()`.
+ *
+ * Tools should NOT inject services directly via Nest — the registry
+ * pattern keeps them as pure factories so they're trivially
+ * unit-testable with a stubbed `PlanningToolDeps` bag.
+ */
+export interface PlanningToolDeps {
+  // Collaborator services
+  graphService: GraphService;
+  memoryService: MemoryService;
+  subAgentService: SubAgentService;
+  githubService: GitHubService;
+  reconciliationService: ReconciliationService;
+  proposalState: ProposalStateService;
+
+  // PlanningService-owned hooks (callbacks so the SSE stream + counter
+  // stay private to PlanningService).
+  emitStudioEvent: (eventType: string, payload: unknown) => void;
+  buildProposalDefaults: () => { currentTurnId: string | null; sessionId: string };
+  getCurrentTurnId: () => string | null;
+}


### PR DESCRIPTION
## Summary
Phase 7 of the cqrs refactor series. Splits the 1378-line
\`PlanningService\` god class into three smaller pieces:

  1. **\`ProposalStateService\`** — owns the staging state for graph
     proposals, planning-memory changes, and GitHub-sync proposals.
     11 private fields + 17 helper methods + a new \`resetTurnState()\`
     called from \`PlanningService.handleSessionEvent\` at turn
     boundaries.
  2. **\`src/modules/planning/tools/\` directory** — 12 new files: a
     typed \`PlanningToolDeps\` interface, a \`createPlanningTools(deps)\`
     registry factory, and 10 individual tool factory files (one per
     root-planner custom tool).
  3. **\`PlanningService\`** — slimmed to session lifecycle, prompt
     queue, the three approval handlers (\`approveProposal\` /
     \`approveMemoryChange\` / \`approveGitHubSync\`), \`getSessionSnapshot\`,
     and the SSE stream. Tool wiring is a single line:
     \`createPlanningTools(this.buildToolDeps())\`.

\`PlanningService\` line count: **1016 → 577** (-439, target was < 600).

Closes #227. Full scope:
[\`docs/proposals/phase-7-planner-tool-registry.md\`](docs/proposals/phase-7-planner-tool-registry.md).

## Critical contract preserved
**Tool names are unchanged.** The LLM has them memorised; renaming
costs weeks of recovery prompts. Verified: all 10 names
(\`graph_query\`, \`propose_mutations\`, \`graph_mutate\`, \`memory_read\`,
\`memory_write\`, \`delegate_subagent\`, \`github_read\`,
\`github_create_issue\`, \`github_sync\`, \`reconciliation_query\`) lifted
verbatim into the new factory files. Parameter schemas, prompt
snippets, prompt guidelines, and execute bodies preserved
byte-for-byte — only \`this.X\` references rewrote to \`deps.X\`.

## Key changes

### Commit 1 — \`refactor(planning): extract ProposalStateService\`
- New \`src/modules/planning/proposal-state.service.ts\` (\`@Injectable\`)
- Lifts 11 state fields and 17 helper methods verbatim out of
  \`PlanningService\`
- New \`resetTurnState()\` method called from \`handleSessionEvent\` at
  turn boundaries (replaces the inline \`this.issueIdAliases.clear()\`)
- \`PlanningService\` injects it as the 9th constructor dep
- \`PlanningModule\` registers + exports \`ProposalStateService\`
- \`planning.service.test.ts\` constructs a real \`ProposalStateService\`
  with the test mocks instead of passing \`{} as never\`
- \`PlanningService\` shrinks 1378 → 1016 (-362)

### Commit 2 — \`refactor(planning): extract 10 planner tools into a registry-based factory\`
- 12 new files under \`src/modules/planning/tools/\`:
  - \`types.ts\` — \`PlanningToolDeps\` interface
  - \`tool-registry.ts\` — \`createPlanningTools(deps)\` factory
  - 10 \`*.tool.ts\` files — one per tool, each exporting
    \`createXxxTool(deps)\`
- \`PlanningService\` deletes all 10 \`createXxxTool()\` methods + their
  inline \`Type.Object({...})\` schemas
- New \`PlanningService.buildToolDeps()\` private method composes the
  dep bag with bound callbacks for \`emitStudioEvent\` /
  \`buildProposalDefaults\` / \`getCurrentTurnId\` so the SSE emitter +
  counter stay private to PlanningService
- \`createOrResumeSession\` switches from a 10-line literal
  \`customTools: [...]\` array to
  \`customTools: createPlanningTools(this.buildToolDeps())\`
- \`planning.service.test.ts\` rewires the github_create_issue tests to
  call \`createGitHubCreateIssueTool(deps)\` directly instead of
  reaching into \`(service as any).createGitHubCreateIssueTool()\`
- \`PlanningService\` shrinks 1016 → 577 (-439)

## Test plan
- [x] \`npm run check\` (tsc) — clean
- [x] \`npx vitest run --no-file-parallelism\` — **561 / 561** pass
  (planning suite: 22 / 22)
- [x] \`npm run build:web\` — clean
- [x] \`wc -l src/modules/planning/planning.service.ts\` → **577**
  (target < 600)
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\` → **4**
  (unchanged)
- [x] \`grep -nE 'create(GraphQuery|ProposeMutations|GraphMutate|MemoryRead|MemoryWrite|DelegateSubAgent|GitHubRead|GitHubCreateIssue|GitHubSync|ReconciliationQuery)Tool' src/modules/planning/planning.service.ts\` → **0 matches**
- [x] \`PORT=3030 npm start\` boots; \`GET /health\` → \`{\"ok\":true,\"db\":{...}}\`
- [ ] **Deferred manual smoke:** the 5 README planner flows (steps 8,
  9, 14, 17, 18) — start planner session, call \`graph_query\` /
  \`propose_mutations\` / \`approve_proposal\` / \`memory_write\` /
  \`github_create_issue\` and confirm the SSE envelope shapes are
  unchanged. The unit suite + tsc + dev boot cover the wiring path
  but not the live LLM round-trip. Reviewer to confirm or run
  themselves.

## Architecture notes
- **\`ProposalStateService\` is a state-owning service**, not a helper
  bag. It owns the 11 state fields AND the helpers that mutate them.
  PlanningService delegates; it does not reach through to the state
  directly.
- **\`PlanningToolDeps\` is a typed static interface**, not a runtime
  bag. Every tool file gets compile-time guarantees about what's
  available. Adding a new dep means updating the interface AND
  \`PlanningService.buildToolDeps()\`.
- **\`emitStudioEvent\` stays on PlanningService** because it has
  intimate knowledge of the SSE stream subject + event counter.
  Tools reach it via the deps bag callback.
- **\`toGraphMutation\` stays on PlanningService** (despite the proposal
  doc's wording suggesting it move) because it's called by
  \`approveProposal\` (the commit path), not by any tool's execute body.
  Keeping it on PlanningService matches the actual call graph.

## What's next
Phase 7 leaves \`PlanningService\` at the right shape for Phase 8
(#228) — the dead-code deletion + reconciliation rename pass — and
for any per-tool unit-test follow-up. Adding light unit tests for the
other 9 tools (the \`github_create_issue\` tests already cover the
hardest one) is a natural follow-up but explicitly out of scope here.