### PR TITLE
Phase 9d: add service-size convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# Escapement Studio — project conventions
+
+This file is the home for project-level conventions that should be
+applied when working in this repo. It's auto-loaded by Claude Code
+when run from the repo root.
+
+## Service size convention
+
+- Services stay under ~400 lines where practical.
+- When a service crosses ~600 lines, open an issue to extract a
+  sub-service on the next feature that would grow it further.
+- God classes (>1000 lines) are a code smell, not a design goal.
+- Controllers should be thin. Orchestrator classes that coordinate
+  sub-services are fine; service classes that own multiple unrelated
+  responsibilities are not.
+- When in doubt, pick "extract now" over "extract later" — the cost
+  of a premature extraction is smaller than the cost of a deferred
+  one.
+
+The motivating historical context for these thresholds is
+[`docs/proposals/assessment.md` §3](docs/proposals/assessment.md),
+where `ExecutionService` had grown to 3286 lines before the Phase 4
+extraction pass broke it apart into `RunStore`, `PullRequestService`,
+`RunDispositionService`, `RunInteractionService`, `ScratchpadService`,
+and `WorktreeService`. Write this convention in front of the next
+class so the decision to extract gets made early instead of after.

--- a/docs/proposals/assessment.md
+++ b/docs/proposals/assessment.md
@@ -217,6 +217,12 @@ Phase 6), but not in the cleanest order. See §12.
 
 ## 3. Smell #1: `ExecutionService` is a god class
 
+> The size thresholds discussed below (~400 / ~600 / ~1000 lines) are
+> codified as a written convention in
+> [`CLAUDE.md`](../../CLAUDE.md#service-size-convention).
+> Treat that as the forcing function for future extractions; §3 is
+> the historical rationale behind the numbers.
+
 **File:** `src/modules/execution/execution.service.ts`
 **Size:** 3286 lines
 **Constructor:** 8 injected services, one of them forwardRef'd.


### PR DESCRIPTION
## Summary

Phase 9d (#243) establishes a written service-size convention so the
next "should this service grow?" decision has a forcing function
instead of waiting for a 3286-line god class to emerge (see
`assessment.md` §3).

Docs-only PR. Two files, 32 insertions, zero behavior change.

## What this PR does

### 1. Creates `CLAUDE.md` at the repo root

There wasn't one. The file gets a short header identifying it as the
project-level Claude Code conventions file and a single section:

> ## Service size convention
>
> - Services stay under ~400 lines where practical.
> - When a service crosses ~600 lines, open an issue to extract a sub-service on the next feature that would grow it further.
> - God classes (>1000 lines) are a code smell, not a design goal.
> - Controllers should be thin. Orchestrator classes that coordinate sub-services are fine; service classes that own multiple unrelated responsibilities are not.
> - When in doubt, pick "extract now" over "extract later" — the cost of a premature extraction is smaller than the cost of a deferred one.

Content is the issue body's proposed bullets verbatim. We kept
CLAUDE.md deliberately minimal — just this one convention. Future
PRs can add other conventions as they earn their way in. A
convention doc that tries to cover everything gets ignored; one
that names the one thing that actually hurt us gets read.

### 2. Cross-links from `assessment.md` §3

A short blockquote at the top of §3 (the ExecutionService god-class
smell) points at `CLAUDE.md#service-size-convention` as the live
forcing function, with §3 itself retained as the historical
rationale for the ~400/~600/~1000 numbers.

## Deviations from the issue body (noted for reviewer visibility)

### §14 → §3 retarget

The issue body says "link the new section from `docs/proposals/assessment.md`
§14." §14 is actually **"What this assessment does NOT cover"**
(lines 1185-1204) — frontend, SCXML rewrites, DB migrations, test
harnesses. It's unrelated to service sizing.

The god-class discussion with the ~400/~600/~1000-line thresholds
lives at **§3 "Smell #1: `ExecutionService` is a god class"** (lines
218-286), where every natural extraction is enumerated. Linking
from §3 puts the pointer next to the rationale; linking from §14
would put it next to an unrelated list. We took the §3 link and
flagged the mismatch here rather than forcing the pointer into a
place it doesn't fit.

### `AGENTS.md` skip

The issue's "if AGENTS.md exists and is user-facing" guard excludes
the only AGENTS.md in the tree: `node_modules/escapement/AGENTS.md`,
which is vendor code. No user-facing AGENTS.md exists, so this PR
doesn't touch any.

## Phase 9 epic closure

This is the last Phase 9 sub-issue (9a → 9d, issues #240, #241,
#242, #243). After this PR merges, the Phase 9 epic (#229) and the
overall CQRS refactor epic (#228) can be closed. That's a post-merge
step, not part of this PR's diff.

## Test plan

- [x] `npm run check` — clean (docs-only)
- [x] `npx vitest run --no-file-parallelism` — 547/547 green
- [x] `CLAUDE.md` renders correctly on GitHub (headings, bullets, code spans)
- [x] The `../../CLAUDE.md#service-size-convention` relative link resolves from `docs/proposals/assessment.md`

Closes #243. Part of #229 (Phase 9 epic) and #228 (CQRS refactor epic).