### PR TITLE
Phase 9c: miscellaneous review items (9.3 verify / 9.4–9.5 skip / 9.6 delete)

### DIFF
--- a/src/modules/graph/__tests__/work-item-hsm.service.test.ts
+++ b/src/modules/graph/__tests__/work-item-hsm.service.test.ts
@@ -147,7 +147,6 @@ describe("WorkItemHsmService", () => {
     ["pre_pr.in_progress", { type: "run.error", run_id: "r1", reason: "boom" }, "pre_pr.run_errored"],
     ["pre_pr.run_errored", { type: "user.retry" }, "pre_pr.in_progress"],
     ["pre_pr.run_errored", { type: "user.investigate" }, "pre_pr.ready"],
-    ["pre_pr.run_errored", { type: "user.resolve_disambiguation" }, "pre_pr.ready"],
     ["pre_pr.in_progress", { type: "run.completed", run_id: "r2", pr_exists: false }, "merged_pr"],
     ["pre_pr.ready", { type: "user.defer" }, "deferred"],
     ["pre_pr.ready", { type: "user.cancel" }, "cancelled"],

--- a/src/modules/graph/types.ts
+++ b/src/modules/graph/types.ts
@@ -210,7 +210,6 @@ export type WorkItemHsmEvent =
   | { type: "user.cancel" }
   | { type: "user.defer" }
   | { type: "user.undefer" }
-  | { type: "user.resolve_disambiguation" }
   | { type: "run.completed"; run_id: string; pr_exists: boolean }
   | { type: "run.error"; run_id: string; reason: string }
   | { type: "gh.pr_opened"; pull_request: Record<string, unknown> }

--- a/src/modules/graph/work-item.scxml
+++ b/src/modules/graph/work-item.scxml
@@ -63,7 +63,6 @@
     <state id="run_errored">
       <transition event="user.retry" target="in_progress" />
       <transition event="user.investigate" target="ready" />
-      <transition event="user.resolve_disambiguation" target="ready" />
     </state>
   </state>
 


### PR DESCRIPTION
## Summary

Phase 9c (#242) bundles four small Phase 9 review items (§9.3–§9.6 of `docs/proposals/phase-9-review-pass.md`). Each is resolved with either a concrete change or a documented defer.

One of the four (9.6) lands as a real code change; the other three are verify/skip decisions with rationale.

## 9.3 — Verify `PullRequestTruthRefreshedEvent` timing (no change)

**Status: verified; no drift; no code change needed.**

Confirmed the Phase 5 callback→event refactor (commit `2aa794f`) is clean:

- **Dispatch order:** `github.service.ts:555-571` updates the work item meta via `workItems.update()` *then* publishes the event. Update-first, publish-second, as the old callback required.
- **Dispatch synchrony:** EventBus is synchronous in-process, so `PullRequestTruthRefreshedHandler.handle()` runs before `publish()` returns. Matches the old direct-callback semantics.
- **Subscriber set:** single subscriber (`PullRequestTruthRefreshedHandler` → `PullRequestService.refreshRunsForPullRequest`).
- **Documentation:** already in place — event class jsdoc, dispatch-site comment, and handler jsdoc all document the contract. No additional comment needed.

## 9.4 — Rename `ExecutionService`? (skip)

**Decision: skip. Keep as `ExecutionService`.**

- 116 references across `src/` — high-churn mechanical rename for a name that isn't obviously wrong
- Issue's own criterion: "Rename iff the new name is obviously clearer to someone reading the code cold." Not met.

## 9.5 — Inline `transitionInProgressToReady/Drafting` wrappers? (skip)

**Decision: skip.**

- The wrappers (`execution.service.ts:750-778`) are ~10 lines each: `workItemsService.get` → state guard → `hsmService.dispatch` → re-read.
- Only callers besides the handlers: `launch-eligibility.test.ts:433-577` (~145 lines of direct service tests). The HTTP controller routes already dispatch via `commandBus.execute(...)`, so they don't see the wrappers directly.
- Inlining means: both handlers gain `WorkItemsService` + `WorkItemHsmService` constructor deps, both test describes rewritten as handler-layer tests, both wrapper methods deleted.
- Estimated diff ~100–140 lines, mostly test rewrites. Exceeds the issue's explicit "skip if diff > ~80 lines" threshold.
- The wrappers are short, readable, self-contained, and have direct test coverage. Inlining wouldn't materially improve the code.

## 9.6 — Delete dead `user.resolve_disambiguation` HSM transition (**done**)

**Decision: delete.**

Audit finding — the transition was fully dead and semantically redundant:

- Declared in `src/modules/graph/types.ts:213` as a `WorkItemHsmEvent` union member
- Defined in `src/modules/graph/work-item.scxml:66` as a transition on `pre_pr.run_errored → ready`
- Tested at `src/modules/graph/__tests__/work-item-hsm.service.test.ts:150`
- **Zero production dispatch sites.** Nothing in `src/` or `web/` ever called `dispatch({ type: "user.resolve_disambiguation" })`.
- **Fully redundant:** `pre_pr.run_errored` already has `<transition event="user.investigate" target="ready" />` one line above (`work-item.scxml:65`) with the same target and no guard difference. The dead transition was a pure semantic alias.

Commit: `be9643f — refactor(graph): delete dead user.resolve_disambiguation HSM transition`
Diff: 3 files, 3 deletions.

> **Note on the unrelated `POST /api/execution/resolve-disambiguation` HTTP route:** this endpoint is a *different, live* feature — user-facing run-disambiguation prompts on `ExecutionService.resolveDisambiguation`. It's untouched by this PR.

## Test plan

- [x] `npm run check` — clean
- [x] `npx vitest run --no-file-parallelism` — 547/547 green (down from 548 as expected, one transition case removed)
- [x] `grep -rn 'resolve_disambiguation' src/ web/` — only the unrelated HTTP route remains
- [x] Server boots; `/health` → `{"ok":true,...}`
- [ ] **Deferred manual smoke:** click through Planning / Execute / Reconcile / Settings tabs to confirm live UI still renders

Closes #242. Part of #229 (Phase 9 epic).