### PR TITLE
docs(proposals): mark phases 0-9 landed in phase table (closes #229 + #228)

### DIFF
--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -22,23 +22,25 @@ captures why migration vs rebuild, what smells exist with line
 pointers, and how phases map to current code. The phase docs assume
 that context.
 
-| # | Phase | Proposal doc | Net outcome | fwdRef |
-|---|---|---|---|---:|
-| 0 | Platform bus (`@nestjs/cqrs`) | [`phase-0-platform-bus.md`](phase-0-platform-bus.md) | Command + event bus infrastructure via the Nest-native CQRS package. No production code touched. | 0 |
-| 1 | Kill the HSM shadow vocabulary | [`phase-1-hsm-action-handlers.md`](phase-1-hsm-action-handlers.md) | Move `HsmActionHandlers` to ExecutionModule, rewrite to runtime signature, delete `HsmGuardHandlers` + `createRunRecord` action + `kickOffPlanDrafter` shadow. Named, testable, single-sourced. | −1 |
-| 2 | Route `WorkItemsController` through the command bus | [`phase-2-work-items-controller-command-bus.md`](phase-2-work-items-controller-command-bus.md) | Six commands for cancel/delete/transition/prepare/reopen. Controller injects only `CommandBus` + same-module services. | −2 |
-| 3 | Extract `RunDispositionService` | [`phase-3-run-disposition-service.md`](phase-3-run-disposition-service.md) | Merged-PR close / archive-and-close / cancel / delete clusters move out of the god class into a dedicated sub-service. God class drops ~800 lines. | 0 |
-| 4 | Carve remaining sub-services out of `ExecutionService` | [`phase-4-execution-sub-services.md`](phase-4-execution-sub-services.md) | `RunStore`, `WorktreeService`, `ScratchpadService`, `RunInteractionService`, `PullRequestService`. God class drops from ~2500 to ~500. | 0 |
-| 5 | Event-driven cross-context calls (picked per event) | [`phase-5-event-driven-cross-context.md`](phase-5-event-driven-cross-context.md) | `WorkItemMergedEvent`, `RunCompletedEvent`, `PullRequestTruthRefreshedEvent`, `WorkItemDeletedEvent`. Bespoke callback handshake retired. | −1 |
-| 6 | `PlatformModule` for `SQLiteService` + move `GitHubBatchCache` to `GitHubModule` | [`phase-6-platform-module.md`](phase-6-platform-module.md) | Infrastructure out of GraphModule. External-state caching home-moved. Transitive cycles through Graph collapse. | −3 |
-| 7 | Planner tool registry | [`phase-7-planner-tool-registry.md`](phase-7-planner-tool-registry.md) | 10 planner tools move to per-file factories. `ProposalStateService` owns staging state. `PlanningService` drops from ~1380 to ~500. | 0 |
-| 8 | Delete dead code + rename reconciliation | [`phase-8-delete-dead-code.md`](phase-8-delete-dead-code.md) | Delete `GitModule`, four legacy Svelte components, orphaned `createHsmRunRecord`. Rename `ReconciliationService` → `DriftReportService` (URL preserved for compat). | −1 |
-| 9 | Review pass | [`phase-9-review-pass.md`](phase-9-review-pass.md) | Unwrap residual forwardRefs, dedup run scaffolding audit, ratify service-size convention in CLAUDE.md. | −1 to −3 |
+| # | Phase | Proposal doc | Net outcome | fwdRef | Status |
+|---|---|---|---|---:|---|
+| 0 | Platform bus (`@nestjs/cqrs`) | [`phase-0-platform-bus.md`](phase-0-platform-bus.md) | Command + event bus infrastructure via the Nest-native CQRS package. No production code touched. | 0 | landed |
+| 1 | Kill the HSM shadow vocabulary | [`phase-1-hsm-action-handlers.md`](phase-1-hsm-action-handlers.md) | Move `HsmActionHandlers` to ExecutionModule, rewrite to runtime signature, delete `HsmGuardHandlers` + `createRunRecord` action + `kickOffPlanDrafter` shadow. Named, testable, single-sourced. | −1 | landed |
+| 2 | Route `WorkItemsController` through the command bus | [`phase-2-work-items-controller-command-bus.md`](phase-2-work-items-controller-command-bus.md) | Six commands for cancel/delete/transition/prepare/reopen. Controller injects only `CommandBus` + same-module services. | −2 | landed |
+| 3 | Extract `RunDispositionService` | [`phase-3-run-disposition-service.md`](phase-3-run-disposition-service.md) | Merged-PR close / archive-and-close / cancel / delete clusters move out of the god class into a dedicated sub-service. God class drops ~800 lines. | 0 | landed |
+| 4 | Carve remaining sub-services out of `ExecutionService` | [`phase-4-execution-sub-services.md`](phase-4-execution-sub-services.md) | `RunStore`, `WorktreeService`, `ScratchpadService`, `RunInteractionService`, `PullRequestService`. God class drops from ~2500 to ~500. | 0 | landed |
+| 5 | Event-driven cross-context calls (picked per event) | [`phase-5-event-driven-cross-context.md`](phase-5-event-driven-cross-context.md) | `WorkItemMergedEvent`, `RunCompletedEvent`, `PullRequestTruthRefreshedEvent`, `WorkItemDeletedEvent`. Bespoke callback handshake retired. | −1 | landed |
+| 6 | `PlatformModule` for `SQLiteService` + move `GitHubBatchCache` to `GitHubModule` | [`phase-6-platform-module.md`](phase-6-platform-module.md) | Infrastructure out of GraphModule. External-state caching home-moved. Transitive cycles through Graph collapse. | −3 | landed |
+| 7 | Planner tool registry | [`phase-7-planner-tool-registry.md`](phase-7-planner-tool-registry.md) | 10 planner tools move to per-file factories. `ProposalStateService` owns staging state. `PlanningService` drops from ~1380 to ~500. | 0 | landed |
+| 8 | Delete dead code + rename reconciliation | [`phase-8-delete-dead-code.md`](phase-8-delete-dead-code.md) | Delete `GitModule`, four legacy Svelte components, orphaned `createHsmRunRecord`. Rename `ReconciliationService` → `DriftReportService` (URL preserved for compat). | −1 | landed |
+| 9 | Review pass | [`phase-9-review-pass.md`](phase-9-review-pass.md) | Unwrap residual forwardRefs (4 → 0), defer run-scaffolding dedup to #264, verify PR-truth event timing, skip rename + inline wrappers, delete dead `user.resolve_disambiguation` transition, add service-size convention to `CLAUDE.md`. | −4 | landed |
 
 **Starting forwardRef count:** 11 (verified by
 `grep -c 'forwardRef(' src/modules/*/*.module.ts` as of
 2026-04-12).
-**Target after Phase 9:** 0–1.
+**Final forwardRef count after Phase 9:** **0** — every module-level
+wrapper in `src/modules/*/*.module.ts` is gone. The migration
+exceeded the original 0–1 target.
 
 ## How to read the proposals
 


### PR DESCRIPTION
## Summary

Closes the one remaining open acceptance criterion on Phase 9 (#229):
the phase table in `docs/proposals/README.md` needs a `Status`
column.

None of the 9a–9d sub-issue PRs touched this file, so this tiny
follow-up does:

1. **Add a `Status` column** to the phase table with `landed` on every
   row 0-9.
2. **Flip the forward-looking "Target after Phase 9: 0-1" paragraph**
   into a retrospective: started at 11, finished at **0**
   (module-level forwardRef wrappers).
3. **Tighten the Phase 9 row's `Net outcome`** to list the actual
   landed work across 9a–9d rather than the original forecast:
   - Phase 9a: forwardRef unwrap 4 → 0 (#240 / PR #263)
   - Phase 9b: run-scaffolding dedup deferred to #264 (#241 / PR #265)
   - Phase 9c: PR-truth event timing verified, rename + wrapper-inline skipped, dead `user.resolve_disambiguation` HSM transition deleted (#242 / PR #266)
   - Phase 9d: service-size convention landed in `CLAUDE.md` (#243 / PR #267)
4. **Update the Phase 9 `fwdRef` delta** from the original `−1 to −3`
   estimate to the actual **`−4`**.

## Phase 9 epic status after this merges

All six phase-level acceptance criteria on #229:

- ✅ forwardRef count ≤1 — actual: **0**
- ✅ Every surviving forwardRef has an inline comment — vacuously true
- ✅ Every audit resolved or deferred — 9a done, 9b → #264, 9c mix, 9d done
- ✅ `CLAUDE.md` contains the service-size convention
- ⏸ README E2E smoke flows (steps 1–41) — manual verification, not automatable
- ✅ `docs/proposals/README.md` phase table has Status column — **this PR**

Plus #228 (the CQRS refactor epic) is satisfied, since Phase 9 was its
final phase.

## Test plan

- [x] Table renders correctly on GitHub (column count matches on every row)
- [x] Relative links in the Phase 9 row still resolve
- [x] `npm run check` clean (docs-only, no source touched)
- [ ] **Deferred manual smoke:** the #229 README E2E smoke-flow check (steps 1–41) — needs a human session in the browser

Closes #229 (Phase 9 epic). Closes #228 (CQRS refactor epic).