### PR TITLE
Phase 9a: unwrap residual forwardRefs (4 → 0)

### DIFF
--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
@@ -22,7 +22,7 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
+  imports: [GraphModule, GitHubModule, SettingsModule],
   controllers: [ExecutionController, WorkItemReconcilerController],
   providers: [
     ExecutionService,

--- a/src/modules/execution/execution.module.ts
+++ b/src/modules/execution/execution.module.ts
@@ -22,7 +22,7 @@ import { WorkItemReconcilerService } from "./work-item-reconciler.service.js";
 import { WorktreeService } from "./worktree.service.js";
 
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), SettingsModule],
+  imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
   controllers: [ExecutionController, WorkItemReconcilerController],
   providers: [
     ExecutionService,

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -17,7 +17,7 @@ import { WorkItemDeletedHandler } from "./work-item-deleted.handler.js";
  * PlansModule, so no forwardRef cycles.
  */
 @Module({
-  imports: [forwardRef(() => GraphModule), forwardRef(() => GitHubModule), SettingsModule],
+  imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
   controllers: [PlansController],
   providers: [
     PlansService,

--- a/src/modules/plans/plans.module.ts
+++ b/src/modules/plans/plans.module.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Module } from "@nestjs/common";
+import { Module } from "@nestjs/common";
 import { GitHubModule } from "../github/github.module.js";
 import { GraphModule } from "../graph/graph.module.js";
 import { SettingsModule } from "../settings/settings.module.js";
@@ -13,11 +13,12 @@ import { WorkItemDeletedHandler } from "./work-item-deleted.handler.js";
  * ADR 014 step 4 — plan preparation module.
  *
  * Depends on GraphModule (for WorkItemsService) and GitHubModule (for
- * StudioIssueTemplateService). One-directional — nothing else imports
- * PlansModule, so no forwardRef cycles.
+ * StudioIssueTemplateService). Both are direct, non-forwardRef imports
+ * after Phase 9a (#240): Graph has no imports of its own and GitHub
+ * only imports Graph, so no cycle reaches back into Plans.
  */
 @Module({
-  imports: [forwardRef(() => GraphModule), GitHubModule, SettingsModule],
+  imports: [GraphModule, GitHubModule, SettingsModule],
   controllers: [PlansController],
   providers: [
     PlansService,


### PR DESCRIPTION
## Summary

Phase 9a (#240) audits every module-level `forwardRef()` wrapper in
`src/modules/*/*.module.ts`, traces the cycle each was defending, and
unwraps wrappers whose cycle is gone. All four surviving wrappers
turned out to be defensive residue from earlier phases — none defend
a real cycle anymore.

**forwardRef count: 4 → 0** (issue target was ≤1, ideally 0).

## Cycle analysis

Module dep graph before this PR:

| Module       | imports                                             |
|--------------|-----------------------------------------------------|
| Graph        | `[]`                                                |
| Settings     | `[]`                                                |
| GitHub       | `[Graph]`                                           |
| DriftReport  | `[Graph, Execution]`                                |
| Planning     | `[Graph, GitHub, DriftReport, Settings]`            |
| Execution    | `[forwardRef(Graph), forwardRef(GitHub), Settings]` |
| Plans        | `[forwardRef(Graph), forwardRef(GitHub), Settings]` |

Since Graph imports nothing and GitHub only imports Graph, nothing
transitively reaches back into Execution or Plans. No cycle exists
for the four wrappers to defend.

- **ExecutionModule → forwardRef(GitHubModule):** residue from
  pre-Phase-6 when `GitHubBatchCache` lived in ExecutionModule and
  created a real ExecutionModule ↔ GitHubModule cycle. Phase 6b
  (#236) moved the cache to GitHubModule; the cycle died but the
  wrapper stayed.
- **PlansModule → forwardRef(GitHubModule):** same shape, same fix.
- **ExecutionModule → forwardRef(GraphModule):** Graph imports
  nothing, so the only way this could cycle is via file-level ES
  module imports (command DTOs in \`graph/work-items.controller.ts\`).
  Those are leaf classes with no service references, so there's no
  round-trip and no cycle.
- **PlansModule → forwardRef(GraphModule):** same shape, same fix.

All four unwrapped first-try. Full vitest (548 tests) stayed green
after every step and the full Nest app boots cleanly with the DI
graph now a pure DAG:

\`\`\`
DriftReport → Graph → Plans → GitHub → Planning → Execution
\`\`\`

## Scope notes

- Constructor-level \`@Inject(forwardRef(() => ExecutionService))\` in
  \`run-disposition.service.ts\` is intentionally **out of scope** —
  it's a self-referential injection inside ExecutionModule and the
  issue's AC only targets \`src/modules/*/*.module.ts\`.
- \`plans.module.ts\` docstring refreshed: the old \"no forwardRef
  cycles\" claim contradicted the then-current wrappers and is now
  accurate.
- Commits are split one-per-unwrap for rollback safety. The last two
  commits also drop the now-unused \`forwardRef\` symbol from the
  \`@nestjs/common\` import in each file.

## Test plan

- [x] \`npm run check\` clean after every task
- [x] \`npx vitest run --no-file-parallelism\` — 548/548 green after every task
- [x] \`grep -o 'forwardRef(' src/modules/*/*.module.ts | wc -l\` → 0
- [x] Server boots; \`/health\` → \`{\"ok\":true,...}\`
- [x] Module init order logged in correct DAG shape, no lazy resolution
- [ ] **Deferred manual smoke:** click through Planning / Execute / Reconcile / Settings tabs to confirm the live UI still renders

Closes #240. Part of #229 (Phase 9 epic).