### PR TITLE
Phase 9b: audit run-scaffolding duplication (Option B — defer)

### DIFF
--- a/src/modules/execution/run-store.service.ts
+++ b/src/modules/execution/run-store.service.ts
@@ -30,6 +30,15 @@ import type {
  * constant (`recentRunLimit`, `streamId`), computed from
  * `getConfig()` (`artifactRoot`), or internal. This keeps Phase 4
  * coupling minimal and lets tests construct RunStore directly.
+ *
+ * Phase 9b audit (#241): `SubAgentService` in `src/modules/planning/`
+ * has a parallel private implementation of the same `runs/<id>/`
+ * artifact contract (`upsertRecentRun`, `writeMetadata`, `writeStatus`,
+ * `writeSummary`, `appendEvent`) for `SubAgentRunRecord`. We
+ * deliberately did NOT extract a generic `RunArtifactStore<T>` base
+ * class in Phase 9 — two consumers is not enough shape evidence and
+ * this is a cleanup pass, not a speculative-abstraction pass. Revisit
+ * if a third consumer shows up or if the two drift. Tracked in #264.
  */
 @Injectable()
 export class RunStore {

--- a/src/modules/planning/sub-agent.service.ts
+++ b/src/modules/planning/sub-agent.service.ts
@@ -25,6 +25,17 @@ interface RunHooks {
   onResult?: (run: SubAgentRunRecord) => void;
 }
 
+/**
+ * Phase 9b audit (#241): this service's private `upsertRecentRun` /
+ * `writeMetadata` / `writeStatus` / `writeSummary` / `appendEvent`
+ * methods (below) are a parallel implementation of the same
+ * `runs/<id>/` artifact contract that `RunStore` owns in
+ * `src/modules/execution/run-store.service.ts`, operating on
+ * `SubAgentRunRecord` instead of `ExecutionRunRecord`. We deliberately
+ * did NOT extract a generic `RunArtifactStore<T>` base class in
+ * Phase 9 — two consumers is not enough shape evidence. Revisit when a
+ * third consumer shows up or when the two drift. Tracked in #264.
+ */
 @Injectable()
 export class SubAgentService {
   private readonly logger = new Logger(SubAgentService.name);


### PR DESCRIPTION
## Summary

Phase 9b (#241) audits the parallel `runs/<id>/` artifact-contract
implementations in `RunStore` (execution) and `SubAgentService`
(planning). The issue was an explicit judgment call: extract a generic
`RunArtifactStore<T>` base class now (Option A) vs document and defer
(Option B).

**Decision: Option B.**

## Rationale

- The proposal doc (`docs/proposals/phase-9-review-pass.md` §9.2) and
  the issue body both recommend Option B unless the team explicitly
  wants A.
- Two known consumers is not enough shape evidence to design the right
  base class. The third consumer may need hooks or fields neither of
  the current two do, and guessing now invariably papers over that.
- Phase 9 is a cleanup pass, not a speculative-abstraction pass.
- Consistent with earlier review feedback on a Phase 8b structural
  move (extract \`RunStoreModule\`), which landed on "don't bother."
- Global guidance: "Don't add features, refactor, or introduce
  abstractions beyond what the task requires."

## What this PR actually does

Zero behavior change. Comment-only.

- Adds a ~10-line class jsdoc block to \`run-store.service.ts\`
  explaining the parallel implementation and linking to the follow-up.
- Adds a ~10-line class jsdoc block to \`sub-agent.service.ts\` doing
  the same from the other side.
- Both comments reference #264, the follow-up issue filed as part of
  this PR.

A future reader landing in either file now immediately sees the known
duplication and finds the revisit criteria without having to dig
through the Phase 9 proposal docs.

## Follow-up issue

Filed as **#264 — \"Dedup run-scaffolding (deferred from Phase 9b)\"**

The issue documents the current state of the duplication (files,
methods, line ranges), the rationale for deferring, an explicit
"revisit when" list (third consumer, drift, contract growth), and a
reference sketch of what Option A would look like if we ever decide
to pick it back up.

## Test plan

- [x] \`npm run check\` — clean (comment-only diff)
- [x] \`npx vitest run --no-file-parallelism\` — 548/548 green
- [x] Diff only touches the two service files
- [x] Follow-up issue #264 visible on the repo with correct title and links

Closes #241. Part of #229 (Phase 9 epic).